### PR TITLE
chore(*): add typescript to project

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Build Project
+        run: npm run build
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Check code style
         run: npm run lint
 
+      - name: Build Project
+        run: npm run build
+
       - name: Run unit tests
         run: npm test -- --runInBand
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1816,9 +1816,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz",
-      "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==",
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -11290,6 +11290,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "description": "Command line interface for SASjs",
   "main": "index.js",
   "scripts": {
+    "build": "tsc -p .",
     "test": "jest --silent --runInBand",
-    "semantic-release": "semantic-release",
+    "semantic-release": "semantic-release -d",
+    "prepublishOnly": "cp -r ./build/* . && rm -rf ./build",
+    "postpublish": "git clean -fd",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\"",
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\""
   },
@@ -14,7 +17,7 @@
     ]
   },
   "bin": {
-    "sasjs": "bin/sasjs"
+    "sasjs": "./build/index.js"
   },
   "repository": {
     "type": "git",
@@ -57,11 +60,13 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.11.5",
+    "@types/node": "^14.14.10",
     "babel-jest": "^26.5.0",
     "jest-cli": "^26.5.0",
     "mock-stdin": "^1.0.0",
     "puppeteer": "^5.3.1",
-    "semantic-release": "^17.1.1"
+    "semantic-release": "^17.1.1",
+    "typescript": "^4.1.2"
   },
   "version": "1.0.0",
   "directories": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require = require("esm")(module /*, options*/);
+require("../src/cli").cli(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-require = require("esm")(module /*, options*/);
-require("../src/cli").cli(process.argv);
+require = require('esm')(module /*, options*/)
+require('../src/cli').cli(process.argv)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,33 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "allowJs": true,
+        "module": "commonjs",
+        "lib": [
+            "ES2018",
+            "DOM",
+            "ES2019.String"
+        ],
+        "declaration": true,
+        "outDir": "build",
+        "rootDir": "src",
+        "strict": true,
+        "types": [
+            "node"
+        ],
+        "esModuleInterop": true,
+        "resolveJsonModule": true
+    },
+    "exclude": [
+        "test/**/*",
+        "node_modules",
+        "**/*.spec.ts",
+        "PULL_REQUEST_TEMPLATE.md",
+        "test.sh",
+        "jest.config.js",
+        "babel.config.js",
+        ".env*",
+        ".prettierrc"
+    ],
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/274

## Intent

Add TypeScript to CLI project.

## Implementation

* Added `TypeScript` and `@types/node` dependencies.
* Added `tsconfig.json`.
* Tweaked build and release process. 

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.

## Note
Since adding TypeScript, there's now an extra build step to run the CLI locally from sources.

So after this PR is merged, you should pull from `main` and:
* `npm unlink`
* `npm ci`
* `npm run build`
* `npm link`

After this, you'll need to build it each time you make a code change.