### PR TITLE
fix(sasjs-build): recognise global targets, fix compile-build logic

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -91,7 +91,7 @@ export async function build(
     console.log(chalk.white('Skipping compiling of build folders...'))
   } else {
     console.log(chalk.redBright(result.message))
-    await compile()
+    await compile(targetName)
   }
 
   await createFinalSasFiles()

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -955,13 +955,16 @@ async function validCompiled(servicesBuildFolders, jobsBuildFolders) {
       message: `Build Folder doesn't exists: ${buildDestinationFolder}`
     }
 
-  const subFolders = await getSubFoldersInFolder(buildDestinationServ)
+  const serviceSubFolders = await getSubFoldersInFolder(buildDestinationServ)
 
   const servicesPresent = servicesBuildFolders.every((folder) =>
-    subFolders.includes(folder)
+    serviceSubFolders.includes(folder)
   )
+
+  const jobSubFolders = await getSubFoldersInFolder(buildDestinationJobs)
+
   const jobsPresent = jobsBuildFolders.every((folder) =>
-    subFolders.includes(folder)
+    jobSubFolders.includes(folder)
   )
 
   if (servicesPresent && jobsPresent) {
@@ -986,7 +989,7 @@ async function validCompiled(servicesBuildFolders, jobsBuildFolders) {
 
     if (returnObj.compiled) {
       await asyncForEach(jobsBuildFolders, async (buildFolder) => {
-        const folderPath = path.join(buildDestinationServ, buildFolder)
+        const folderPath = path.join(buildDestinationJobs, buildFolder)
         const subFolders = await getSubFoldersInFolder(folderPath)
         const filesNamesInPath = await getFilesInFolder(folderPath)
         if (subFolders.length == 0 && filesNamesInPath.length == 0) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -191,6 +191,9 @@ global.addToGlobalConfigs = async (buildTarget) => {
   let globalConfig = await getGlobalRcFile()
   if (globalConfig) {
     if (globalConfig.targets && globalConfig.targets.length) {
+      if (globalConfig.targets.some((t) => t.name === buildTarget.name)) {
+        throw new Error('Target already exists.')
+      }
       globalConfig.targets.push(buildTarget)
     } else {
       globalConfig.targets = [buildTarget]


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/241
Fixes https://github.com/sasjs/cli/issues/248

## Intent

Recognise global targets when they are named in `sasjs build -t <target-name>`.

## Implementation

* Pass `targetName` to `compile()` function.
* Check jobs against `buildDestinationFolderJobs` when determining if a project has already been compiled.

* Check for existing targets with the same name in the unit tests when adding new targets.
## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested. - no new functionality.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [x] JSDoc comments have been added or updated.
