### PR TITLE
fix(sas-programs): report on missing dependencies after checking all program paths

### DIFF
--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -773,9 +773,9 @@ export async function getProgramDependencies(
     if (unfoundProgramNames.length) {
       console.log(
         chalk.yellowBright(
-          `Skipped these programs as program files were not found:
+          `The following files were listed under SAS Programs but could not be found:
 ${unfoundProgramNames.join(', ')}
-Please check your SAS program dependencies.\n`
+Please check they exist in the folder(s) listed in the programFolders array of the sasjsconfig.json file.\n`
         )
       )
     }

--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -745,6 +745,7 @@ export async function getProgramDependencies(
   const programs = getProgramList(fileContent)
   if (programs.length) {
     const foundPrograms = []
+    const foundProgramNames = []
     await asyncForEach(programFolders, async (programFolder) => {
       await asyncForEach(programs, async (program) => {
         const filePath = path.join(buildSourceFolder, programFolder)
@@ -761,16 +762,23 @@ export async function getProgramDependencies(
             program.fileRef
           )
           foundPrograms.push(programDependencyContent)
-        } else {
-          console.log(
-            chalk.yellowBright(
-              `Skipping ${program.fileName} as program file was not found. Please check your SAS program dependencies.\n`
-            )
-          )
+          foundProgramNames.push(program.fileName)
         }
       })
     })
 
+    const unfoundProgramNames = programs.filter(
+      (program) => !foundProgramNames.includes(program.fileName)
+    )
+    if (unfoundProgramNames.length) {
+      console.log(
+        chalk.yellowBright(
+          `Skipped these programs as program files were not found:
+${unfoundProgramNames.join(', ')}
+Please check your SAS program dependencies.\n`
+        )
+      )
+    }
     return foundPrograms.join('\n')
   }
 


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/237.

## Intent

Remove unnecessary false warnings when compiling SAS program dependencies.

## Implementation

* Build up a list of found filenames.
* Check against list of all filenames and log the unfound filenames in a warning.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
