### PR TITLE
fix(sasjs-deploy): get access token from environment

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -1,7 +1,10 @@
 import path from 'path'
 import SASjs from '@sasjs/adapter/node'
 import chalk from 'chalk'
-import { findTargetInConfiguration } from '../utils/config-utils'
+import {
+  getAccessToken,
+  findTargetInConfiguration
+} from '../utils/config-utils'
 import { asyncForEach, executeShellScript, getVariable } from '../utils/utils'
 import {
   isSasFile,
@@ -10,11 +13,7 @@ import {
   folderExists,
   createFile
 } from '../utils/file-utils'
-import {
-  getAccessToken,
-  isAccessTokenExpiring,
-  refreshTokens
-} from '../utils/auth-utils'
+import { isAccessTokenExpiring, refreshTokens } from '../utils/auth-utils'
 
 let targetToBuild = null
 let executionSession
@@ -26,7 +25,8 @@ export async function deploy(targetName = null, preTargetToBuild = null) {
     targetToBuild = target
   }
 
-  if (targetToBuild.serverType === 'SASVIYA' && !targetToBuild.authInfo) {
+  const accessToken = await getAccessToken(targetToBuild)
+  if (targetToBuild.serverType === 'SASVIYA' && !accessToken) {
     console.log(
       chalk.redBright.bold(
         `Deployment failed. Request is not authenticated.\nRun 'sasjs add' command and provide 'client' and 'secret'.`

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -29,7 +29,7 @@ export async function deploy(targetName = null, preTargetToBuild = null) {
   if (targetToBuild.serverType === 'SASVIYA' && !accessToken) {
     console.log(
       chalk.redBright.bold(
-        `Deployment failed. Request is not authenticated.\nRun 'sasjs add' command and provide 'client' and 'secret'.`
+        `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
       )
     )
 

--- a/src/commands/servicepack/deploy.js
+++ b/src/commands/servicepack/deploy.js
@@ -96,7 +96,7 @@ async function deployToSasViyaWithServicePack(
   if (!access_token) {
     console.log(
       chalk.redBright.bold(
-        `Deployment failed. Request is not authenticated.\nRun 'sasjs add' command and provide 'client' and 'secret'.`
+        `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
       )
     )
   }

--- a/src/main.js
+++ b/src/main.js
@@ -116,13 +116,13 @@ export async function compileServices(targetName) {
 
         console.log(
           chalk.redBright(
-            'An error has occurred when building services.',
+            'An error has occurred when compiling services.',
             `${message}${details ? '\n' + details : ''}`
           )
         )
       } else {
         console.log(
-          chalk.redBright('An error has occurred when building services.', err)
+          chalk.redBright('An error has occurred when compiling services.', err)
         )
       }
     })
@@ -153,7 +153,7 @@ export async function deployServices(commandLine) {
 
         console.log(
           chalk.redBright(
-            'An error has occurred when building services.',
+            'An error has occurred when deploying services.',
             `${message}
             ${details ? '\n' + details : ''}`
           )


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/261

## Intent

Fix `sasjs deploy` erroring out when the credentials are available in a local `.env` file.

## Implementation

* Get access token from the `.env` file.
* Only error out when the access token is unavailable.
* Improved error messages for compile and deploy functions.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested. - no new functionality
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
