### PR TITLE
fix(sasjs-run): add the ability to execute sasjs run against a global target

### DIFF
--- a/test/config-utils.spec.js
+++ b/test/config-utils.spec.js
@@ -1,10 +1,18 @@
 import { getAccessToken, sanitizeAppLoc } from '../src/utils/config-utils'
+import {
+  isAccessTokenExpiring,
+  refreshTokens,
+  getNewAccessToken
+} from '../src/utils/auth-utils'
+jest.mock('@sasjs/adapter/node')
 
 describe('Config Utils', () => {
+  let authUtils
   beforeEach(() => {
     process.env.access_token = null
 
-    jest.mock('@sasjs/adapter/node')
+    jest.unmock('../src/utils/auth-utils')
+    authUtils = require('../src/utils/auth-utils')
   })
 
   afterEach(() => {
@@ -47,6 +55,79 @@ describe('Config Utils', () => {
       const token = await getAccessToken(target, false)
 
       expect(token).toEqual('3NVT0K3N')
+    })
+
+    test('should refresh access token when it is expiring and refresh token is available', async () => {
+      authUtils.isAccessTokenExpiring = jest.fn(() => true)
+      authUtils.getNewAccessToken = jest.fn()
+      authUtils.refreshTokens = jest.fn(() =>
+        Promise.resolve({
+          access_token: 'N3WT0K3N'
+        })
+      )
+      const target = {
+        authInfo: {
+          access_token: 'T0K3N',
+          refresh_token: 'R3FR35H',
+          client: 'CL13NT',
+          secret: '53CR3T'
+        }
+      }
+
+      const token = await getAccessToken(target, true)
+
+      expect(isAccessTokenExpiring.mock.calls.length).toEqual(1)
+      expect(refreshTokens.mock.calls.length).toEqual(1)
+      expect(getNewAccessToken.mock.calls.length).toEqual(0)
+      expect(token).toEqual('N3WT0K3N')
+    })
+
+    test('should get new access token when it is expiring and refresh token is not available', async () => {
+      authUtils.isAccessTokenExpiring = jest.fn(() => true)
+      authUtils.refreshTokens = jest.fn()
+      authUtils.getNewAccessToken = jest.fn(() =>
+        Promise.resolve({
+          access_token: 'N3WT0K3N'
+        })
+      )
+      const target = {
+        authInfo: {
+          access_token: 'T0K3N',
+          client: 'CL13NT',
+          secret: '53CR3T'
+        }
+      }
+
+      const token = await getAccessToken(target, true)
+
+      expect(isAccessTokenExpiring.mock.calls.length).toEqual(1)
+      expect(refreshTokens.mock.calls.length).toEqual(0)
+      expect(getNewAccessToken.mock.calls.length).toEqual(1)
+      expect(token).toEqual('N3WT0K3N')
+    })
+
+    test('should throw an error if access token is expiring and client ID is not available', async () => {
+      authUtils.isAccessTokenExpiring = jest.fn(() => true)
+      const target = {
+        authInfo: {
+          access_token: 'T0K3N',
+          secret: '53CR3T'
+        }
+      }
+
+      await expect(getAccessToken(target)).rejects.toThrow()
+    })
+
+    test('should throw an error if access token is expiring and client secret is not available', async () => {
+      authUtils.isAccessTokenExpiring = jest.fn(() => true)
+      const target = {
+        authInfo: {
+          access_token: 'T0K3N',
+          client: 'CL13NT'
+        }
+      }
+
+      await expect(getAccessToken(target)).rejects.toThrow()
     })
   })
 

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -16,7 +16,7 @@ describe('generateTimestamp', () => {
     }
   })
 
-  it('should generate a timestamp in the correct format', () => {
+  test('should generate a timestamp in the correct format', () => {
     const expectedTimestamp = '202092101010'
 
     const timestamp = generateTimestamp()


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/130.

## Intent

Make `sasjs run`(and any other command that depends on `getAccessToken()` work with targets from the global `.sasjsrc` file.

## Implementation

* Use access token, refresh token, client and secret from global target if available.

## Additional improvements
* Use refresh token to automatically refresh access token if expiring.
* When refresh token is unavailable, use existing mechanism that requires manual intervention.
* Add unit tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
