### PR TITLE
fix(sasjs-run): Change access token mechanism, store log to file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1523,9 +1523,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.15.0.tgz",
-      "integrity": "sha512-tSGiP79+TkQZ07S6gaAdlvFdCTtR57lQ6kS0XxEcj8eyNgYhzwKm0DqnDeKAkl2QYIBqPkAze3a+Ei1badlbBg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.15.2.tgz",
+      "integrity": "sha512-BoW+S3sIyzS9ExC33KKfw3sI+rXQMyHA4BiFEUrIvqbt/qk43BpIClY12+hfpqSj1bBoIOoYeKPlFw34j4RfXA==",
       "requires": {
         "es6-promise": "^4.2.8",
         "form-data": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "^1.15.0",
+    "@sasjs/adapter": "^1.15.2",
     "@sasjs/core": "^1.5.5",
     "base64-img": "^1.0.4",
     "btoa": "^1.2.1",

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -214,7 +214,7 @@ export async function getVariable(name, target) {
  */
 export function generateTimestamp() {
   const date = new Date()
-  const timestamp = `${date.getFullYear()}${date.getMonth()}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}`
+  const timestamp = `${date.getUTCFullYear()}${date.getUTCMonth()}${date.getUTCDate()}${date.getUTCHours()}${date.getUTCMinutes()}${date.getUTCSeconds()}`
 
   return timestamp
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -208,3 +208,13 @@ export async function getVariable(name, target) {
     return null
   }
 }
+
+/**
+ * Returns a timestamp in YYYYMMDDSS format
+ */
+export function generateTimestamp() {
+  const date = new Date()
+  const timestamp = `${date.getFullYear()}${date.getMonth()}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}`
+
+  return timestamp
+}

--- a/test/sasjs-run.spec.js
+++ b/test/sasjs-run.spec.js
@@ -1,4 +1,3 @@
-import { test } from 'shelljs'
 import { runSasCode } from '../src/sasjs-run/index'
 
 describe('sasjs run', () => {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,30 @@
+import { generateTimestamp } from '../src/utils/utils'
+
+describe('generateTimestamp', () => {
+  let realDate
+  beforeAll(() => {
+    const currentDate = new Date('2020-10-02T10:10:10.10Z')
+    realDate = Date
+    global.Date = class extends Date {
+      constructor(date) {
+        if (date) {
+          return super(date)
+        }
+
+        return currentDate
+      }
+    }
+  })
+
+  it('should generate a timestamp in the correct format', () => {
+    const expectedTimestamp = '202092111010'
+
+    const timestamp = generateTimestamp()
+
+    expect(timestamp).toEqual(expectedTimestamp)
+  })
+
+  afterAll(() => {
+    global.Date = realDate
+  })
+})

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -17,7 +17,7 @@ describe('generateTimestamp', () => {
   })
 
   it('should generate a timestamp in the correct format', () => {
-    const expectedTimestamp = '202092111010'
+    const expectedTimestamp = '202092101010'
 
     const timestamp = generateTimestamp()
 


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/128.

## Intent

Improve the `sasjs run` command to address the issues described in https://github.com/sasjs/cli/issues/128.

## Implementation

* Migrated to the access token mechanism used by the other commands - fetch it from the `.env` file.
* Saved execution log to a `sasjs-run-{timestamp}.log` file.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
