### PR TITLE
AppLoc for global targets, code style checks in CI builds

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,8 +21,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm test
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check code style
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
         env:
           CI: true
-      - run: sh ./test.sh
+
+      - name: Run smoke tests
+        run: sh ./test.sh

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "jest --silent",
     "semantic-release": "semantic-release",
-    "lint:fix": "npx prettier --write 'src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'"
+    "lint:fix": "npx prettier --write 'src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
+    "lint": "npx prettier --check 'src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'"
   },
   "release": {
     "branches": [

--- a/src/sasjs-servicepack/index.js
+++ b/src/sasjs-servicepack/index.js
@@ -30,9 +30,19 @@ export async function processServicepack(commandLine) {
 
   switch (command) {
     case commands.deploy:
-      let targetName = getCommandParameterLastMultiWord('-t', '--target', commandLine, commandExample)
-      let jsonFilePath = getCommandParameter('-s', '--source', commandLine, commandExample)
-      let isForced = isFlagPresent('-f', commandLine)
+      const targetName = getCommandParameterLastMultiWord(
+        '-t',
+        '--target',
+        commandLine,
+        commandExample
+      )
+      const jsonFilePath = getCommandParameter(
+        '-s',
+        '--source',
+        commandLine,
+        commandExample
+      )
+      const isForced = isFlagPresent('-f', commandLine)
 
       servicePackDeploy(jsonFilePath, targetName, isForced)
       break

--- a/src/utils/input-utils.js
+++ b/src/utils/input-utils.js
@@ -12,3 +12,18 @@ export async function getUserInput(fields) {
     })
   })
 }
+
+export async function getAndValidateField(
+  field,
+  validator,
+  message,
+  validatorParams
+) {
+  const input = await getUserInput([field])
+  const isValid = await validator(input[field.name], validatorParams)
+  if (!isValid) {
+    console.log(chalk.redBright.bold(message))
+    return await getAndValidateField(field, validator, message)
+  }
+  return input[field.name]
+}

--- a/src/utils/input-utils.js
+++ b/src/utils/input-utils.js
@@ -1,5 +1,10 @@
 import prompt from 'prompt'
 
+/**
+ * Gets values input from the command line
+ * @param {Array} fields - the fields to get user input for. Each field should have at least a `name` property.
+ * More information about fields available at https://github.com/flatiron/prompt#readme
+ */
 export async function getUserInput(fields) {
   prompt.message = ''
   prompt.start()
@@ -13,6 +18,14 @@ export async function getUserInput(fields) {
   })
 }
 
+/**
+ * Get input from the command line and validates it against the specified validator.
+ * @param {object} field - the field to get user input for, should have at least a `name` property.
+ * More information about fields available at https://github.com/flatiron/prompt#readme
+ * @param {function} validator - an async validator function that resolves with a boolean value.
+ * @param {string} message - the message to display when validation has failed.
+ * @param {any} validatorParams - any additional parameters to be passed to the validator.
+ */
 export async function getAndValidateField(
   field,
   validator,


### PR DESCRIPTION
## Issue

* Fixes https://github.com/sasjs/cli/issues/134.
* Fixes https://github.com/sasjs/cli/issues/135.

## Intent

* Allow users to specify an appLoc when adding a target to the global `.sasjsrc` file.
* Check code style as part of CI builds

## Implementation

* Removed check that allows appLoc only for local targets.
* Added lint script and added build step to run it.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested
        Unit test was unable to be added as it is currently impossible to mock two functions from the same module if they call each other. https://github.com/facebook/jest/issues/936
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
