### PR TITLE
fix(sasjs-folder-delete): wait for operation to complete, fix tests

### DIFF
--- a/src/sasjs-folder/index.js
+++ b/src/sasjs-folder/index.js
@@ -88,17 +88,11 @@ export async function folder(commandLine) {
 
   switch (command) {
     case commands.create:
-      create(folderPath, sasjs, accessToken, forceFlagIndex !== -1)
-
-      break
+      return await create(folderPath, sasjs, accessToken, forceFlagIndex !== -1)
     case commands.delete:
-      remove(folderPath, sasjs, accessToken)
-
-      break
+      return await remove(folderPath, sasjs, accessToken)
     case commands.move:
-      move(folderPath, sasjs, accessToken)
-
-      break
+      return await move(folderPath, sasjs, accessToken)
     default:
       break
   }

--- a/src/sasjs-folder/remove.js
+++ b/src/sasjs-folder/remove.js
@@ -19,5 +19,7 @@ export const remove = async (path, sasjs, accessToken) => {
       null,
       `Folder '${path}' has been moved to 'Recycle Bin'.`
     )
+    return Promise.resolve(true)
   }
+  return Promise.reject()
 }

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -4,12 +4,11 @@ import { generateTimestamp } from '../../../src/utils/utils'
 describe('sasjs folder delete', () => {
   let config
   const timestamp = generateTimestamp()
+  const targetName = 'cli-tests-folder-delete'
+  config = createConfig(targetName, timestamp)
 
   beforeAll(async (done) => {
     dotenv.config()
-    const targetName = 'cli-tests-folder-delete'
-    config = createConfig(targetName, timestamp)
-
     await addToGlobalConfigs(config)
     done()
   })

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -1,3 +1,4 @@
+import dotenv from 'dotenv'
 import { folder } from '../../../src/sasjs-folder/index'
 import { generateTimestamp } from '../../../src/utils/utils'
 

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -31,6 +31,7 @@ describe('sasjs folder delete', () => {
 
   beforeAll(async (done) => {
     dotenv.config()
+    process.projectDir = process.cwd()
     await addToGlobalConfigs(config)
     done()
   })

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -28,10 +28,10 @@ describe('sasjs folder delete', () => {
   const timestamp = generateTimestamp()
   const targetName = 'cli-tests-folder-delete'
   config = createConfig(targetName, timestamp)
+  process.projectDir = process.cwd()
 
   beforeAll(async (done) => {
     dotenv.config()
-    process.projectDir = process.cwd()
     await addToGlobalConfigs(config)
     done()
   })

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -30,13 +30,9 @@ describe('sasjs folder delete', () => {
   config = createConfig(targetName, timestamp)
   process.projectDir = process.cwd()
 
-  beforeAll(async (done) => {
+  it('should delete folders when a relative path is provided', async (done) => {
     dotenv.config()
     await addToGlobalConfigs(config)
-    done()
-  })
-
-  it('should delete folders when a relative path is provided', async (done) => {
     await folder(['folder', 'create', `${config.appLoc}/test-${timestamp}`])
 
     await expect(
@@ -46,6 +42,8 @@ describe('sasjs folder delete', () => {
   })
 
   it('should delete folders when an absolute path is provided', async (done) => {
+    dotenv.config()
+    await addToGlobalConfigs(config)
     await folder(['folder', 'create', `${config.appLoc}/test-${timestamp}`])
 
     await expect(

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -1,6 +1,28 @@
 import { folder } from '../../../src/sasjs-folder/index'
 import { generateTimestamp } from '../../../src/utils/utils'
 
+const createConfig = (targetName, timestamp) => ({
+  name: targetName,
+  serverType: process.env.SERVER_TYPE,
+  serverUrl: process.env.SERVER_URL,
+  appLoc: `/Public/app/cli-tests-${timestamp}`,
+  useComputeApi: true,
+  contextName: 'SAS Studio compute context', // FIXME: should not be hard coded
+  tgtServices: ['../test/commands/request/runRequest'],
+  authInfo: {
+    client: process.env.CLIENT,
+    secret: process.env.SECRET,
+    access_token: process.env.ACCESS_TOKEN,
+    refresh_token: process.env.REFRESH_TOKEN
+  },
+  tgtDeployVars: {
+    client: process.env.CLIENT,
+    secret: process.env.SECRET
+  },
+  deployServicePack: true,
+  tgtDeployScripts: []
+})
+
 describe('sasjs folder delete', () => {
   let config
   const timestamp = generateTimestamp()
@@ -30,26 +52,4 @@ describe('sasjs folder delete', () => {
     ).resolves.toEqual(true)
     done()
   })
-})
-
-const createConfig = (targetName, timestamp) => ({
-  name: targetName,
-  serverType: process.env.SERVER_TYPE,
-  serverUrl: process.env.SERVER_URL,
-  appLoc: `/Public/app/cli-tests-${timestamp}`,
-  useComputeApi: true,
-  contextName: 'SAS Studio compute context', // FIXME: should not be hard coded
-  tgtServices: ['../test/commands/request/runRequest'],
-  authInfo: {
-    client: process.env.CLIENT,
-    secret: process.env.SECRET,
-    access_token: process.env.ACCESS_TOKEN,
-    refresh_token: process.env.REFRESH_TOKEN
-  },
-  tgtDeployVars: {
-    client: process.env.CLIENT,
-    secret: process.env.SECRET
-  },
-  deployServicePack: true,
-  tgtDeployScripts: []
 })

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -2,14 +2,19 @@ import { folder } from '../../../src/sasjs-folder/index'
 import { generateTimestamp } from '../../../src/utils/utils'
 
 describe('sasjs folder delete', () => {
+  let config
+  const timestamp = generateTimestamp()
+
   beforeAll(async (done) => {
     dotenv.config()
+    config = createConfig(targetName, timestamp)
+
+    await addToGlobalConfigs(config)
     done()
   })
 
   it('should delete folders when a relative path is provided', async (done) => {
-    const timestamp = generateTimestamp()
-    await folder(`folder create /Public/app/test-${timestamp}`)
+    await folder(`folder create ${config.appLoc}/test-${timestamp}`)
 
     await expect(folder(`folder delete test-${timestamp}`)).resolves.toEqual(
       true
@@ -18,12 +23,33 @@ describe('sasjs folder delete', () => {
   })
 
   it('should delete folders when an absolute path is provided', async (done) => {
-    const timestamp = generateTimestamp()
-    await folder(`folder create /Public/app/test-${timestamp}`)
+    await folder(`folder create ${config.appLoc}/test-${timestamp}`)
 
     await expect(
-      folder(`folder delete /Public/app/test-${timestamp}`)
+      folder(`folder delete ${config.appLoc}/test-${timestamp}`)
     ).resolves.toEqual(true)
     done()
   })
+})
+
+const createConfig = (targetName, timestamp) => ({
+  name: targetName,
+  serverType: process.env.SERVER_TYPE,
+  serverUrl: process.env.SERVER_URL,
+  appLoc: `/Public/app/cli-tests-${timestamp}`,
+  useComputeApi: true,
+  contextName: 'SAS Studio compute context', // FIXME: should not be hard coded
+  tgtServices: ['../test/commands/request/runRequest'],
+  authInfo: {
+    client: process.env.CLIENT,
+    secret: process.env.SECRET,
+    access_token: process.env.ACCESS_TOKEN,
+    refresh_token: process.env.REFRESH_TOKEN
+  },
+  tgtDeployVars: {
+    client: process.env.CLIENT,
+    secret: process.env.SECRET
+  },
+  deployServicePack: true,
+  tgtDeployScripts: []
 })

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -7,6 +7,7 @@ describe('sasjs folder delete', () => {
 
   beforeAll(async (done) => {
     dotenv.config()
+    const targetName = 'cli-tests-folder-delete'
     config = createConfig(targetName, timestamp)
 
     await addToGlobalConfigs(config)

--- a/test/commands/folder/delete.spec.js
+++ b/test/commands/folder/delete.spec.js
@@ -36,19 +36,19 @@ describe('sasjs folder delete', () => {
   })
 
   it('should delete folders when a relative path is provided', async (done) => {
-    await folder(`folder create ${config.appLoc}/test-${timestamp}`)
+    await folder(['folder', 'create', `${config.appLoc}/test-${timestamp}`])
 
-    await expect(folder(`folder delete test-${timestamp}`)).resolves.toEqual(
-      true
-    )
+    await expect(
+      folder(['folder', 'delete', `test-${timestamp}`])
+    ).resolves.toEqual(true)
     done()
   })
 
   it('should delete folders when an absolute path is provided', async (done) => {
-    await folder(`folder create ${config.appLoc}/test-${timestamp}`)
+    await folder(['folder', 'create', `${config.appLoc}/test-${timestamp}`])
 
     await expect(
-      folder(`folder delete ${config.appLoc}/test-${timestamp}`)
+      folder(['folder', 'delete', `${config.appLoc}/test-${timestamp}`])
     ).resolves.toEqual(true)
     done()
   })


### PR DESCRIPTION
## Issue

#234 was merged before checks passed.

## Intent

Fix failing tests for `sasjs folder delete`.

## Implementation

* Generate configuration using timestamp.
* Fix `sasjs folder` command to wait for operation to complete.
* Mock `remove` module in tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
