### PR TITLE
fix(sasjs-context): read access token from environment

### DIFF
--- a/src/sasjs-context/index.js
+++ b/src/sasjs-context/index.js
@@ -177,6 +177,7 @@ async function create(config, target) {
     throw new Error(`A valid access token was not found.
     Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
   }
+
   const {
     name,
     launchName,
@@ -213,7 +214,16 @@ async function edit(config, target) {
     serverType: target.serverType
   })
 
-  const accessToken = target.authInfo.access_token
+  const accessToken =
+    target && target.authInfo
+      ? target.authInfo.access_token
+      : process.env.access_token
+
+  if (!accessToken) {
+    throw new Error(`A valid access token was not found.
+    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
+  }
+
   const { name, updatedContext } = config
 
   const editedContext = await sasjs
@@ -239,7 +249,16 @@ async function remove(config, target) {
     serverType: target.serverType
   })
 
-  const accessToken = target.authInfo.access_token
+  const accessToken =
+    target && target.authInfo
+      ? target.authInfo.access_token
+      : process.env.access_token
+
+  if (!accessToken) {
+    throw new Error(`A valid access token was not found.
+    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
+  }
+
   const { name } = config
 
   const deletedContext = await sasjs

--- a/src/sasjs-context/index.js
+++ b/src/sasjs-context/index.js
@@ -168,15 +168,7 @@ async function create(config, target) {
     serverType: target.serverType
   })
 
-  const accessToken =
-    target && target.authInfo
-      ? target.authInfo.access_token
-      : process.env.access_token
-
-  if (!accessToken) {
-    throw new Error(`A valid access token was not found.
-    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
-  }
+  const accessToken = getAccessToken(target)
 
   const {
     name,
@@ -214,15 +206,7 @@ async function edit(config, target) {
     serverType: target.serverType
   })
 
-  const accessToken =
-    target && target.authInfo
-      ? target.authInfo.access_token
-      : process.env.access_token
-
-  if (!accessToken) {
-    throw new Error(`A valid access token was not found.
-    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
-  }
+  const accessToken = getAccessToken(target)
 
   const { name, updatedContext } = config
 
@@ -249,15 +233,7 @@ async function remove(config, target) {
     serverType: target.serverType
   })
 
-  const accessToken =
-    target && target.authInfo
-      ? target.authInfo.access_token
-      : process.env.access_token
-
-  if (!accessToken) {
-    throw new Error(`A valid access token was not found.
-    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
-  }
+  const accessToken = getAccessToken(target)
 
   const { name } = config
 
@@ -315,4 +291,18 @@ function displayResult(err, failureMessage, successMessage) {
   if (successMessage) {
     console.log(chalk.greenBright.bold.italic(successMessage))
   }
+}
+
+function getAccessToken(target) {
+  const accessToken =
+    target && target.authInfo
+      ? target.authInfo.access_token
+      : process.env.access_token
+
+  if (!accessToken) {
+    throw new Error(`A valid access token was not found.
+    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
+  }
+
+  return accessToken
 }

--- a/src/sasjs-context/index.js
+++ b/src/sasjs-context/index.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import { getUserInput } from '../utils/input-utils'
 import { fileExists, readFile } from '../utils/file-utils'
-import { getBuildTargets } from '../utils/config-utils'
+import { getBuildTargets, getAccessToken } from '../utils/config-utils'
 import SASjs from '@sasjs/adapter/node'
 
 export async function processContext(command) {
@@ -291,18 +291,4 @@ function displayResult(err, failureMessage, successMessage) {
   if (successMessage) {
     console.log(chalk.greenBright.bold.italic(successMessage))
   }
-}
-
-function getAccessToken(target) {
-  const accessToken =
-    target && target.authInfo
-      ? target.authInfo.access_token
-      : process.env.access_token
-
-  if (!accessToken) {
-    throw new Error(`A valid access token was not found.
-    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration.`)
-  }
-
-  return accessToken
 }

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -216,3 +216,17 @@ export async function getProjectRoot() {
   }
   return root
 }
+
+export function getAccessToken(target) {
+  const accessToken =
+    target && target.authInfo && target.authInfo.access_token
+      ? target.authInfo.access_token
+      : process.env.access_token
+
+  if (!accessToken || accessToken.trim() === 'null') {
+    throw new Error(`A valid access token was not found.
+    Please provide an access token in the access_token property in your .env file or as part of the authInfo in your target configuration (sasjsconfig.json).`)
+  }
+
+  return accessToken
+}

--- a/test/config-utils.spec.js
+++ b/test/config-utils.spec.js
@@ -5,6 +5,10 @@ describe('Config Utils', () => {
     process.env.access_token = null
   })
 
+  afterEach(() => {
+    process.env.access_token = null
+  })
+
   describe('getAccessToken', () => {
     test('should get access token from authInfo', () => {
       const target = {

--- a/test/config-utils.spec.js
+++ b/test/config-utils.spec.js
@@ -1,0 +1,46 @@
+import { getAccessToken } from '../src/utils/config-utils'
+
+describe('Config Utils', () => {
+  beforeEach(() => {
+    process.env.access_token = null
+  })
+
+  describe('getAccessToken', () => {
+    test('should get access token from authInfo', () => {
+      const target = {
+        authInfo: {
+          access_token: 'T0K3N'
+        }
+      }
+
+      const token = getAccessToken(target)
+
+      expect(token).toEqual('T0K3N')
+    })
+
+    test('should throw an error when access token is unavailable', () => {
+      const target = {
+        authInfo: {
+          access_token: ''
+        }
+      }
+
+      expect(() => getAccessToken(target)).toThrow()
+    })
+
+    test('should throw an error when auth info is unavailable', () => {
+      const target = null
+
+      expect(() => getAccessToken(target)).toThrow()
+    })
+
+    test('should get access token from environment', () => {
+      const target = null
+      process.env.access_token = '3NVT0K3N'
+
+      const token = getAccessToken(target)
+
+      expect(token).toEqual('3NVT0K3N')
+    })
+  })
+})


### PR DESCRIPTION
* Read `access_token` from environment if it wasn't found in the target configuration.
* Improve error parsing logic - this currently fails when the returned error body is not JSON.

We now show the parse error along with the original error like so:
![image](https://user-images.githubusercontent.com/2980428/93181852-e9ba1a00-f730-11ea-8d6c-2682c6142a93.png)

