### PR TITLE
chore(ci): correct test output escape sequences

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,8 +2,8 @@
 set -e
 
 process_result() {
-  success_message="\e[32mSuccess!"
-  failure_message="\e[91mTest \e[91mfailed."
+  success_message=$'\e[32mSuccess!'
+  failure_message=$'\e[91mTest failed.'
 
   if [ $1 -eq 0 ]
   then
@@ -14,41 +14,41 @@ process_result() {
   fi
 }
 
-echo "\e[34mLinking \e[34mSASjs \e[34mCLI..."
+echo $'\e[34mLinking SASjs CLI...'
 npm link
 if [ $? -eq 0 ]
 then
-  echo "\e[32mSuccess: SASjs CLI linked."
+  echo $'\e[32mSuccess: SASjs CLI linked.'
 else
-  echo "\e[91mError: Could not link SASjs CLI."
+  echo $'\e[91mError: Could not link SASjs CLI.'
   exit 1
 fi
 
-echo "\e[34mSASjs \e[34mVersion"
+echo $'\e[34mSASjs Version'
 sasjs v
 process_result $?
 
-echo "\e[34mSASjs \e[34mCreate"
+echo $'\e[34mSASjs Create'
 sasjs create test1
 process_result $?
 
-echo "\e[34mSASjs \e[34mCreate \e[34mMinimal \e[34mApp"
+echo $'\e[34mSASjs Create Minimal App'
 sasjs create test2 -t minimal
 process_result $?
 
-echo "\e[34mSASjs \e[34mCreate \e[34mReact \e[34mApp"
+echo $'\e[34mSASjs Create React App'
 sasjs create test3 -t react
 process_result $?
 
-echo "\e[34mSASjs \e[34mCreate \e[34mAngular \e[34mApp"
+echo $'\e[34mSASjs Create Angular App'
 sasjs create test4 -t angular
 process_result $?
 
-echo "SASjs Create SAS Only App"
+echo $'\e[34mSASjs Create SAS Only App'
 sasjs create test5 -t sasonly
 process_result $?
 
-echo "SASjs Compile Build"
+echo $'\e[34mSASjs Compile Build'
 cd test5
 sasjs cb
 process_result $?


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/106

## Intent

Test output escape sequences are rendered as plain text on `zsh` and other terminals when running locally.
This needs to be fixed so that the output is readable.

## Implementation

* Used `$'` notation for strings with escape sequences.
NB: This causes a `$` sign to be shown before each command in the GitHub Actions output, but that's still a fair compromise for being able to read the output locally.
![image](https://user-images.githubusercontent.com/2980428/93992064-fff55500-fd84-11ea-8711-e7f3818b462f.png)

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested. N/A
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated. N/A
