### PR TITLE
fix(sasjs-create): install dependencies when creating minimal app

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -32,11 +32,7 @@ export async function createAngularApp(folderPath) {
 
 export async function createMinimalApp(folderPath) {
   return new Promise(async (resolve, _) => {
-    createApp(
-      folderPath,
-      'https://github.com/sasjs/minimal-seed-app.git',
-      false
-    )
+    createApp(folderPath, 'https://github.com/sasjs/minimal-seed-app.git')
     return resolve()
   })
 }


### PR DESCRIPTION
Previously we did not have a `package.json` in the `minimal-seed-app` project, so there was no need to run an `npm install` when creating an app using the `minimal` template.

Since that has been added, we now need to run an install step when creating an app.

This change removes the third parameter to `createApp` which is an `installDependencies` flag that is `true` by default.