### PR TITLE
chore(appLoc): added 'appLoc' sanitation

### DIFF
--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -281,7 +281,7 @@ export async function getTargetToBuild(targetName) {
   }
 }
 
-function sanitizeAppLoc(appLoc) {
+export function sanitizeAppLoc(appLoc) {
   if (!appLoc || typeof appLoc !== 'string') return
 
   // Removes trailing '/'

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -228,6 +228,8 @@ export async function getBuildTarget(targetName) {
     )
   }
 
+  if (target.appLoc) target.appLoc = sanitizeAppLoc(target.appLoc)
+
   return target
 }
 
@@ -254,6 +256,9 @@ export async function getTargetToBuild(targetName) {
       )
     }
 
+    if (targetToBuild.appLoc)
+      targetToBuild.appLoc = sanitizeAppLoc(targetToBuild.appLoc)
+
     return Promise.resolve(targetToBuild)
   } else {
     // Use default target to build. For cases when build target was not found.
@@ -274,6 +279,21 @@ export async function getTargetToBuild(targetName) {
 
     return Promise.resolve(defaultTargetToBuild)
   }
+}
+
+function sanitizeAppLoc(appLoc) {
+  if (!appLoc || typeof appLoc !== 'string') return
+
+  // Removes trailing '/'
+  appLoc = appLoc.replace(/\/{1,}$/, '')
+
+  // Adds leading '/'
+  if (!/^\//.test(appLoc)) appLoc = '/' + appLoc
+
+  // Replaces multiple leading '/' with a single '/'
+  appLoc = appLoc.replace(/^\/{2,}/, '/')
+
+  return appLoc
 }
 
 export async function getTargetSpecificFile(typeOfFile, targetToBuild = {}) {

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -281,6 +281,10 @@ export async function getTargetToBuild(targetName) {
   }
 }
 
+/**
+ * Sanitizes app location string.
+ * @param {string} appLoc - app location
+ */
 export function sanitizeAppLoc(appLoc) {
   if (!appLoc || typeof appLoc !== 'string') return
 

--- a/test/config-utils.spec.js
+++ b/test/config-utils.spec.js
@@ -1,4 +1,4 @@
-import { getAccessToken } from '../src/utils/config-utils'
+import { getAccessToken, sanitizeAppLoc } from '../src/utils/config-utils'
 
 describe('Config Utils', () => {
   beforeEach(() => {
@@ -47,6 +47,24 @@ describe('Config Utils', () => {
       const token = await getAccessToken(target, false)
 
       expect(token).toEqual('3NVT0K3N')
+    })
+  })
+
+  describe('sanitizeAppLoc', () => {
+    let notValidAppLoc = '///Public/app///'
+    const validAppLoc = '/Public/app'
+
+    test('should remove trailing slash', () => {
+      expect(sanitizeAppLoc(notValidAppLoc)).toEqual(validAppLoc)
+    })
+
+    test('should remove multiple leading slashes', () => {
+      expect(sanitizeAppLoc(notValidAppLoc)).toEqual(validAppLoc)
+    })
+
+    notValidAppLoc = 'Public/app///'
+    test('should add leading slash', () => {
+      expect(sanitizeAppLoc(notValidAppLoc)).toEqual(validAppLoc)
     })
   })
 })


### PR DESCRIPTION
## Issue

closes #119 

## Intent

Sanitize `appLoc`.

## Implementation

Added `sanitizeAppLoc` function and used it in `getBuildTargets` and `getTargetToBuild` functions.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/94806105-1c813500-03f6-11eb-8bbd-08c50500aefa.png)
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
