### PR TITLE
fix(sasjs-compile): make file header parsing more resilient

### DIFF
--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -14,7 +14,8 @@ import {
   deleteFolder,
   fileExists,
   folderExists,
-  copy
+  copy,
+  getList
 } from '../utils/file-utils'
 import { asyncForEach, removeComments, chunk, diff } from '../utils/utils'
 import {
@@ -583,49 +584,6 @@ export function validateFileRef(fileRef) {
   }
 
   return true
-}
-
-export function getList(listHeader, fileContent) {
-  let fileHeader
-  try {
-    const hasFileHeader = fileContent.split('/**')[0] !== fileContent
-    if (!hasFileHeader) return []
-    fileHeader = fileContent.split('/**')[1].split('**/')[0]
-  } catch (e) {
-    console.error(
-      chalk.redBright(
-        'File header parse error.\nPlease make sure your file header is in the correct format.'
-      )
-    )
-  }
-
-  const list = []
-
-  const lines = fileHeader.split('\n').map((s) => (s ? s.trim() : s))
-  let startIndex = null
-  let endIndex = null
-  for (let i = 0; i < lines.length; i++) {
-    if (new RegExp(listHeader, 'i').test(lines[i])) {
-      startIndex = i + 1
-      break
-    }
-  }
-
-  for (let i = startIndex; i < lines.length; i++) {
-    if (!lines[i]) {
-      endIndex = i
-      break
-    }
-  }
-
-  for (let i = startIndex; i < endIndex; i++) {
-    list.push(lines[i])
-  }
-
-  return list
-    .filter((l) => l.startsWith('@li'))
-    .map((d) => d.replace(/\@li/g, ''))
-    .map((d) => d.trim())
 }
 
 export async function getProgramDependencies(

--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -476,62 +476,29 @@ async function getDependencies(filePaths) {
 }
 
 export function getProgramList(fileContent) {
-  let fileHeader
-  try {
-    const hasFileHeader = fileContent.split('/**')[0] !== fileContent
-    if (!hasFileHeader) return []
-    fileHeader = fileContent.split('/**')[1].split('**/')[0]
-  } catch (e) {
-    console.error(
-      chalk.redBright(
-        'File header parse error.\nPlease make sure your file header is in the correct format.'
+  let programList = getList('<h4> SAS Programs </h4>', fileContent)
+  programList = programList.map((l) => {
+    const [fileName, fileRef] = l.split(' ')
+
+    if (!fileName) {
+      throw new Error(
+        `SAS Program ${fileName} is missing file name. Please specify SAS program dependencies in the format: @li <filename> <fileref>`
       )
-    )
-  }
+    }
 
-  let programsSection
-
-  try {
-    programsSection = fileHeader.split(/\<h4\> SAS Programs \<\/h4\>/i)[1]
-
-    if (!programsSection) return []
-  } catch (e) {
-    console.error(
-      chalk.redBright(
-        'File header parse error.\nPlease make sure your SAS program dependencies are specified in the correct format.'
+    if (fileName && !fileRef) {
+      throw new Error(
+        `SAS Program ${fileName} is missing fileref. Please specify SAS program dependencies in the format: @li <filename> <fileref>`
       )
-    )
-  }
+    }
 
-  const programsList = programsSection
-    .replace(/\r\n/g, '\n')
-    .split('\n')
-    .filter((l) => !!l)
-    .map((l) => l.trim())
-    .filter((l) => l.startsWith('@li'))
-    .map((l) => l.replace(/\@li/g, '').trim())
-    .map((l) => {
-      const [fileName, fileRef] = l.split(' ')
+    validateFileRef(fileRef)
+    return { fileName, fileRef }
+  })
 
-      if (!fileName) {
-        throw new Error(
-          `SAS Program ${fileName} is missing file name. Please specify SAS program dependencies in the format: @li <filename> <fileref>`
-        )
-      }
+  validateProgramsList(programList)
 
-      if (fileName && !fileRef) {
-        throw new Error(
-          `SAS Program ${fileName} is missing fileref. Please specify SAS program dependencies in the format: @li <filename> <fileref>`
-        )
-      }
-
-      validateFileRef(fileRef)
-      return { fileName, fileRef }
-    })
-
-  validateProgramsList(programsList)
-
-  return uniqBy(programsList, 'fileName')
+  return uniqBy(programList, 'fileName')
 }
 
 export function validateProgramsList(programsList) {
@@ -591,6 +558,49 @@ export function validateFileRef(fileRef) {
   }
 
   return true
+}
+
+export function getList(listHeader, fileContent) {
+  let fileHeader
+  try {
+    const hasFileHeader = fileContent.split('/**')[0] !== fileContent
+    if (!hasFileHeader) return []
+    fileHeader = fileContent.split('/**')[1].split('**/')[0]
+  } catch (e) {
+    console.error(
+      chalk.redBright(
+        'File header parse error.\nPlease make sure your file header is in the correct format.'
+      )
+    )
+  }
+
+  const list = []
+
+  const lines = fileHeader.split('\n').map((s) => (s ? s.trim() : s))
+  let startIndex = null
+  let endIndex = null
+  for (let i = 0; i < lines.length; i++) {
+    if (new RegExp(listHeader, 'i').test(lines[i])) {
+      startIndex = i + 1
+      break
+    }
+  }
+
+  for (let i = startIndex; i < lines.length; i++) {
+    if (!lines[i]) {
+      endIndex = i
+      break
+    }
+  }
+
+  for (let i = startIndex; i < endIndex; i++) {
+    list.push(lines[i])
+  }
+
+  return list
+    .filter((l) => l.startsWith('@li'))
+    .map((d) => d.replace(/\@li/g, ''))
+    .map((d) => d.trim())
 }
 
 export async function getProgramDependencies(
@@ -674,56 +684,44 @@ export async function getDependencyPaths(fileContent, tgtMacros = []) {
       sourcePaths.push(tgtMacroPath)
     })
   }
-  const dependenciesStart = fileContent.split('<h4> Dependencies </h4>')
-  let dependencies = []
-  if (dependenciesStart.length > 1) {
-    let count = 1
-    while (count < dependenciesStart.length) {
-      let dependency = dependenciesStart[count]
-        .split('**/')[0]
-        .replace(/\r\n/g, '\n')
-        .split('\n')
-        .filter((d) => !!d)
-        .map((d) => d.replace(/\@li/g, '').replace(/ /g, ''))
-        .filter((d) => d.endsWith('.sas'))
-      dependencies = [...dependencies, ...dependency]
-      count++
-    }
-    let dependencyPaths = []
-    const foundDependencies = []
-    await asyncForEach(sourcePaths, async (sourcePath) => {
-      await asyncForEach(dependencies, async (dep) => {
-        const filePaths = find.fileSync(dep, sourcePath)
-        if (filePaths.length) {
-          const fileContent = await readFile(filePaths[0])
-          foundDependencies.push(dep)
-          dependencyPaths.push(
-            ...(await getDependencyPaths(fileContent, tgtMacros))
-          )
-        }
-        dependencyPaths.push(...filePaths)
-      })
+  const dependencies = getList(
+    '<h4> Dependencies </h4>',
+    fileContent
+  ).filter((d) => d.endsWith('.sas'))
+
+  let dependencyPaths = []
+  const foundDependencies = []
+
+  await asyncForEach(sourcePaths, async (sourcePath) => {
+    await asyncForEach(dependencies, async (dep) => {
+      const filePaths = find.fileSync(dep, sourcePath)
+      if (filePaths.length) {
+        const fileContent = await readFile(filePaths[0])
+        foundDependencies.push(dep)
+        dependencyPaths.push(
+          ...(await getDependencyPaths(fileContent, tgtMacros))
+        )
+      }
+      dependencyPaths.push(...filePaths)
     })
+  })
 
-    const unfoundDependencies = diff(dependencies, foundDependencies)
-    if (unfoundDependencies.length) {
-      throw new Error(
-        `${'Unable to locate dependencies:'} ${chalk.cyanBright(
-          unfoundDependencies.join(', ')
-        )}`
-      )
-    }
-
-    dependencyPaths = prioritiseDependencyOverrides(
-      dependencies,
-      dependencyPaths,
-      tgtMacros
+  const unfoundDependencies = diff(dependencies, foundDependencies)
+  if (unfoundDependencies.length) {
+    throw new Error(
+      `${'Unable to locate dependencies:'} ${chalk.cyanBright(
+        unfoundDependencies.join(', ')
+      )}`
     )
-
-    return [...new Set(dependencyPaths)]
-  } else {
-    return []
   }
+
+  dependencyPaths = prioritiseDependencyOverrides(
+    dependencies,
+    dependencyPaths,
+    tgtMacros
+  )
+
+  return [...new Set(dependencyPaths)]
 }
 
 export function prioritiseDependencyOverrides(

--- a/src/utils/file-utils.js
+++ b/src/utils/file-utils.js
@@ -241,3 +241,51 @@ export function isShellScript(filePath) {
 
 export const sanitizeFileName = (fileName) =>
   fileName.replace(/[^a-z0-9]/gi, '_')
+
+/**
+ * Gets a list of @li items from the supplied file content with the specified header.
+ * @param {string} listHeader - the header of the section to look for - e.g. <h4> Dependencies </h4>.
+ * @param {string} fileContent - the text content of the file.
+ */
+export function getList(listHeader, fileContent) {
+  let fileHeader
+  try {
+    const hasFileHeader = fileContent.split('/**')[0] !== fileContent
+    if (!hasFileHeader) return []
+    fileHeader = fileContent.split('/**')[1].split('**/')[0]
+  } catch (e) {
+    console.error(
+      chalk.redBright(
+        'File header parse error.\nPlease make sure your file header is in the correct format.'
+      )
+    )
+  }
+
+  const list = []
+
+  const lines = fileHeader.split('\n').map((s) => (s ? s.trim() : s))
+  let startIndex = null
+  let endIndex = null
+  for (let i = 0; i < lines.length; i++) {
+    if (new RegExp(listHeader, 'i').test(lines[i])) {
+      startIndex = i + 1
+      break
+    }
+  }
+
+  for (let i = startIndex; i < lines.length; i++) {
+    if (!lines[i]) {
+      endIndex = i
+      break
+    }
+  }
+
+  for (let i = startIndex; i < endIndex; i++) {
+    list.push(lines[i])
+  }
+
+  return list
+    .filter((l) => l.startsWith('@li'))
+    .map((d) => d.replace(/\@li/g, ''))
+    .map((d) => d.trim())
+}

--- a/test/commands/compile/example-reversed.sas
+++ b/test/commands/compile/example-reversed.sas
@@ -1,0 +1,22 @@
+/**
+  @file example.sas
+  @brief example file
+  @details  This service does stuff. Like - ya know - stuff.
+<h4> Dependencies </h4>
+  @li mv_createfolder.sas
+
+
+
+  <h4> SAS Programs </h4>
+  @li test.sas TEST
+
+
+
+
+
+
+
+
+**/
+
+%put stuff;

--- a/test/commands/compile/getProgramDependencies.spec.js
+++ b/test/commands/compile/getProgramDependencies.spec.js
@@ -189,6 +189,44 @@ describe('getProgramList', () => {
     done()
   })
 
+  test('it should return programs list when SAS programs are listed first', async (done) => {
+    const fileContent = await readFile(
+      path.join(__dirname, './example-reversed.sas')
+    )
+    const expectedList = [{ fileName: 'test.sas', fileRef: 'TEST' }]
+
+    const actualList = await getProgramList(fileContent)
+
+    expect(actualList).toEqual(expectedList)
+
+    done()
+  })
+
+  test('it should be able to handle extra newlines', async (done) => {
+    const fileContent = await readFile(path.join(__dirname, './newlines.sas'))
+    const expectedList = [{ fileName: 'test.sas', fileRef: 'TEST' }]
+
+    const actualList = await getProgramList(fileContent)
+
+    expect(actualList).toEqual(expectedList)
+
+    done()
+  })
+
+  test('it should be able to handle irregular spacing', async (done) => {
+    const fileContent = await readFile(path.join(__dirname, './spacing.sas'))
+    const expectedList = [
+      { fileName: 'test.sas', fileRef: 'TEST' },
+      { fileName: 'test2.sas', fileRef: 'TEST2' }
+    ]
+
+    const actualList = await getProgramList(fileContent)
+
+    expect(actualList).toEqual(expectedList)
+
+    done()
+  })
+
   test('it should get program dependencies when header is mixed case', async (done) => {
     let fileContent = await readFile(path.join(__dirname, './example.sas'))
     fileContent = fileContent.replace('SAS Programs', 'sas PROGRaMS')

--- a/test/commands/compile/newlines.sas
+++ b/test/commands/compile/newlines.sas
@@ -1,0 +1,15 @@
+/**
+  @file example.sas
+  @brief example file
+  @details  This service does stuff. Like - ya know - stuff.
+
+
+  <h4> SAS Programs </h4>
+  @li test.sas TEST
+
+  <h4> Dependencies </h4>
+  @li mv_createfolder.sas
+
+**/
+
+%put stuff;

--- a/test/commands/compile/spacing.sas
+++ b/test/commands/compile/spacing.sas
@@ -1,0 +1,17 @@
+/**
+  @file example.sas
+  @brief example file
+  @details  This service does stuff. Like - ya know - stuff.
+
+
+  <h4> SAS Programs </h4>
+  @li test.sas TEST
+  @li test2.sas TEST2
+
+  <h4> Dependencies </h4>
+  @li mv_createfolder.sas
+  @li mv_createfolder2.sas
+
+**/
+
+%put stuff;


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/203

## Intent

Improve the file header parsing mechanism and make it common between dependencies and SAS programs.

## Implementation

* Added `getList` function.
* Used `getList` function when parsing dependencies and SAS programs.
* Added tests for weird spacing scenarios.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
