### PR TITLE
fix(win-path): delimiter in path slash OS specific

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -279,15 +279,15 @@ async function checkProjectDirectory() {
     if (pathExists) {
       found = true
     } else {
-      let strBreak = newBSF.split('/')
+      let strBreak = newBSF.split(path.sep)
       strBreak.splice(-1, 1)
-      newBSF = strBreak.join('/')
+      newBSF = strBreak.join(path.sep)
     }
   } while (newBSF.length && !found)
   if (found) {
-    let strBreak = newBSF.split('/')
+    let strBreak = newBSF.split(path.sep)
     strBreak.splice(-1, 1)
-    let newProDir = strBreak.join('/')
+    let newProDir = strBreak.join(path.sep)
     process.projectDir = newProDir
     console.log(
       chalk.cyanBright(

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,15 +16,11 @@ const buildDestinationDBFolder = path.join(
   'db'
 )
 
-const isWin = process.platform === 'win32'
-const slashInPath = isWin ? '\\' : '/'
-
 module.exports = {
   buildSourceFolder,
   buildSourceDBFolder,
   buildDestinationFolder,
   buildDestinationServ,
   buildDestinationJobs,
-  buildDestinationDBFolder,
-  slashInPath
+  buildDestinationDBFolder
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,11 +16,15 @@ const buildDestinationDBFolder = path.join(
   'db'
 )
 
+const isWin = process.platform === 'win32'
+const slashInPath = isWin ? '\\' : '/'
+
 module.exports = {
   buildSourceFolder,
   buildSourceDBFolder,
   buildDestinationFolder,
   buildDestinationServ,
   buildDestinationJobs,
-  buildDestinationDBFolder
+  buildDestinationDBFolder,
+  slashInPath
 }

--- a/src/sasjs-job/execute.js
+++ b/src/sasjs-job/execute.js
@@ -4,8 +4,6 @@ import { displayResult } from '../utils/displayResult'
 import { createFile, createFolder, folderExists } from '../utils/file-utils'
 import path from 'path'
 
-let slashInPath
-
 /**
  * Triggers existing job for execution.
  * @param {object} sasjs - configuration object of SAS adapter.
@@ -26,7 +24,6 @@ export async function execute(
   output,
   log
 ) {
-  slashInPath = require('../constants').slashInPath
   let result
 
   const startTime = new Date().getTime()
@@ -82,9 +79,9 @@ export async function execute(
             /\.json$/i.test(output) ? output : path.join(output, 'output.json')
           )
 
-          let folderPath = outputPath.split(slashInPath)
+          let folderPath = outputPath.split(path.sep)
           folderPath.pop()
-          folderPath = folderPath.join(slashInPath)
+          folderPath = folderPath.join(path.sep)
 
           if (!(await folderExists(folderPath))) await createFolder(folderPath)
 
@@ -124,9 +121,9 @@ export async function execute(
               )
             }
 
-            let folderPath = logPath.split(slashInPath)
+            let folderPath = logPath.split(path.sep)
             folderPath.pop()
-            folderPath = folderPath.join(slashInPath)
+            folderPath = folderPath.join(path.sep)
 
             if (!(await folderExists(folderPath))) {
               await createFolder(folderPath)

--- a/src/sasjs-job/execute.js
+++ b/src/sasjs-job/execute.js
@@ -4,6 +4,8 @@ import { displayResult } from '../utils/displayResult'
 import { createFile, createFolder, folderExists } from '../utils/file-utils'
 import path from 'path'
 
+let slashInPath
+
 /**
  * Triggers existing job for execution.
  * @param {object} sasjs - configuration object of SAS adapter.
@@ -24,6 +26,7 @@ export async function execute(
   output,
   log
 ) {
+  slashInPath = require('../constants').slashInPath
   let result
 
   const startTime = new Date().getTime()
@@ -79,9 +82,9 @@ export async function execute(
             /\.json$/i.test(output) ? output : path.join(output, 'output.json')
           )
 
-          let folderPath = outputPath.split('/')
+          let folderPath = outputPath.split(slashInPath)
           folderPath.pop()
-          folderPath = folderPath.join('/')
+          folderPath = folderPath.join(slashInPath)
 
           if (!(await folderExists(folderPath))) await createFolder(folderPath)
 
@@ -121,9 +124,9 @@ export async function execute(
               )
             }
 
-            let folderPath = logPath.split('/')
+            let folderPath = logPath.split(slashInPath)
             folderPath.pop()
-            folderPath = folderPath.join('/')
+            folderPath = folderPath.join(slashInPath)
 
             if (!(await folderExists(folderPath))) {
               await createFolder(folderPath)


### PR DESCRIPTION
## Issue

#229

## Intent

Cater cater case in Windows, Paths are with forward slash

## Implementation

Added OS specific slash constant `slashInPath`, use this in all command files, wherever `path` utility is used
Update: now we are using  `path.sep` provided by utility itself

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
