### PR TITLE
fix(targets): use a single function to fetch target from configuration

### DIFF
--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -38,7 +38,9 @@ export async function build(
   buildSourceFolder = CONSTANTS.buildSourceFolder
   buildDestinationFolder = CONSTANTS.buildDestinationFolder
   buildDestinationServ = CONSTANTS.buildDestinationServ
-  targetToBuild = await findTargetInConfiguration(targetName)
+  const { target } = await findTargetInConfiguration(targetName)
+  targetToBuild = target
+
   if (compileBuildDeployOnly) {
     await compile()
     await createFinalSasFiles()

--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -17,7 +17,7 @@ import { asyncForEach, removeComments, chunk, diff } from '../utils/utils'
 import {
   getSourcePaths,
   getConfiguration,
-  getTargetToBuild,
+  findTargetInConfiguration,
   getTargetSpecificFile,
   getMacroCorePath
 } from '../utils/config-utils'
@@ -38,7 +38,7 @@ export async function build(
   buildSourceFolder = CONSTANTS.buildSourceFolder
   buildDestinationFolder = CONSTANTS.buildDestinationFolder
   buildDestinationServ = CONSTANTS.buildDestinationServ
-  targetToBuild = await getTargetToBuild(targetName)
+  targetToBuild = await findTargetInConfiguration(targetName)
   if (compileBuildDeployOnly) {
     await compile()
     await createFinalSasFiles()

--- a/src/sasjs-deploy/index.js
+++ b/src/sasjs-deploy/index.js
@@ -25,7 +25,10 @@ export async function deploy(
   isForced = false
 ) {
   if (preTargetToBuild) targetToBuild = preTargetToBuild
-  else targetToBuild = await findTargetInConfiguration(targetName)
+  else {
+    const { target } = await findTargetInConfiguration(targetName)
+    targetToBuild = target
+  }
 
   if (targetToBuild.serverType === 'SASVIYA' && !targetToBuild.authInfo) {
     console.log(

--- a/src/sasjs-deploy/index.js
+++ b/src/sasjs-deploy/index.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import SASjs from '@sasjs/adapter/node'
 import chalk from 'chalk'
-import { getTargetToBuild } from '../utils/config-utils'
+import { findTargetInConfiguration } from '../utils/config-utils'
 import { asyncForEach, executeShellScript, getVariable } from '../utils/utils'
 import {
   isSasFile,
@@ -25,7 +25,7 @@ export async function deploy(
   isForced = false
 ) {
   if (preTargetToBuild) targetToBuild = preTargetToBuild
-  else targetToBuild = await getTargetToBuild(targetName)
+  else targetToBuild = await findTargetInConfiguration(targetName)
 
   if (targetToBuild.serverType === 'SASVIYA' && !targetToBuild.authInfo) {
     console.log(

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -31,25 +31,33 @@ export async function createWebAppServices(
   buildDestinationFolder = CONSTANTS.buildDestinationFolder
   console.log(chalk.greenBright('Building web app services...'))
   await createBuildDestinationFolder()
-  let target = null
-  if (preTargetToBuild) target = preTargetToBuild
-  else target = await findTargetInConfiguration(targetName)
+  let targetToBuild = null
+  if (preTargetToBuild) targetToBuild = preTargetToBuild
+  else {
+    const { target } = await findTargetInConfiguration(targetName)
+    targetToBuild = target
+  }
 
-  if (target) {
+  if (targetToBuild) {
     console.log(
-      chalk.greenBright(`Building for target ${chalk.cyanBright(target.name)}`)
+      chalk.greenBright(
+        `Building for target ${chalk.cyanBright(targetToBuild.name)}`
+      )
     )
 
-    const webAppSourcePath = target.webSourcePath
+    const webAppSourcePath = targetToBuild.webSourcePath
     const destinationPath = path.join(
       buildDestinationFolder,
       'services',
-      target.streamWebFolder
+      targetToBuild.streamWebFolder
     )
     await createTargetDestinationFolder(destinationPath)
 
     if (webAppSourcePath) {
-      const assetPathMap = await createAssetServices(target, destinationPath)
+      const assetPathMap = await createAssetServices(
+        targetToBuild,
+        destinationPath
+      )
       const hasIndexHtml = await fileExists(
         path.join(process.projectDir, webAppSourcePath, 'index.html')
       )
@@ -64,7 +72,7 @@ export async function createWebAppServices(
             tag,
             webAppSourcePath,
             destinationPath,
-            target,
+            targetToBuild,
             assetPathMap
           )
         })
@@ -74,7 +82,7 @@ export async function createWebAppServices(
             linkTag,
             webAppSourcePath,
             destinationPath,
-            target
+            targetToBuild
           )
         })
 
@@ -85,7 +93,7 @@ export async function createWebAppServices(
             faviconTag,
             webAppSourcePath,
             destinationPath,
-            target
+            targetToBuild
           )
         })
 

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -1,4 +1,4 @@
-import { getTargetToBuild } from '../utils/config-utils'
+import { findTargetInConfiguration } from '../utils/config-utils'
 import { asyncForEach, chunk } from '../utils/utils'
 import {
   readFile,
@@ -33,7 +33,7 @@ export async function createWebAppServices(
   await createBuildDestinationFolder()
   let target = null
   if (preTargetToBuild) target = preTargetToBuild
-  else target = await getTargetToBuild(targetName)
+  else target = await findTargetInConfiguration(targetName)
 
   if (target) {
     console.log(

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -18,6 +18,14 @@ export async function getConfiguration(pathToFile) {
   return Promise.resolve(null)
 }
 
+/**
+ * Returns the target with the given name.
+ * If the target is not found in the local configuration,
+ * this function then looks in the global configuration.
+ * If it is still unable to find it, it throws an error.
+ * @param {string} targetName - the name of the target in question.
+ * @param {boolean} viyaSpecific - will fall back to the first target of type SASVIYA.
+ */
 export async function findTargetInConfiguration(
   targetName,
   viyaSpecific = false

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -249,50 +249,6 @@ export function getMacroCorePath() {
   return path.join(process.projectDir, 'node_modules', '@sasjs/core')
 }
 
-export async function getTargetToBuild(targetName) {
-  const { buildSourceFolder } = require('../constants')
-  const buildTargets = await getBuildTargets(buildSourceFolder)
-
-  if (buildTargets.length) {
-    let targetToBuild = buildTargets.find((t) => t.name === targetName)
-
-    if (!targetToBuild) {
-      targetToBuild = buildTargets[0]
-
-      console.log(
-        chalk.yellowBright(
-          `No build target specified. Using ${chalk.cyanBright(
-            targetToBuild.name
-          )} by default.`
-        )
-      )
-    }
-
-    if (targetToBuild.appLoc)
-      targetToBuild.appLoc = sanitizeAppLoc(targetToBuild.appLoc)
-
-    return Promise.resolve(targetToBuild)
-  } else {
-    // Use default target to build. For cases when build target was not found.
-    const defaultTargetToBuild = {
-      buildOutputFileName: 'build.sas',
-      serverType: 'SASVIYA'
-    }
-
-    console.log(
-      chalk.yellowBright(
-        `No build target found. Using default target:\n${JSON.stringify(
-          defaultTargetToBuild,
-          null,
-          2
-        )}`
-      )
-    )
-
-    return Promise.resolve(defaultTargetToBuild)
-  }
-}
-
 /**
  * Sanitizes app location string.
  * @param {string} appLoc - app location

--- a/test/commands/servicepack/sasjs-servicepack.deploy.spec.js
+++ b/test/commands/servicepack/sasjs-servicepack.deploy.spec.js
@@ -4,8 +4,8 @@ import dotenv from 'dotenv'
 import path from 'path'
 
 describe('sasjs servicepack', () => {
-  beforeAll(() => {
-    saveGlobalRcFile(
+  beforeAll(async () => {
+    await saveGlobalRcFile(
       JSON.stringify({
         targets: [
           {


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/157.

## Intent

Look for target in global`.sasjsrc` if not present in local configuration.

## Implementation

* Use `findTargetInConfiguration` which already implements the expected behaviour.
* Remove redundant function `findTargetToBuild`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
  (Unable to add a unit test due to issues with mocking out functions from the same module as the one being tested)
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
