### PR TITLE
fix(sasjs-folder-delete): support relative and absolute paths

### DIFF
--- a/src/sasjs-folder/index.js
+++ b/src/sasjs-folder/index.js
@@ -74,13 +74,13 @@ export async function folder(commandLine) {
     return
   }
 
-  // Folder path should has prefix '/'
-  if (!/^\//.test(folderPath)) folderPath = '/' + folderPath
-
   const sasjs = new SASjs({
     serverUrl: target.serverUrl,
     serverType: target.serverType
   })
+
+  // Folder paths not starting with a slash are prefixed with the appLoc
+  if (!/^\//.test(folderPath)) folderPath = `${target.appLoc}/${folderPath}`
 
   const accessToken = await getAccessToken(target).catch((err) =>
     displayResult(err)

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -1,0 +1,29 @@
+import { folder } from '../../../src/sasjs-folder/index'
+import { generateTimestamp } from '../../../src/utils/utils'
+
+describe('sasjs folder delete', () => {
+  beforeAll(async (done) => {
+    dotenv.config()
+    done()
+  })
+
+  it('should delete folders when a relative path is provided', async (done) => {
+    const timestamp = generateTimestamp()
+    await folder(`folder create /Public/app/test-${timestamp}`)
+
+    await expect(folder(`folder delete test-${timestamp}`)).resolves.toEqual(
+      true
+    )
+    done()
+  })
+
+  it('should delete folders when an absolute path is provided', async (done) => {
+    const timestamp = generateTimestamp()
+    await folder(`folder create /Public/app/test-${timestamp}`)
+
+    await expect(
+      folder(`folder delete /Public/app/test-${timestamp}`)
+    ).resolves.toEqual(true)
+    done()
+  })
+})


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/234.

## Intent

Support relative and absolute paths in `sasjs folder delete` command.

## Implementation

* Prepend `appLoc` to folder paths that don't start with a `/`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated. - there are no relevant JSDoc comments, but a code comment has been updated.
