### PR TITLE
Service dependencies

### DIFF
--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -542,17 +542,24 @@ export async function loadDependencies(
       : ''
   }
 
-  const dependencyFilePaths = await getDependencyPaths(
+  const fileDependencyPaths = await getDependencyPaths(
     `${fileContent}\n${init}\n${term}`,
     tgtMacros
   )
+  const initDependencyPaths = await getDependencyPaths(init, tgtMacros)
+  const termDependencyPaths = await getDependencyPaths(term, tgtMacros)
+  const allDependencyPaths = [
+    ...initDependencyPaths,
+    ...fileDependencyPaths,
+    ...termDependencyPaths
+  ]
   const programDependencies = await getProgramDependencies(
     fileContent,
     programFolders,
     buildSourceFolder
   )
 
-  const dependenciesContent = await getDependencies(dependencyFilePaths)
+  const dependenciesContent = await getDependencies(allDependencyPaths)
 
   fileContent = `* Dependencies start;\n${dependenciesContent}\n* Dependencies end;\n* Programs start;\n${programDependencies}\n*Programs end;${init}${fileContent}${term}`
 
@@ -567,7 +574,7 @@ async function getBuildInit() {
   return await getTargetSpecificFile('BuildInit', targetToBuild)
 }
 
-async function getServiceInit() {
+export async function getServiceInit() {
   const init = (await getTargetSpecificFile('ServiceInit', targetToBuild))
     .content
   return init ? `\n* ServiceInit start;\n${init}\n* ServiceInit end;` : ''

--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -1,3 +1,5 @@
+import * as thisModule from './index'
+
 import find from 'find'
 import path from 'path'
 import chalk from 'chalk'
@@ -525,17 +527,17 @@ export async function loadDependencies(
   if (type === 'service') {
     serviceVars = await getServiceVars()
 
-    init = await getServiceInit()
+    init = await thisModule.getServiceInit()
 
-    term = await getServiceTerm()
+    term = await thisModule.getServiceTerm()
 
     fileContent = fileContent
       ? `\n* Service start;\n${fileContent}\n* Service end;`
       : ''
   } else {
-    init = await getJobInit()
+    init = await thisModule.getJobInit()
 
-    term = await getJobTerm()
+    term = await thisModule.getJobTerm()
 
     fileContent = fileContent
       ? `\n* Job start;\n${fileContent}\n* Job end;`
@@ -580,18 +582,18 @@ export async function getServiceInit() {
   return init ? `\n* ServiceInit start;\n${init}\n* ServiceInit end;` : ''
 }
 
-async function getJobInit() {
+export async function getJobInit() {
   const init = (await getTargetSpecificFile('jobInit', targetToBuild)).content
   return init ? `\n* JobInit start;\n${init}\n* JobInit end;` : ''
 }
 
-async function getServiceTerm() {
+export async function getServiceTerm() {
   const term = (await getTargetSpecificFile('ServiceTerm', targetToBuild))
     .content
   return term ? `\n* ServiceTerm start;\n${term}\n* ServiceTerm end;` : ''
 }
 
-async function getJobTerm() {
+export async function getJobTerm() {
   const term = (await getTargetSpecificFile('jobTerm', targetToBuild)).content
   return term ? `\n* JobTerm start;\n${term}\n* JobTerm end;` : ''
 }

--- a/test/commands/compile/loadDependencies.spec.js
+++ b/test/commands/compile/loadDependencies.spec.js
@@ -1,14 +1,43 @@
 import path from 'path'
 import * as compileModule from '../../../src/sasjs-build/index'
 
+const fakeServiceInit = `/**
+  @file serviceinit.sas
+  @brief this file is called with every service
+  @details  This file is included in *every* service, *after* the macros and *before* the service code.
+
+  <h4> Dependencies </h4>
+  @li mf_abort.sas
+
+**/
+
+options
+  DATASTMTCHK=ALLKEYWORDS /* some sites have this enabled */
+  PS=MAX /* reduce log size slightly */
+;
+%put service is starting!!;`
+
+const fakeServiceTerm = `/**
+  @file serviceterm.sas
+  @brief this file is called at the end of every service
+  @details  This file is included at the *end* of every service.
+
+  <h4> Dependencies </h4>
+  @li mf_abort.sas
+  @li mf_existds.sas
+
+**/
+
+%put service is finishing.  Thanks, SASjs!;`
+
 process.projectDir = path.join(process.cwd())
 describe('loadDependencies', () => {
   test('it should load dependencies for a service', async (done) => {
     spyOn(compileModule, 'getServiceInit').and.returnValue(
-      '\n* ServiceInit start;\nFAKE SERVICE INIT\n* ServiceInit end;'
+      `\n* ServiceInit start;\n${fakeServiceInit}\n* ServiceInit end;`
     )
     spyOn(compileModule, 'getServiceTerm').and.returnValue(
-      '\n* ServiceTerm start;\nFAKE SERVICE TERM\n* ServiceTerm end;'
+      `\n* ServiceTerm start;\n${fakeServiceTerm}\n* ServiceTerm end;`
     )
 
     const dependencies = await compileModule.loadDependencies(
@@ -17,27 +46,22 @@ describe('loadDependencies', () => {
       [],
       'service'
     )
-
-    expect(
-      /\* ServiceInit start;\nFAKE SERVICE INIT\n\* ServiceInit end;/.test(
-        dependencies
-      )
-    ).toEqual(true)
-    expect(
-      /\* ServiceTerm start;\nFAKE SERVICE TERM\n\* ServiceTerm end;/.test(
-        dependencies
-      )
-    ).toEqual(true)
+    expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
 
     done()
   })
 
   test('it should load dependencies for a job', async (done) => {
-    spyOn(compileModule, 'getJobTerm').and.returnValue(
-      '\n* JobTerm start;\nFAKE JOB TERM\n* JobTerm end;'
-    )
     spyOn(compileModule, 'getJobInit').and.returnValue(
-      '\n* JobInit start;\nFAKE JOB INIT\n* JobInit end;'
+      `\n* JobInit start;\n${fakeServiceInit}\n* JobInit end;`
+    )
+    spyOn(compileModule, 'getJobTerm').and.returnValue(
+      `\n* JobTerm start;\n${fakeServiceTerm}\n* JobTerm end;`
     )
 
     const dependencies = await compileModule.loadDependencies(
@@ -47,12 +71,12 @@ describe('loadDependencies', () => {
       'job'
     )
 
-    expect(
-      /\* JobTerm start;\nFAKE JOB TERM\n\* JobTerm end;/.test(dependencies)
-    ).toEqual(true)
-    expect(
-      /\* JobInit start;\nFAKE JOB INIT\n\* JobInit end;/.test(dependencies)
-    ).toEqual(true)
+    expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
 
     done()
   })

--- a/test/commands/compile/loadDependencies.spec.js
+++ b/test/commands/compile/loadDependencies.spec.js
@@ -1,34 +1,59 @@
 import path from 'path'
-jest.unmock('../../../src/sasjs-build/index')
-import { loadDependencies } from '../../../src/sasjs-build/index'
+import * as compileModule from '../../../src/sasjs-build/index'
 
 process.projectDir = path.join(process.cwd())
 describe('loadDependencies', () => {
-  test.todo('it should load dependencies for a service', async (done) => {
-    const dependencies = await loadDependencies(
+  test('it should load dependencies for a service', async (done) => {
+    spyOn(compileModule, 'getServiceInit').and.returnValue(
+      '\n* ServiceInit start;\nFAKE SERVICE INIT\n* ServiceInit end;'
+    )
+    spyOn(compileModule, 'getServiceTerm').and.returnValue(
+      '\n* ServiceTerm start;\nFAKE SERVICE TERM\n* ServiceTerm end;'
+    )
+
+    const dependencies = await compileModule.loadDependencies(
       path.join(__dirname, './service.sas'),
       [],
       [],
       'service'
     )
 
-    console.log(dependencies)
-    // TODO: Assert on the fact that dependencies text is included
-    expect(true).toEqual(true)
+    expect(
+      /\* ServiceInit start;\nFAKE SERVICE INIT\n\* ServiceInit end;/.test(
+        dependencies
+      )
+    ).toEqual(true)
+    expect(
+      /\* ServiceTerm start;\nFAKE SERVICE TERM\n\* ServiceTerm end;/.test(
+        dependencies
+      )
+    ).toEqual(true)
+
     done()
   })
 
-  test.todo('it should load dependencies for a job', async (done) => {
-    const dependencies = await sasjsBuild.loadDependencies(
+  test('it should load dependencies for a job', async (done) => {
+    spyOn(compileModule, 'getJobTerm').and.returnValue(
+      '\n* JobTerm start;\nFAKE JOB TERM\n* JobTerm end;'
+    )
+    spyOn(compileModule, 'getJobInit').and.returnValue(
+      '\n* JobInit start;\nFAKE JOB INIT\n* JobInit end;'
+    )
+
+    const dependencies = await compileModule.loadDependencies(
       path.join(__dirname, './service.sas'),
       [],
       [],
       'job'
     )
 
-    console.log(dependencies)
-    // TODO: Assert on the fact that dependencies text is included
-    expect(true).toEqual(true)
+    expect(
+      /\* JobTerm start;\nFAKE JOB TERM\n\* JobTerm end;/.test(dependencies)
+    ).toEqual(true)
+    expect(
+      /\* JobInit start;\nFAKE JOB INIT\n\* JobInit end;/.test(dependencies)
+    ).toEqual(true)
+
     done()
   })
 })

--- a/test/commands/compile/loadDependencies.spec.js
+++ b/test/commands/compile/loadDependencies.spec.js
@@ -1,14 +1,11 @@
 import path from 'path'
-import { readFile } from '../../../src/utils/file-utils'
 jest.unmock('../../../src/sasjs-build/index')
-import * as sasjsBuild from '../../../src/sasjs-build/index'
+import { loadDependencies } from '../../../src/sasjs-build/index'
 
 process.projectDir = path.join(process.cwd())
-jest.spyOn(sasjsBuild, 'getServiceInit')
-sasjsBuild.getServiceInit.mockImplementation(() => Promise.resolve(''))
 describe('loadDependencies', () => {
   test.todo('it should load dependencies for a service', async (done) => {
-    const dependencies = await sasjsBuild.loadDependencies(
+    const dependencies = await loadDependencies(
       path.join(__dirname, './service.sas'),
       [],
       [],

--- a/test/commands/compile/loadDependencies.spec.js
+++ b/test/commands/compile/loadDependencies.spec.js
@@ -1,0 +1,37 @@
+import path from 'path'
+import { readFile } from '../../../src/utils/file-utils'
+jest.unmock('../../../src/sasjs-build/index')
+import * as sasjsBuild from '../../../src/sasjs-build/index'
+
+process.projectDir = path.join(process.cwd())
+jest.spyOn(sasjsBuild, 'getServiceInit')
+sasjsBuild.getServiceInit.mockImplementation(() => Promise.resolve(''))
+describe('loadDependencies', () => {
+  test.todo('it should load dependencies for a service', async (done) => {
+    const dependencies = await sasjsBuild.loadDependencies(
+      path.join(__dirname, './service.sas'),
+      [],
+      [],
+      'service'
+    )
+
+    console.log(dependencies)
+    // TODO: Assert on the fact that dependencies text is included
+    expect(true).toEqual(true)
+    done()
+  })
+
+  test.todo('it should load dependencies for a job', async (done) => {
+    const dependencies = await sasjsBuild.loadDependencies(
+      path.join(__dirname, './service.sas'),
+      [],
+      [],
+      'job'
+    )
+
+    console.log(dependencies)
+    // TODO: Assert on the fact that dependencies text is included
+    expect(true).toEqual(true)
+    done()
+  })
+})


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/215

## Intent

* Load dependencies for `init` and `term` files as part of the compile process.

## Implementation

* Call `getDependencyPaths` separately for `init`, `term` and actual file.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
