### PR TITLE
fix(sasjs-cb): handled cases when dependency source is not present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,9 +1899,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-1.7.2.tgz",
-      "integrity": "sha512-OzbUVJNlMOrvP36/ffyQhkDuQIPYHaOFxwt7GdU29NG0ae9xrohw+DpWUU3PhUg+Agh/H+Zdf5ERWZLx3TiW3g=="
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-iXlFQoYiJUIMISftOL03VLCW9LRWG2dmflA0xMWVnW03Oy0eldjnc5Uhf7nYYfrIz682pWG613Fz+ZDbP2XV/w=="
     },
     "@semantic-release/commit-analyzer": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "^1.17.0",
-    "@sasjs/core": "^1.7.2",
+    "@sasjs/core": "^1.7.3",
     "base64-img": "^1.0.4",
     "btoa": "^1.2.1",
     "chalk": "^4.1.0",

--- a/src/main.js
+++ b/src/main.js
@@ -155,16 +155,21 @@ export async function compileBuildServices(targetName) {
         )
       )
     )
-    .catch((err) => {
-      const body = JSON.parse(err.body)
-      const message = body.message || ''
-
-      console.log(
-        chalk.redBright(
-          'An error has occurred when building services.',
-          message
+    .catch((error) => {
+      if (Array.isArray(error)) {
+        const nodeModulesErrors = error.find((err) =>
+          err.includes('node_modules/@sasjs/core')
         )
-      )
+
+        if (nodeModulesErrors)
+          console.log(
+            chalk.yellowBright(
+              `Suggestion: @sasjs/core dependency is missing. Try running 'npm install @sasjs/core' command.`
+            )
+          )
+      } else {
+        displayResult(error, 'An error has occurred when building services.')
+      }
     })
 }
 

--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -736,19 +736,19 @@ export async function getDependencyPaths(fileContent, tgtMacros = []) {
 
         console.log(chalk.redBright(errorMessage))
 
+        const unFoundDependencies = diff(dependencies, foundDependencies)
+
+        if (unFoundDependencies.length) {
+          console.log(
+            `${chalk.redBright(
+              'Unable to locate dependencies: ' + unFoundDependencies.join(', ')
+            )}`
+          )
+        }
+
         throw errorMessage
       }
     })
-
-    const unFoundDependencies = diff(dependencies, foundDependencies)
-
-    if (unFoundDependencies.length) {
-      console.log(
-        `${chalk.redBright(
-          'Unable to locate dependencies: ' + unFoundDependencies.join(', ')
-        )}`
-      )
-    }
 
     dependencyPaths = prioritiseDependencyOverrides(
       dependencies,

--- a/test/commands/compile/getDependencyPaths.spec.js
+++ b/test/commands/compile/getDependencyPaths.spec.js
@@ -61,11 +61,15 @@ describe('getDependencyPaths', () => {
   })
 
   test('it should throw an error when a dependency is not found', async (done) => {
-    const fileContent = await readFile(
-      path.join(__dirname, './missing-dependency.sas')
-    )
+    const missingDependency = './missing-dependency.sas'
 
-    await expect(getDependencyPaths(fileContent)).rejects.toThrow()
+    const fileContent = await readFile(path.join(__dirname, missingDependency))
+
+    const dependencyPaths = await getDependencyPaths(fileContent)
+
+    expect(
+      dependencyPaths.find((dep) => dep.includes(missingDependency))
+    ).toEqual(undefined)
 
     done()
   })


### PR DESCRIPTION
## Intent

Handle cases when the dependency source is not present.

## Implementation

1. Updated error handling in `main.js`.
2. Changed `sasjs-build` logic.
3. Updated `getDependencyPaths.spec.js` test.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/97970859-36d27800-1dd3-11eb-9df1-3b282b8015c6.png)
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
