### PR TITLE
fix: sasjs job execute issue for git-bash windows

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -25,7 +25,8 @@ import { exit } from 'process'
 function parseCommand(rawArgs) {
   checkNodeVersion()
 
-  const args = rawArgs.slice(2)
+  // should update paths converted by POSIX in case of process.env.MSYSTEM is present
+  const args = rawArgs.slice(2).map((arg) => arg.replace(/(.*)\/Git\//i, '/'))
 
   if (args.length) {
     const name = getUnaliasedCommand(args[0])

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,8 +25,16 @@ import { exit } from 'process'
 function parseCommand(rawArgs) {
   checkNodeVersion()
 
-  // should update paths converted by POSIX in case of process.env.MSYSTEM is present
-  const args = rawArgs.slice(2).map((arg) => arg.replace(/(.*)\/Git\//i, '/'))
+  const isWin = process.platform === 'win32'
+  const isMSys = !!process.env.MSYSTEM
+  const prefix = process.env.EXEPATH
+    ? process.env.EXEPATH.replace(/\\/g, '/')
+    : ''
+
+  const args =
+    isWin && isMSys
+      ? rawArgs.slice(2).map((arg) => arg.replace(prefix, ''))
+      : rawArgs.slice(2)
 
   if (args.length) {
     const name = getUnaliasedCommand(args[0])


### PR DESCRIPTION
## Issue

Closes #221 

## Intent

Bash breaks Windows tools by replacing forward slash with a directory path
POSIX path conversion: http://www.mingw.org/wiki/Posix_path_conversion

## Implementation

Written regex to replace if /git/ path is pre appended in args in cli.js file

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
