### PR TITLE
Issue172

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -841,7 +841,7 @@ export async function getDependencyPaths(fileContent, tgtMacros = []) {
     })
   }
 
-  const dependenciesHeader = fileContent.includes('<h4> Dependencies </h4>')
+  const dependenciesHeader = fileContent.includes('<h4> SAS Macros </h4>')
     ? '<h4> SAS Macros </h4>'
     : '<h4> Dependencies </h4>'
 

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -825,10 +825,14 @@ export async function getDependencyPaths(fileContent, tgtMacros = []) {
       sourcePaths.push(tgtMacroPath)
     })
   }
-  const dependencies = getList(
-    '<h4> Dependencies </h4>',
-    fileContent
-  ).filter((d) => d.endsWith('.sas'))
+
+  const dependenciesHeader = fileContent.includes('<h4> SAS Macros </h4>')
+    ? '<h4> SAS Macros </h4>'
+    : '<h4> Dependencies </h4>'
+
+  let dependencies = getList(dependenciesHeader, fileContent).filter((d) =>
+    d.endsWith('.sas')
+  )
 
   let dependencyPaths = []
   const foundDependencies = []

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -825,9 +825,24 @@ export async function getDependencyPaths(fileContent, tgtMacros = []) {
     })
   }
 
-  const dependenciesHeader = fileContent.includes('<h4> SAS Macros </h4>')
-    ? '<h4> SAS Macros </h4>'
-    : '<h4> Dependencies </h4>'
+  const dependenciesHeader = '<h4> SAS Macros </h4>'
+
+  if (fileContent.includes('<h4> Dependencies </h4>')) {
+    dependenciesHeader = '<h4> Dependencies </h4>'
+
+    const deprecationDate = new Date(2021, 10, 2)
+    const today = new Date()
+
+    if (today < deprecationDate) {
+      console.log(
+        chalk.yellowBright(
+          `WARNING: use <h4> SAS Macros </h4> syntax to specify dependencies. Specifying dependencies with a <h4> Dependencies </h4> syntax will not be supported starting from November 1, 2021.`
+        )
+      )
+    } else {
+      throw 'Using <h4> Dependencies </h4> syntax is deprecated. Please use <h4> SAS Macros </h4> instead.'
+    }
+  }
 
   let dependencies = getList(dependenciesHeader, fileContent).filter((d) =>
     d.endsWith('.sas')

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -527,6 +527,22 @@ export async function loadDependencies(
     chalk.greenBright('Loading dependencies for', chalk.cyanBright(filePath))
   )
   let fileContent = await readFile(filePath)
+
+  if (fileContent.includes('<h4> Dependencies </h4>')) {
+    const deprecationDate = new Date(2021, 10, 2)
+    const today = new Date()
+
+    if (today < deprecationDate) {
+      console.log(
+        chalk.yellowBright(
+          `WARNING: use <h4> SAS Macros </h4> syntax to specify dependencies. Specifying dependencies with a <h4> Dependencies </h4> syntax will not be supported starting from November 1, 2021.`
+        )
+      )
+    } else {
+      throw 'Using <h4> Dependencies </h4> syntax is deprecated. Please use <h4> SAS Macros </h4> instead.'
+    }
+  }
+
   let init
   let term
   let serviceVars = ''
@@ -825,24 +841,9 @@ export async function getDependencyPaths(fileContent, tgtMacros = []) {
     })
   }
 
-  let dependenciesHeader = '<h4> SAS Macros </h4>'
-
-  if (fileContent.includes('<h4> Dependencies </h4>')) {
-    dependenciesHeader = '<h4> Dependencies </h4>'
-
-    const deprecationDate = new Date(2021, 10, 2)
-    const today = new Date()
-
-    if (today < deprecationDate) {
-      console.log(
-        chalk.yellowBright(
-          `WARNING: use <h4> SAS Macros </h4> syntax to specify dependencies. Specifying dependencies with a <h4> Dependencies </h4> syntax will not be supported starting from November 1, 2021.`
-        )
-      )
-    } else {
-      throw 'Using <h4> Dependencies </h4> syntax is deprecated. Please use <h4> SAS Macros </h4> instead.'
-    }
-  }
+  const dependenciesHeader = fileContent.includes('<h4> Dependencies </h4>')
+    ? '<h4> SAS Macros </h4>'
+    : '<h4> Dependencies </h4>'
 
   let dependencies = getList(dependenciesHeader, fileContent).filter((d) =>
     d.endsWith('.sas')

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -825,7 +825,7 @@ export async function getDependencyPaths(fileContent, tgtMacros = []) {
     })
   }
 
