### PR TITLE
fix(job flags): --log, --output and new --status

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,6 +1,7 @@
 name: 'Assign Reviewer'
 on:
   pull_request:
+    types: [opened]
 
 jobs:
   test:

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
     "trailingComma": "none",
     "tabWidth": 2,
     "semi": false,
-    "singleQuote": true
+    "singleQuote": true,
+    "endOfLine": "auto"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1491,9 +1491,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.18.2.tgz",
-      "integrity": "sha512-5bN9cVApKrm6KfMYNNso6zDQYOAuhy2GObVNXYovffW6nDEvhvfjs8eQKLATS/OaWk8bV3a4rmyLD+6wVzeF7g==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.18.3.tgz",
+      "integrity": "sha512-wzDFJRyt2dXFeQP+JzqRGunYUbujrAbU/Jc4IWg5URsCkGAzwsNl/4G0xJVbqOTy1MvoZ431rfCnvhkUlg7D3Q==",
       "requires": {
         "es6-promise": "^4.2.8",
         "form-data": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "^1.18.2",
+    "@sasjs/adapter": "^1.18.3",
     "@sasjs/core": "^1.8.0",
     "base64-img": "^1.0.4",
     "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "jest --silent --runInBand",
     "semantic-release": "semantic-release",
-    "lint:fix": "npx prettier --write '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'",
-    "lint": "npx prettier --check '{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}'"
+    "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\"",
+    "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\""
   },
   "release": {
     "branches": [

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,10 +30,13 @@ function parseCommand(rawArgs) {
   const prefix = process.env.EXEPATH
     ? process.env.EXEPATH.replace(/\\/g, '/')
     : ''
+  const homedir = require('os').homedir()
 
   const args =
     isWin && isMSys
       ? rawArgs.slice(2).map((arg) => arg.replace(prefix, ''))
+      : isWin
+      ? rawArgs.slice(2).map((arg) => arg.replace('~', homedir.replace(/\\/g, '/')))
       : rawArgs.slice(2)
 
   if (args.length) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -36,7 +36,9 @@ function parseCommand(rawArgs) {
     isWin && isMSys
       ? rawArgs.slice(2).map((arg) => arg.replace(prefix, ''))
       : isWin
-      ? rawArgs.slice(2).map((arg) => arg.replace('~', homedir.replace(/\\/g, '/')))
+      ? rawArgs
+          .slice(2)
+          .map((arg) => arg.replace('~', homedir.replace(/\\/g, '/')))
       : rawArgs.slice(2)
 
   if (args.length) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,14 +32,14 @@ function parseCommand(rawArgs) {
     : ''
   const homedir = require('os').homedir()
 
-  const args =
+  const argsTemp =
     isWin && isMSys
       ? rawArgs.slice(2).map((arg) => arg.replace(prefix, ''))
-      : isWin
-      ? rawArgs
-          .slice(2)
-          .map((arg) => arg.replace('~', homedir.replace(/\\/g, '/')))
       : rawArgs.slice(2)
+
+  const args = argsTemp.map((arg) =>
+    arg.replace('~', homedir.replace(/\\/g, '/'))
+  )
 
   if (args.length) {
     const name = getUnaliasedCommand(args[0])

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -27,7 +27,7 @@ export async function execute(
   logFile,
   statusFile
 ) {
-  let result = {}
+  let result
 
   const startTime = new Date().getTime()
 
@@ -52,7 +52,12 @@ export async function execute(
     )
     .catch((err) => {
       spinner.stop()
-      if (statusFile !== undefined) displayStatus(null, statusFile, err)
+      err =
+        typeof err === 'object' && Object.keys(err).length
+          ? JSON.stringify(err)
+          : err
+      if (statusFile !== undefined)
+        displayStatus({ state: 'Error' }, statusFile, err)
       throw new Error(err)
     })
 
@@ -76,6 +81,7 @@ export async function execute(
         ? `Job located at '${jobPath}' has been executed.\nJob details`
         : `Job session`) + ` can be found at ${target.serverUrl + sessionLink}`
     )
+
     if (output !== undefined || logFile !== undefined) {
       try {
         const outputJson = JSON.stringify(submittedJob, null, 2)
@@ -165,7 +171,7 @@ async function displayStatus(submittedJob, statusFile, error = '') {
     submittedJob && submittedJob.state ? submittedJob.state : 'Not Available'
 
   const status =
-    adapterStatus === 'Not Available'
+    adapterStatus === 'Not Available' || adapterStatus === 'Error'
       ? `Job Status: ${adapterStatus}\nDetails: ${error}\n`
       : `Job Status: ${adapterStatus}`
 

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -32,7 +32,7 @@ export async function execute(
   const startTime = new Date().getTime()
 
   if (statusFile !== undefined)
-    displayStatus({ state: 'Initiating' }, statusFile)
+    await displayStatus({ state: 'Initiating' }, statusFile)
 
   const spinner = ora(
     `Job located at ${chalk.greenBright(
@@ -69,7 +69,7 @@ export async function execute(
   if (result)
     displayResult(result, 'An error has occurred when executing a job.', null)
   if (statusFile !== undefined)
-    displayStatus(submittedJob, statusFile, result, true)
+    await displayStatus(submittedJob, statusFile, result, true)
 
   if (submittedJob && submittedJob.links) {
     if (!result) result = true

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -167,9 +167,8 @@ export async function execute(
 }
 
 async function displayStatus(submittedJob, statusOfJob, result = {}) {
-  const adapterStatus = submittedJob?.state
-    ? submittedJob.state
-    : 'Not Available'
+  const adapterStatus =
+    submittedJob && submittedJob.state ? submittedJob.state : 'Not Available'
   const status = `Job Status: ${adapterStatus}`
 
   if (adapterStatus === 'completed') displayResult(null, null, status)

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -51,7 +51,6 @@ export async function execute(
       waitForJob || logFile !== undefined ? true : false
     )
     .catch((err) => {
-      err = typeof err === 'object' ? JSON.stringify(err) : err
       spinner.stop()
       if (statusFile !== undefined) displayStatus(null, statusFile, err)
       throw new Error(err)

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -90,8 +90,9 @@ export async function execute(
         const outputJson = JSON.stringify(submittedJob, null, 2)
 
         if (typeof output === 'string') {
+          const currentDirPath = path.isAbsolute(output) ? '' : process.cwd()
           const outputPath = path.join(
-            process.cwd(),
+            currentDirPath,
             /\.[a-z]{3,4}$/i.test(output)
               ? output
               : path.join(output, 'output.json')
@@ -123,7 +124,10 @@ export async function execute(
             let logPath
 
             if (typeof logFile === 'string') {
-              logPath = path.join(process.cwd(), logFile)
+              const currentDirPath = path.isAbsolute(logFile)
+                ? ''
+                : process.cwd()
+              logPath = path.join(currentDirPath, logFile)
             } else {
               logPath = path.join(
                 process.cwd(),
@@ -202,7 +206,8 @@ async function displayStatus(submittedJob, statusFile, error = '') {
   else displayResult({}, status, null)
 
   if (typeof statusFile === 'string') {
-    const statusPath = path.join(process.cwd(), statusFile)
+    const currentDirPath = path.isAbsolute(statusFile) ? '' : process.cwd()
+    const statusPath = path.join(currentDirPath, statusFile)
 
     let folderPath = statusPath.split(path.sep)
     folderPath.pop()

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -68,7 +68,8 @@ export async function execute(
 
   if (result)
     displayResult(result, 'An error has occurred when executing a job.', null)
-  if (statusFile !== undefined) displayStatus(submittedJob, statusFile, result)
+  if (statusFile !== undefined)
+    displayStatus(submittedJob, statusFile, result, true)
 
   if (submittedJob && submittedJob.links) {
     if (!result) result = true
@@ -193,16 +194,22 @@ export function getContextName(target) {
   return defaultContextName
 }
 
-async function displayStatus(submittedJob, statusFile, error = '') {
+async function displayStatus(
+  submittedJob,
+  statusFile,
+  error = '',
+  displayStatusFilePath = false
+) {
   const adapterStatus =
     submittedJob && submittedJob.state ? submittedJob.state : 'Not Available'
 
   const status =
-    adapterStatus === 'Not Available' || adapterStatus === 'Error'
+    adapterStatus === 'Not Available'
       ? `Job Status: ${adapterStatus}\nDetails: ${error}\n`
       : `Job Status: ${adapterStatus}`
 
-  if (adapterStatus === 'completed') displayResult(null, null, status)
+  if (adapterStatus === 'Initiating' || adapterStatus === 'completed')
+    displayResult(null, null, status)
   else displayResult({}, status, null)
 
   if (typeof statusFile === 'string') {
@@ -216,5 +223,7 @@ async function displayStatus(submittedJob, statusFile, error = '') {
     if (!(await folderExists(folderPath))) await createFolder(folderPath)
 
     await createFile(statusPath, status)
+    if (displayStatusFilePath)
+      displayResult(null, null, `Status saved to: ${statusPath}`)
   }
 }

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -48,7 +48,7 @@ export async function execute(
       null,
       { contextName: target.tgtDeployVars.contextName },
       accessToken,
-      waitForJob || logFile ? true : false
+      waitForJob || logFile !== undefined ? true : false
     )
     .catch((err) => {
       err = typeof err === 'object' ? JSON.stringify(err) : err
@@ -77,7 +77,7 @@ export async function execute(
         ? `Job located at '${jobPath}' has been executed.\nJob details`
         : `Job session`) + ` can be found at ${target.serverUrl + sessionLink}`
     )
-    if (output !== undefined || logFile) {
+    if (output !== undefined || logFile !== undefined) {
       try {
         const outputJson = JSON.stringify(submittedJob, null, 2)
 
@@ -102,7 +102,7 @@ export async function execute(
           console.log(outputJson)
         }
 
-        if (logFile) {
+        if (logFile !== undefined) {
           const logObj = submittedJob.links.find(
             (link) => link.rel === 'log' && link.method === 'GET'
           )

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -39,14 +39,16 @@ export async function execute(
 
   spinner.start()
 
-  const waitEffective = waitForJob || log ? true : false
+  if (statusOfJob !== undefined)
+    displayStatus({ state: 'Initiating' }, statusOfJob)
+
   const submittedJob = await sasjs
     .startComputeJob(
       jobPath,
       null,
       { contextName: target.tgtDeployVars.contextName },
       accessToken,
-      waitEffective
+      waitForJob || log ? true : false
     )
     .catch((err) => {
       result = err
@@ -59,7 +61,7 @@ export async function execute(
   const endTime = new Date().getTime()
 
   if (statusOfJob !== undefined)
-    displayStatus(submittedJob, statusOfJob, waitEffective, result)
+    displayStatus(submittedJob, statusOfJob, result)
 
   if (submittedJob && submittedJob.links) {
     result = true
@@ -164,7 +166,7 @@ export async function execute(
   return result
 }
 
-async function displayStatus(submittedJob, statusOfJob, wait, result = {}) {
+async function displayStatus(submittedJob, statusOfJob, result = {}) {
   const adapterStatus = submittedJob?.state
     ? submittedJob.state
     : 'Not Available'

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -31,6 +31,9 @@ export async function execute(
 
   const startTime = new Date().getTime()
 
+  if (statusOfJob !== undefined)
+    displayStatus({ state: 'Initiating' }, statusOfJob)
+
   const spinner = ora(
     `Job located at ${chalk.greenBright(
       jobPath
@@ -38,9 +41,6 @@ export async function execute(
   )
 
   spinner.start()
-
-  if (statusOfJob !== undefined)
-    displayStatus({ state: 'Initiating' }, statusOfJob)
 
   const submittedJob = await sasjs
     .startComputeJob(
@@ -52,7 +52,7 @@ export async function execute(
     )
     .catch((err) => {
       result = err
-
+      // need to fix this error return, it's not printing `err` on console
       displayResult(err, 'An error has occurred when executing a job.', null)
     })
 
@@ -169,7 +169,10 @@ export async function execute(
 async function displayStatus(submittedJob, statusOfJob, result = {}) {
   const adapterStatus =
     submittedJob && submittedJob.state ? submittedJob.state : 'Not Available'
-  const status = `Job Status: ${adapterStatus}`
+  const status =
+    adapterStatus === 'Not Available'
+      ? `Job Status: ${adapterStatus}\n\nDetails: ${result}`
+      : `Job Status: ${adapterStatus}`
 
   if (adapterStatus === 'completed') displayResult(null, null, status)
   else displayResult(result, status, null)

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -51,24 +51,25 @@ export async function execute(
       waitForJob || logFile !== undefined ? true : false
     )
     .catch((err) => {
-      spinner.stop()
-      err =
+      result =
         typeof err === 'object' && Object.keys(err).length
-          ? JSON.stringify(err)
-          : err
-      if (statusFile !== undefined)
-        displayStatus({ state: 'Error' }, statusFile, err)
-      throw new Error(err)
+          ? JSON.stringify({ state: err.result.state })
+          : `${err}`
+      if (err.result) {
+        return err.result
+      }
     })
 
   spinner.stop()
 
   const endTime = new Date().getTime()
 
-  if (statusFile !== undefined) displayStatus(submittedJob, statusFile)
+  if (result)
+    displayResult(result, 'An error has occurred when executing a job.', null)
+  if (statusFile !== undefined) displayStatus(submittedJob, statusFile, result)
 
   if (submittedJob && submittedJob.links) {
-    result = true
+    if (!result) result = true
 
     const sessionLink = submittedJob.links.find(
       (l) => l.method === 'GET' && l.rel === 'self'

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -14,7 +14,7 @@ import path from 'path'
  * @param {boolean} waitForJob - flag indicating if CLI should wait for job completion.
  * @param {boolean} output - flag indicating if CLI should print out job output. If string was provided, it will be treated as file path to store output.
  * @param {boolean | string} output - flag indicating if CLI should print out job output. If string was provided, it will be treated as file path to store output. If filepath wasn't provided, output.json file will be created in current folder.
- * @param {boolean | string} log - flag indicating if CLI should fetch and save log to the local folder. If filepath wasn't provided, {job}.log file will be created in current folder.
+ * @param {boolean | string} logFile - flag indicating if CLI should fetch and save log to provided file path. If filepath wasn't provided, {job}.log file will be created in current folder.
  * @param {boolean | string} statusFile - flag indicating if CLI should fetch and save status to the local file. If filepath wasn't provided, it will only print on console.
  */
 export async function execute(
@@ -24,7 +24,7 @@ export async function execute(
   target,
   waitForJob,
   output,
-  log,
+  logFile,
   statusFile
 ) {
   let result = {}
@@ -48,7 +48,7 @@ export async function execute(
       null,
       { contextName: target.tgtDeployVars.contextName },
       accessToken,
-      waitForJob || log ? true : false
+      waitForJob || logFile ? true : false
     )
     .catch((err) => {
       err = typeof err === 'object' ? JSON.stringify(err) : err
@@ -77,7 +77,7 @@ export async function execute(
         ? `Job located at '${jobPath}' has been executed.\nJob details`
         : `Job session`) + ` can be found at ${target.serverUrl + sessionLink}`
     )
-    if (output !== undefined || log) {
+    if (output !== undefined || logFile) {
       try {
         const outputJson = JSON.stringify(submittedJob, null, 2)
 
@@ -102,7 +102,7 @@ export async function execute(
           console.log(outputJson)
         }
 
-        if (log) {
+        if (logFile) {
           const logObj = submittedJob.links.find(
             (link) => link.rel === 'log' && link.method === 'GET'
           )
@@ -114,13 +114,8 @@ export async function execute(
 
             let logPath
 
-            if (typeof log === 'string') {
-              logPath = path.join(
-                process.cwd(),
-                /\.log$/i.test(log)
-                  ? log
-                  : path.join(log, `${jobPath.split('/').slice(-1).pop()}.log`)
-              )
+            if (typeof logFile === 'string') {
+              logPath = path.join(process.cwd(), logFile)
             } else {
               logPath = path.join(
                 process.cwd(),

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -53,10 +53,10 @@ export async function execute(
     .catch((err) => {
       result =
         typeof err === 'object' && Object.keys(err).length
-          ? JSON.stringify({ state: err.result.state })
+          ? JSON.stringify({ state: err.job.state })
           : `${err}`
-      if (err.result) {
-        return err.result
+      if (err.job) {
+        return err.job
       }
     })
 

--- a/src/commands/job/execute.js
+++ b/src/commands/job/execute.js
@@ -42,11 +42,13 @@ export async function execute(
 
   spinner.start()
 
+  const contextName = getContextName(target)
+
   const submittedJob = await sasjs
     .startComputeJob(
       jobPath,
       null,
-      { contextName: target.tgtDeployVars.contextName },
+      { contextName },
       accessToken,
       waitForJob || logFile !== undefined ? true : false
     )
@@ -165,6 +167,26 @@ export async function execute(
   )
 
   return result
+}
+
+export function getContextName(target) {
+  const defaultContextName = 'SAS Job Execution compute context'
+  if (target && target.contextName) {
+    return target.contextName
+  }
+
+  console.log(
+    chalk.yellowBright(
+      `contextName was not provided. Using ${defaultContextName} by default.`
+    )
+  )
+  console.log(
+    chalk.whiteBright(
+      `You can specify the context name in your target configuration.`
+    )
+  )
+
+  return defaultContextName
 }
 
 async function displayStatus(submittedJob, statusFile, error = '') {

--- a/src/commands/job/index.js
+++ b/src/commands/job/index.js
@@ -31,9 +31,9 @@ export async function processJob(commandLine) {
 
   const targetName = command.getFlagValue('target')
   const waitForJob = command.getFlagValue('wait')
-  const statusOfJob = command.getFlagValue('status')
   const output = command.getFlagValue('output')
   const log = command.getFlagValue('logFile')
+  const status = command.getFlagValue('status')
 
   const target = await getBuildTarget(targetName)
 
@@ -59,9 +59,9 @@ export async function processJob(commandLine) {
         jobPath,
         target,
         waitForJob,
-        statusOfJob,
         output,
-        log
+        log,
+        status
       )
 
       break

--- a/src/commands/job/index.js
+++ b/src/commands/job/index.js
@@ -31,8 +31,9 @@ export async function processJob(commandLine) {
 
   const targetName = command.getFlagValue('target')
   const waitForJob = command.getFlagValue('wait')
+  const statusOfJob = command.getFlagValue('status')
   const output = command.getFlagValue('output')
-  const log = command.getFlagValue('log')
+  const log = command.getFlagValue('logFile')
 
   const target = await getBuildTarget(targetName)
 
@@ -58,6 +59,7 @@ export async function processJob(commandLine) {
         jobPath,
         target,
         waitForJob,
+        statusOfJob,
         output,
         log
       )

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -49,10 +49,10 @@ const initialFlags = arrToObj([
     'datafile',
     'configfile',
     'wait',
-    'status',
     'output',
     'force',
-    'logFile'
+    'logFile',
+    'status'
   ])
 ])
 
@@ -103,9 +103,9 @@ const commandFlags = [
     flags: [
       initialFlags.target,
       initialFlags.wait,
-      initialFlags.status,
       initialFlags.output,
-      initialFlags.logFile
+      initialFlags.logFile,
+      initialFlags.status
     ]
   }
 ]
@@ -117,8 +117,8 @@ const flagsWithValue = [
   initialFlags.datafile,
   initialFlags.configfile,
   initialFlags.output,
-  initialFlags.status,
-  initialFlags.logFile
+  initialFlags.logFile,
+  initialFlags.status
 ]
 
 export class Command {

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -117,6 +117,7 @@ const flagsWithValue = [
   initialFlags.datafile,
   initialFlags.configfile,
   initialFlags.output,
+  initialFlags.status,
   initialFlags.logFile
 ]
 

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -49,9 +49,10 @@ const initialFlags = arrToObj([
     'datafile',
     'configfile',
     'wait',
+    'status',
     'output',
     'force',
-    'log'
+    'logFile'
   ])
 ])
 
@@ -102,8 +103,9 @@ const commandFlags = [
     flags: [
       initialFlags.target,
       initialFlags.wait,
+      initialFlags.status,
       initialFlags.output,
-      initialFlags.log
+      initialFlags.logFile
     ]
   }
 ]
@@ -115,7 +117,7 @@ const flagsWithValue = [
   initialFlags.datafile,
   initialFlags.configfile,
   initialFlags.output,
-  initialFlags.log
+  initialFlags.logFile
 ]
 
 export class Command {

--- a/test/commands/cbd/testJob/failingJob.sas
+++ b/test/commands/cbd/testJob/failingJob.sas
@@ -1,0 +1,6 @@
+data; 
+  %abort; 
+  do x=1 to 1e6;
+    output;
+  end;
+run;

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -117,7 +117,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with job output, log and auto-wait',
       async () => {
-        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -o testOutput -l testLog`
+        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -o testOutput -l testLog.txt`
 
         const folderPathOutput = path.join(process.cwd(), 'testOutput')
         const filePathOutput = path.join(
@@ -125,15 +125,13 @@ describe('sasjs job', () => {
           'testOutput/output.json'
         )
 
-        const folderPathLog = path.join(process.cwd(), 'testLog')
-        const filePathLog = path.join(process.cwd(), 'testLog/testJob.log')
+        const filePathLog = path.join(process.cwd(), 'testLog.txt')
 
         await processJob(command)
 
         await expect(folderExists(folderPathOutput)).resolves.toEqual(true)
         await expect(fileExists(filePathOutput)).resolves.toEqual(true)
 
-        await expect(folderExists(folderPathLog)).resolves.toEqual(true)
         await expect(fileExists(filePathLog)).resolves.toEqual(true)
       },
       60 * 1000
@@ -142,14 +140,12 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with job log',
       async () => {
-        const command = `job execute testJob -t ${targetName} -l testLog`
+        const command = `job execute testJob -t ${targetName} -l`
 
-        const folderPath = path.join(process.cwd(), 'testLog')
-        const filePath = path.join(process.cwd(), 'testLog/testJob.log')
+        const filePath = path.join(process.cwd(), 'testJob.log')
 
         await processJob(command)
 
-        await expect(folderExists(folderPath)).resolves.toEqual(true)
         await expect(fileExists(filePath)).resolves.toEqual(true)
       },
       60 * 1000

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -202,6 +202,22 @@ describe('sasjs job', () => {
       },
       60 * 1000
     )
+
+    it(
+      "should submit a job that doesn't exist and create a status file",
+      async () => {
+        const command = `job execute job-no-present -t ${targetName} --wait --status ./my/folder/status.txt`
+
+        const folderPath = path.join(process.cwd(), 'my/folder')
+        const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
+
+        await expect(processJob(command)).rejects.toThrow('{}')
+
+        await expect(folderExists(folderPath)).resolves.toEqual(true)
+        await expect(fileExists(filePathStatus)).resolves.toEqual(true)
+      },
+      60 * 1000
+    )
   })
 
   afterAll(async () => {

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -207,7 +207,9 @@ describe('sasjs job', () => {
         const folderPath = path.join(process.cwd(), 'my/folder')
         const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
 
-        await expect(processJob(command)).rejects.toThrow('Error: Job was not found.')
+        await expect(processJob(command)).rejects.toThrow(
+          'Error: Job was not found.'
+        )
 
         await expect(folderExists(folderPath)).resolves.toEqual(true)
         await expect(fileExists(filePathStatus)).resolves.toEqual(true)

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -184,6 +184,24 @@ describe('sasjs job', () => {
       },
       60 * 1000
     )
+
+    it(
+      'should submit a job and create a file with provided job log filename and status file',
+      async () => {
+        const command = `job execute testJob -t ${targetName} -l ./my/folder/mycustom.log --status ./my/folder/status.txt`
+
+        const folderPath = path.join(process.cwd(), 'my/folder')
+        const filePath = path.join(process.cwd(), 'my/folder/mycustom.log')
+        const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
+
+        await processJob(command)
+
+        await expect(folderExists(folderPath)).resolves.toEqual(true)
+        await expect(fileExists(filePath)).resolves.toEqual(true)
+        await expect(fileExists(filePathStatus)).resolves.toEqual(true)
+      },
+      60 * 1000
+    )
   })
 
   afterAll(async () => {

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -53,7 +53,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job for execution',
       async () => {
-        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName}`
+        const command = `job execute /Public/app/cli-tests/testJob/job -t ${targetName}`
 
         await expect(processJob(command)).resolves.toEqual(true)
       },
@@ -63,7 +63,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and wait for completion',
       async () => {
-        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -w`
+        const command = `job execute /Public/app/cli-tests/testJob/job -t ${targetName} -w`
 
         await expect(processJob(command)).resolves.toEqual(true)
       },
@@ -73,7 +73,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and wait for its output',
       async () => {
-        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -w -o`
+        const command = `job execute /Public/app/cli-tests/testJob/job -t ${targetName} -w -o`
 
         const jobOutput = await processJob(command)
 
@@ -85,7 +85,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with job output',
       async () => {
-        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -o testOutput`
+        const command = `job execute /Public/app/cli-tests/testJob/job -t ${targetName} -o testOutput`
 
         const folderPath = path.join(process.cwd(), 'testOutput')
         const filePath = path.join(process.cwd(), 'testOutput/output.json')
@@ -101,7 +101,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with job output and wait',
       async () => {
-        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -o testOutput -w`
+        const command = `job execute /Public/app/cli-tests/testJob/job -t ${targetName} -o testOutput -w`
 
         const folderPath = path.join(process.cwd(), 'testOutput')
         const filePath = path.join(process.cwd(), 'testOutput/output.json')
@@ -117,7 +117,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with job output, log and auto-wait',
       async () => {
-        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -o testOutput -l testLog.txt`
+        const command = `job execute /Public/app/cli-tests/testJob/job -t ${targetName} -o testOutput -l testLog.txt`
 
         const folderPathOutput = path.join(process.cwd(), 'testOutput')
         const filePathOutput = path.join(
@@ -140,10 +140,9 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with job log',
       async () => {
-        const command = `job execute testJob -t ${targetName} -l`
+        const command = `job execute testJob/job -t ${targetName} -l`
 
-        const filePath = path.join(process.cwd(), 'testJob.log')
-
+        const filePath = path.join(process.cwd(), 'job.log')
         await processJob(command)
 
         await expect(fileExists(filePath)).resolves.toEqual(true)
@@ -154,7 +153,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with provided job log filename',
       async () => {
-        const command = `job execute testJob -t ${targetName} -l mycustom.log`
+        const command = `job execute testJob/job -t ${targetName} -l mycustom.log`
 
         const filePath = path.join(process.cwd(), 'mycustom.log')
 
@@ -168,7 +167,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with provided job log filename and path',
       async () => {
-        const command = `job execute testJob -t ${targetName} -l ./my/folder/mycustom.log`
+        const command = `job execute testJob/job -t ${targetName} -l ./my/folder/mycustom.log`
 
         const folderPath = path.join(process.cwd(), 'my/folder')
         const filePath = path.join(process.cwd(), 'my/folder/mycustom.log')
@@ -184,7 +183,7 @@ describe('sasjs job', () => {
     it(
       'should submit a job and create a file with provided job log filename and status file',
       async () => {
-        const command = `job execute testJob -t ${targetName} -l ./my/folder/mycustom.log --status ./my/folder/status.txt`
+        const command = `job execute testJob/job -t ${targetName} -l ./my/folder/mycustom.log --status ./my/folder/status.txt`
 
         const folderPath = path.join(process.cwd(), 'my/folder')
         const filePath = path.join(process.cwd(), 'my/folder/mycustom.log')
@@ -202,7 +201,7 @@ describe('sasjs job', () => {
     it(
       "should submit a job that doesn't exist and create a status file",
       async () => {
-        const command = `job execute job-no-present -t ${targetName} --wait --status ./my/folder/status.txt`
+        const command = `job execute job-not-present -t ${targetName} --wait --status ./my/folder/status.txt`
 
         const folderPath = path.join(process.cwd(), 'my/folder')
         const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
@@ -210,7 +209,20 @@ describe('sasjs job', () => {
         await expect(processJob(command)).rejects.toThrow(
           'Error: Job was not found.'
         )
+        await expect(folderExists(folderPath)).resolves.toEqual(true)
+        await expect(fileExists(filePathStatus)).resolves.toEqual(true)
+      },
+      60 * 1000
+    )
 
+    it(
+      'should submit a job that fails and create a status file',
+      async () => {
+        const command = `job execute testJob/failingJob -t ${targetName} --wait --status ./my/folder/status.txt`
+
+        const folderPath = path.join(process.cwd(), 'my/folder')
+        const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
+        await expect(processJob(command)).rejects.toThrow('{}')
         await expect(folderExists(folderPath)).resolves.toEqual(true)
         await expect(fileExists(filePathStatus)).resolves.toEqual(true)
       },

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -2,6 +2,7 @@ import dotenv from 'dotenv'
 import path from 'path'
 import { processJob } from '../../src/commands'
 import { processContext } from '../../src/commands'
+import { getContextName } from '../../src/commands/job/execute'
 import { folderExists, fileExists } from '../../src/utils/file-utils'
 
 describe('sasjs job', () => {
@@ -234,5 +235,27 @@ describe('sasjs job', () => {
 
   afterAll(async () => {
     await removeFromGlobalConfigs(targetName)
+  })
+})
+
+describe('getContextName', () => {
+  beforeAll(() => {
+    jest.mock('chalk')
+  })
+
+  afterAll(() => {
+    jest.unmock('chalk')
+  })
+
+  it.only('should return the context name if specified in the target', () => {
+    const target = { contextName: 'Test Context' }
+
+    expect(getContextName(target)).toEqual('Test Context')
+  })
+
+  it.only('should return the default context if context name is not specified', () => {
+    const target = { contextName: undefined }
+
+    expect(getContextName(target)).toEqual('SAS Job Execution compute context')
   })
 })

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -206,7 +206,7 @@ describe('sasjs job', () => {
         const folderPath = path.join(process.cwd(), 'my/folder')
         const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
 
-        await expect(processJob(command)).rejects.toThrow(
+        await expect(processJob(command)).resolves.toEqual(
           'Error: Job was not found.'
         )
         await expect(folderExists(folderPath)).resolves.toEqual(true)
@@ -222,7 +222,9 @@ describe('sasjs job', () => {
 
         const folderPath = path.join(process.cwd(), 'my/folder')
         const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
-        await expect(processJob(command)).rejects.toThrow('{}')
+
+        await expect(processJob(command)).resolves.toEqual('{"state":"error"}')
+
         await expect(folderExists(folderPath)).resolves.toEqual(true)
         await expect(fileExists(filePathStatus)).resolves.toEqual(true)
       },

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -207,7 +207,7 @@ describe('sasjs job', () => {
         const folderPath = path.join(process.cwd(), 'my/folder')
         const filePathStatus = path.join(process.cwd(), 'my/folder/status.txt')
 
-        await expect(processJob(command)).rejects.toThrow('{}')
+        await expect(processJob(command)).rejects.toThrow('Error: Job was not found.')
 
         await expect(folderExists(folderPath)).resolves.toEqual(true)
         await expect(fileExists(filePathStatus)).resolves.toEqual(true)

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -99,6 +99,47 @@ describe('sasjs job', () => {
     )
 
     it(
+      'should submit a job and create a file with job output and wait',
+      async () => {
+        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -o testOutput -w`
+
+        const folderPath = path.join(process.cwd(), 'testOutput')
+        const filePath = path.join(process.cwd(), 'testOutput/output.json')
+
+        await processJob(command)
+
+        await expect(folderExists(folderPath)).resolves.toEqual(true)
+        await expect(fileExists(filePath)).resolves.toEqual(true)
+      },
+      60 * 1000
+    )
+
+    it(
+      'should submit a job and create a file with job output, log and auto-wait',
+      async () => {
+        const command = `job execute /Public/app/cli-tests/testJob -t ${targetName} -o testOutput -l testLog`
+
+        const folderPathOutput = path.join(process.cwd(), 'testOutput')
+        const filePathOutput = path.join(
+          process.cwd(),
+          'testOutput/output.json'
+        )
+
+        const folderPathLog = path.join(process.cwd(), 'testLog')
+        const filePathLog = path.join(process.cwd(), 'testLog/testJob.log')
+
+        await processJob(command)
+
+        await expect(folderExists(folderPathOutput)).resolves.toEqual(true)
+        await expect(fileExists(filePathOutput)).resolves.toEqual(true)
+
+        await expect(folderExists(folderPathLog)).resolves.toEqual(true)
+        await expect(fileExists(filePathLog)).resolves.toEqual(true)
+      },
+      60 * 1000
+    )
+
+    it(
       'should submit a job and create a file with job log',
       async () => {
         const command = `job execute testJob -t ${targetName} -l testLog`

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -5,7 +5,9 @@ describe('generateTimestamp', () => {
   beforeAll(() => {
     const currentDate = new Date('2020-10-02T10:10:10.10Z')
     realDate = Date
-    global.Date = class extends Date {
+    global.Date = class extends (
+      Date
+    ) {
       constructor(date) {
         if (date) {
           return super(date)

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -5,9 +5,7 @@ describe('generateTimestamp', () => {
   beforeAll(() => {
     const currentDate = new Date('2020-10-02T10:10:10.10Z')
     realDate = Date
-    global.Date = class extends (
-      Date
-    ) {
+    global.Date = class extends Date {
       constructor(date) {
         if (date) {
           return super(date)

--- a/test/utils/command.spec.js
+++ b/test/utils/command.spec.js
@@ -486,7 +486,7 @@ describe('parseCommandLine', () => {
 
     test('short syntax', () => {
       const commandLine =
-        'job execute /Public/job -t targetName -w -o ./output.json -l ./log.json -s ./status.txt'
+        'job execute /Public/job -t targetName -w -o ./output.json -l ./log.txt -s ./status.txt'
 
       const command = new Command(commandLine)
 
@@ -501,7 +501,7 @@ describe('parseCommandLine', () => {
         'targetName',
         null,
         './output.json',
-        './log.json',
+        './log.txt',
         './status.txt'
       ]
 

--- a/test/utils/command.spec.js
+++ b/test/utils/command.spec.js
@@ -486,27 +486,7 @@ describe('parseCommandLine', () => {
 
     test('short syntax', () => {
       const commandLine =
-        'job execute /Public/job -t targetName -w -o ./output.json -l ./log.json'
-
-      const command = new Command(commandLine)
-
-      const expectedFlagNames = ['target', 'wait', 'output', 'logFile']
-      const expectedFlagValues = [
-        'targetName',
-        null,
-        './output.json',
-        './log.json'
-      ]
-
-      expect(command.name).toEqual(expectedName)
-      expect(command.values).toEqual(expectedValues)
-      expect(command.flags.map((flag) => flag.name)).toEqual(expectedFlagNames)
-      expect(command.flags.map((f) => f.value)).toEqual(expectedFlagValues)
-    })
-
-    test('short syntax with status', () => {
-      const commandLine =
-        'job execute /Public/job -t targetName -w -o ./output.json -l ./log.json --status'
+        'job execute /Public/job -t targetName -w -o ./output.json -l ./log.json -s ./status.txt'
 
       const command = new Command(commandLine)
 
@@ -522,7 +502,7 @@ describe('parseCommandLine', () => {
         null,
         './output.json',
         './log.json',
-        null
+        './status.txt'
       ]
 
       expect(command.name).toEqual(expectedName)

--- a/test/utils/command.spec.js
+++ b/test/utils/command.spec.js
@@ -490,12 +490,39 @@ describe('parseCommandLine', () => {
 
       const command = new Command(commandLine)
 
-      const expectedFlagNames = ['target', 'wait', 'output', 'log']
+      const expectedFlagNames = ['target', 'wait', 'output', 'logFile']
       const expectedFlagValues = [
         'targetName',
         null,
         './output.json',
         './log.json'
+      ]
+
+      expect(command.name).toEqual(expectedName)
+      expect(command.values).toEqual(expectedValues)
+      expect(command.flags.map((flag) => flag.name)).toEqual(expectedFlagNames)
+      expect(command.flags.map((f) => f.value)).toEqual(expectedFlagValues)
+    })
+
+    test('short syntax with status', () => {
+      const commandLine =
+        'job execute /Public/job -t targetName -w -o ./output.json -l ./log.json --status'
+
+      const command = new Command(commandLine)
+
+      const expectedFlagNames = [
+        'target',
+        'wait',
+        'output',
+        'logFile',
+        'status'
+      ]
+      const expectedFlagValues = [
+        'targetName',
+        null,
+        './output.json',
+        './log.json',
+        null
       ]
 
       expect(command.name).toEqual(expectedName)


### PR DESCRIPTION
## Issue

Closes #250 

## Intent

To update `--log` flag, `--output` flag's behavior and add new `--status` flag
++ handle absolute paths for `output`, `logfile` and `status`
++ handle `~` for win paths
++ use default context if not specified

## Implementation

Updated command utility:
- for `--log` flag updated to `--logFile` and alias are working i.e. `--log` and `-l`
- to have another flag `--status`
Update job execute code to have `status: success` in output file in case of `wait` and print on screen.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
tested with unreleased adapter 
![image](https://user-images.githubusercontent.com/8914650/100032991-0bafd700-2e1b-11eb-944b-376cb412b4c3.png)
- [ ] All CI checks are green.
- [x] JSDoc comments have been added or updated.

## Steps to test
- checkout branch `issue250`
- `npm install`
- `npm link`
- verify with `npm -v` it should give you the path of local repository of sasjs-cli
_You are using a linked version of SASjs CLI running from sources at 1.0.0   {PATH}_
