### PR TITLE
fix: job log extension changed to .log

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -211,8 +211,8 @@ export async function printHelpText() {
           command example: sasjs job execute /Public/job -t targetName -o ./outputFolder/output.json
           command example: sasjs job execute /Public/job --target targetName --wait --output
           command example: sasjs job execute /Public/job -t targetName -w -o
-          command example: sasjs job execute /Public/job -t targetName --log ./logFolder/log.json
-          command example: sasjs job execute /Public/job -t targetName -l ./logFolder/log.json
+          command example: sasjs job execute /Public/job -t targetName --log ./logFolder/jobLog.log
+          command example: sasjs job execute /Public/job -t targetName -l ./logFolder/jobLog.log
           NOTE: Providing target name (--target targetName or -t targetName) is optional. Default target name will be used if target name was omitted.
           NOTE: Providing wait flag (--wait or -w) is optional. If present, CLI will wait for job completion.
           NOTE: Providing output flag (--output or -o) is optional. If present, CLI will immediately print out the response JSON. If value is provided, it will be treated as file path to save the response JSON.

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import ora from 'ora'
 import { displayResult } from '../../utils/displayResult'
 import { createFile, createFolder, folderExists } from '../../utils/file-utils'
+import { parseLogLines } from '../../utils/utils'
 import path from 'path'
 
 /**
@@ -129,7 +130,9 @@ export async function execute(
               await createFolder(folderPath)
             }
 
-            await createFile(logPath, JSON.stringify(logJson, null, 2))
+            let logLines = parseLogLines(logJson)
+
+            await createFile(logPath, logLines)
 
             displayResult(null, null, `Log saved to: ${logPath}`)
           }

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -107,17 +107,17 @@ export async function execute(
             if (typeof log === 'string') {
               logPath = path.join(
                 process.cwd(),
-                /\.json$/i.test(log)
+                /\.log$/i.test(log)
                   ? log
                   : path.join(
                       log,
-                      `${jobPath.split('/').slice(-1).pop()}-log.json`
+                      `${jobPath.split('/').slice(-1).pop()}.log`
                     )
               )
             } else {
               logPath = path.join(
                 process.cwd(),
-                `${jobPath.split('/').slice(-1).pop()}-log.json`
+                `${jobPath.split('/').slice(-1).pop()}.log`
               )
             }
 

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -14,7 +14,7 @@ import path from 'path'
  * @param {boolean} waitForJob - flag indicating if CLI should wait for job completion.
  * @param {boolean} output - flag indicating if CLI should print out job output. If string was provided, it will be treated as file path to store output.
  * @param {boolean | string} output - flag indicating if CLI should print out job output. If string was provided, it will be treated as file path to store output. If filepath wasn't provided, output.json file will be created in current folder.
- * @param {boolean | string} log - flag indicating if CLI should fetch and save log to the local folder. If filepath wasn't provided, {job}-log.json file will be created in current folder.
+ * @param {boolean | string} log - flag indicating if CLI should fetch and save log to the local folder. If filepath wasn't provided, {job}.log file will be created in current folder.
  */
 export async function execute(
   sasjs,

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -110,10 +110,7 @@ export async function execute(
                 process.cwd(),
                 /\.log$/i.test(log)
                   ? log
-                  : path.join(
-                      log,
-                      `${jobPath.split('/').slice(-1).pop()}.log`
-                    )
+                  : path.join(log, `${jobPath.split('/').slice(-1).pop()}.log`)
               )
             } else {
               logPath = path.join(

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -222,7 +222,7 @@ export async function getVariable(name, target) {
 
 /**
  * Extracts plain text job log from fetched json log
- * @param {object} logJson 
+ * @param {object} logJson
  */
 export function parseLogLines(logJson) {
   let logLines = ''

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -221,6 +221,20 @@ export async function getVariable(name, target) {
 }
 
 /**
+ * Extracts plain text job log from fetched json log
+ * @param {object} logJson 
+ */
+export function parseLogLines(logJson) {
+  let logLines = ''
+
+  for (let item of logJson.items) {
+    logLines += `${item.line}\n`
+  }
+
+  return logLines
+}
+
+/**
  * Returns a timestamp in YYYYMMDDSS format
  */
 export function generateTimestamp() {

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -104,7 +104,37 @@ describe('sasjs job', () => {
         const command = `job execute testJob -t ${targetName} -l testLog`
 
         const folderPath = path.join(process.cwd(), 'testLog')
-        const filePath = path.join(process.cwd(), 'testLog/testJob-log.json')
+        const filePath = path.join(process.cwd(), 'testLog/testJob.log')
+
+        await processJob(command)
+
+        await expect(folderExists(folderPath)).resolves.toEqual(true)
+        await expect(fileExists(filePath)).resolves.toEqual(true)
+      },
+      60 * 1000
+    )
+
+    it(
+      'should submit a job and create a file with provided job log filename',
+      async () => {
+        const command = `job execute testJob -t ${targetName} -l mycustom.log`
+
+        const filePath = path.join(process.cwd(), 'mycustom.log')
+
+        await processJob(command)
+
+        await expect(fileExists(filePath)).resolves.toEqual(true)
+      },
+      60 * 1000
+    )
+
+    it(
+      'should submit a job and create a file with provided job log filename and path',
+      async () => {
+        const command = `job execute testJob -t ${targetName} -l ./my/folder/mycustom.log`
+
+        const folderPath = path.join(process.cwd(), 'my/folder')
+        const filePath = path.join(process.cwd(), 'my/folder/mycustom.log')
 
         await processJob(command)
 

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,4 +1,4 @@
-import { generateTimestamp } from '../src/utils/utils'
+import { generateTimestamp, parseLogLines } from '../src/utils/utils'
 
 describe('generateTimestamp', () => {
   let realDate
@@ -22,6 +22,29 @@ describe('generateTimestamp', () => {
     const timestamp = generateTimestamp()
 
     expect(timestamp).toEqual(expectedTimestamp)
+  })
+
+  test('should generate plain text log from json', () => {
+    const expectedLog = `line1\nline2\nline3\nline4\n`
+
+    const json = {
+      items: [
+        {
+          line: 'line1'
+        },
+        {
+          line: 'line2'
+        },
+        {
+          line: 'line3'
+        },
+        {
+          line: 'line4'
+        }
+      ]
+    }
+
+    expect(parseLogLines(json)).toEqual(expectedLog)
   })
 
   afterAll(() => {


### PR DESCRIPTION
## Issue

Closes #193 

## Intent

Log output for job should be plain text, not json.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
