### PR TITLE
fix(line-endings): handle CRLF line endings when removing comments

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -106,8 +106,19 @@ export async function asyncForEach(array, callback) {
   }
 }
 
+/**
+ * Removes comments from a given block of text.
+ * Preserves single line block comments and inline comments.
+ * @param {string} text - the text to remove comments from.
+ */
 export function removeComments(text) {
-  const lines = text.split('\n')
+  if (!text) return ''
+
+  const lines = text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((l) => l.trimEnd())
+
   const linesWithoutComment = []
   let inCommentBlock = false
   lines.forEach((line) => {

--- a/test/removeComments.spec.js
+++ b/test/removeComments.spec.js
@@ -9,6 +9,7 @@ describe('removeComments', () => {
 
   test('should not remove single line block comment', () => {
     const text = `/* test */`
+
     expect(removeComments(text)).toEqual(text)
   })
 
@@ -22,11 +23,41 @@ describe('removeComments', () => {
 
   test('should keep inline comments intact when they start a line', () => {
     const text = '/* Some Comment */ CODE HERE;'
+
     expect(removeComments(text)).toEqual(text)
   })
 
   test('should keep inline comments intact when they are within a line', () => {
     const text = 'CODE HERE /* Some Comment  */'
+
+    expect(removeComments(text)).toEqual(text)
+  })
+
+  test('should handle CRLF line endings', () => {
+    const text = 'CODE HERE\r\n\r\nMORE CODE'
+    const expectedText = 'CODE HERE\nMORE CODE'
+
+    expect(removeComments(text)).toEqual(expectedText)
+  })
+
+  test('should handle a mix of CRLF and LF line endings', () => {
+    const text = 'CODE HERE\r\n\r\nMORE CODE\nEVEN MORE CODE'
+    const expectedText = 'CODE HERE\nMORE CODE\nEVEN MORE CODE'
+
+    expect(removeComments(text)).toEqual(expectedText)
+  })
+
+  test('should return an empty string when the input is falsy', () => {
+    expect(removeComments(null)).toEqual('')
+    expect(removeComments(undefined)).toEqual('')
+    expect(removeComments('')).toEqual('')
+  })
+
+  test('should preserve formatting when removing comments', () => {
+    const text = `if (this === 'code') {
+  console.log('Pigs can fly.')
+  }`
+
     expect(removeComments(text)).toEqual(text)
   })
 })


### PR DESCRIPTION
## Issue

Attempt to fix regression from fix to #209. 

## Intent

Handle CRLF and LF line endings when removing comments from a file.

## Implementation

### `removeComments()`
* Return empty string when input is falsy.
* Convert all CRLF line endings to LF before processing a file.
* Trim the end of each line to remove trailing spaces or line terminators.
* Added tests to cover line endings and formatting.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
![image](https://user-images.githubusercontent.com/2980428/99094367-a31b5b80-25cb-11eb-8bfa-b5ab26c27ba4.png)
