### PR TITLE
fix(web): fixed base64 encoding of *.js and *.css files

### DIFF
--- a/src/sasjs-web/sasjsout.js
+++ b/src/sasjs-web/sasjsout.js
@@ -5,11 +5,11 @@ export const sasjsout = `%macro sasjsout(type,fref=sasjs);
     filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name="_webout.json"
       contenttype="text/html";
   %end;
-  %else %if &type=JS %then %do;
+  %else %if &type=JS or &type=JS64 %then %do;
     filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.js'
       contenttype='application/javascript';
   %end;
-  %else %if &type=CSS %then %do;
+  %else %if &type=CSS or &type=CSS64 %then %do;
     filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.css'
       contenttype='text/css';
   %end;
@@ -27,10 +27,10 @@ export const sasjsout = `%macro sasjsout(type,fref=sasjs);
   %end;
 %end;
 %else %do;
-  %if &type=JS %then %do;
+  %if &type=JS or &type=JS64 %then %do;
     %let rc=%sysfunc(stpsrv_header(Content-type,application/javascript));
   %end;
-  %else %if &type=CSS %then %do;
+  %else %if &type=CSS or &type=CSS64 %then %do;
     %let rc=%sysfunc(stpsrv_header(Content-type,text/css));
   %end;
   %else %if &type=PNG %then %do;


### PR DESCRIPTION
## Intent

Fix base64 encoding of *.js and *.css files when streaming to SAS 9.

## Implementation

Updated 'getWebServiceContent' function and 'sasjsout' file.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/94572105-4d882b00-0279-11eb-9d47-600fd4b5dd07.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