-  const dependenciesHeader = '<h4> SAS Macros </h4>'
+  let dependenciesHeader = '<h4> SAS Macros </h4>'
 
   if (fileContent.includes('<h4> Dependencies </h4>')) {
     dependenciesHeader = '<h4> Dependencies </h4>'

--- a/src/commands/request.js
+++ b/src/commands/request.js
@@ -66,6 +66,8 @@ export async function runSasJob(commandLine) {
 
   if (!dataJson) dataJson = null
 
+  console.log(configJson)
+
   let result
   await sasjs
     .request(
@@ -111,7 +113,7 @@ export async function runSasJob(commandLine) {
       (err) => {
         result = err
         displayResult(
-          err,
+          JSON.stringify(err),
           'An error occurred while executing the request.',
           null
         )

--- a/test/commands/compile/loadDependencies.spec.js
+++ b/test/commands/compile/loadDependencies.spec.js
@@ -30,9 +30,38 @@ const fakeServiceTerm = `/**
 
 %put service is finishing.  Thanks, SASjs!;`
 
+const fakeServiceInit2 = `/**
+  @file serviceinit.sas
+  @brief this file is called with every service
+  @details  This file is included in *every* service, *after* the macros and *before* the service code.
+
+  <h4> SAS Macros </h4>
+  @li mf_abort.sas
+
+**/
+
+options
+  DATASTMTCHK=ALLKEYWORDS /* some sites have this enabled */
+  PS=MAX /* reduce log size slightly */
+;
+%put service is starting!!;`
+
+const fakeServiceTerm2 = `/**
+  @file serviceterm.sas
+  @brief this file is called at the end of every service
+  @details  This file is included at the *end* of every service.
+
+  <h4> SAS Macros </h4>
+  @li mf_abort.sas
+  @li mf_existds.sas
+
+**/
+
+%put service is finishing.  Thanks, SASjs!;`
+
 process.projectDir = path.join(process.cwd())
 describe('loadDependencies', () => {
-  test('it should load dependencies for a service', async (done) => {
+  test('it should load dependencies for a service with <h4> Dependencies </h4>', async (done) => {
     spyOn(compileModule, 'getServiceInit').and.returnValue(
       `\n* ServiceInit start;\n${fakeServiceInit}\n* ServiceInit end;`
     )
@@ -46,6 +75,7 @@ describe('loadDependencies', () => {
       [],
       'service'
     )
+    console.log(dependencies)
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -56,12 +86,62 @@ describe('loadDependencies', () => {
     done()
   })
 
-  test('it should load dependencies for a job', async (done) => {
+  test('it should load dependencies for a job <h4> Dependencies </h4>', async (done) => {
     spyOn(compileModule, 'getJobInit').and.returnValue(
       `\n* JobInit start;\n${fakeServiceInit}\n* JobInit end;`
     )
     spyOn(compileModule, 'getJobTerm').and.returnValue(
       `\n* JobTerm start;\n${fakeServiceTerm}\n* JobTerm end;`
+    )
+
+    const dependencies = await compileModule.loadDependencies(
+      path.join(__dirname, './service.sas'),
+      [],
+      [],
+      'job'
+    )
+
+    expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
+
+    done()
+  })
+
+  test('it should load dependencies for a service with <h4> SAS MAcros </h4>', async (done) => {
+    spyOn(compileModule, 'getServiceInit').and.returnValue(
+      `\n* ServiceInit start;\n${fakeServiceInit2}\n* ServiceInit end;`
+    )
+    spyOn(compileModule, 'getServiceTerm').and.returnValue(
+      `\n* ServiceTerm start;\n${fakeServiceTerm2}\n* ServiceTerm end;`
+    )
+
+    const dependencies = await compileModule.loadDependencies(
+      path.join(__dirname, './service.sas'),
+      [],
+      [],
+      'service'
+    )
+    console.log(dependencies)
+    expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
+
+    done()
+  })
+
+  test('it should load dependencies for a job <h4> SAS MAcros </h4>', async (done) => {
+    spyOn(compileModule, 'getJobInit').and.returnValue(
+      `\n* JobInit start;\n${fakeServiceInit2}\n* JobInit end;`
+    )
+    spyOn(compileModule, 'getJobTerm').and.returnValue(
+      `\n* JobTerm start;\n${fakeServiceTerm2}\n* JobTerm end;`
     )
 
     const dependencies = await compileModule.loadDependencies(

--- a/test/commands/compile/loadDependencies.spec.js
+++ b/test/commands/compile/loadDependencies.spec.js
@@ -75,7 +75,7 @@ describe('loadDependencies', () => {
       [],
       'service'
     )
-    console.log(dependencies)
+
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)


### PR DESCRIPTION
## Issue

Closes #172 

## Intent

Adding support for `SAS Macros` header. `Dependencies` can still be used but it is deprecated.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [x] JSDoc comments have been added or updated.
