### PR TITLE
fix(*): upgrade adapter to work with TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 sas
 sasbuild
 .env
+.DS_Store

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src"],
+  "ext": "js, ts",
+  "exec": "ts-node src/index.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1491,9 +1491,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.18.3.tgz",
-      "integrity": "sha512-wzDFJRyt2dXFeQP+JzqRGunYUbujrAbU/Jc4IWg5URsCkGAzwsNl/4G0xJVbqOTy1MvoZ431rfCnvhkUlg7D3Q==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.18.6.tgz",
+      "integrity": "sha512-9IEIyVVYsLuFQUJgoopCyxO5oeOWNmxwzg14eroa4nSh2yNZgKG0/uSvdbIcsKSv7hY1eB1g4arMhi+/C/Q4sw==",
       "requires": {
         "es6-promise": "^4.2.8",
         "form-data": "^3.0.0",
@@ -10563,7 +10563,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1491,9 +1491,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.18.6.tgz",
-      "integrity": "sha512-9IEIyVVYsLuFQUJgoopCyxO5oeOWNmxwzg14eroa4nSh2yNZgKG0/uSvdbIcsKSv7hY1eB1g4arMhi+/C/Q4sw==",
+      "version": "1.18.7",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-1.18.7.tgz",
+      "integrity": "sha512-OWpk9efBALZ90RJG6rNcHNx7aDkFUo6y+OSaQ+RqGw7aQdj22RhOoJsF90/VWQgJrH91HDH1a6lYSpzPtXvW3Q==",
       "requires": {
         "es6-promise": "^4.2.8",
         "form-data": "^3.0.0",
@@ -1501,9 +1501,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-j1Jq6P5H3M4bHBdVLTVXO442P5Imd0WWG1oPTG++ckNvAme9MIsABCBDGwrLlqvLUIdYoUQEk11FPlACRoiIUA=="
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-riOmAmgaX3VitjANn+0jB3h1bvHUUiYYqtWSjj4dKX96CDGqb+jzlFd0mMQ7dBAfE2sO6i68Mwd4EULPU4tIyQ=="
     },
     "@semantic-release/commit-analyzer": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "^1.18.3",
+    "@sasjs/adapter": "^1.18.6",
     "@sasjs/core": "^1.8.0",
     "base64-img": "^1.0.4",
     "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build/**/*"
   ],
   "scripts": {
-    "start": "nodemon",
+    "start": "nodemon --watch 'src/**/*' --exec 'npm run build && npm link'",
     "build": "rimraf build && tsc -p . && cp ./src/*.json build",
     "test": "jest --silent --runInBand",
     "semantic-release": "semantic-release -d",
@@ -19,7 +19,7 @@
     ]
   },
   "bin": {
-    "sasjs": "./build/index.js"
+    "sasjs": "build/index.js"
   },
   "repository": {
     "type": "git",
@@ -40,8 +40,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "^1.18.6",
-    "@sasjs/core": "^1.8.0",
+    "@sasjs/adapter": "^1.18.7",
+    "@sasjs/core": "^1.11.2",
     "base64-img": "^1.0.4",
     "btoa": "^1.2.1",
     "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build/**/*"
   ],
   "scripts": {
-    "start": "nodemon --watch 'src/**/*' --exec 'npm run build && npm link'",
+    "start": "nodemon",
     "build": "rimraf build && tsc -p . && cp ./src/*.json build",
     "test": "jest --silent --runInBand",
     "semantic-release": "semantic-release -d",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
 #!/usr/bin/env node
+
+require = require('esm')(module /*, options*/)
+require('./cli').cli(process.argv)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,1 @@
 #!/usr/bin/env node
-
-require = require('esm')(module /*, options*/)
-require('./cli').cli(process.argv)

--- a/test/commands/job.spec.js
+++ b/test/commands/job.spec.js
@@ -266,13 +266,13 @@ describe('getContextName', () => {
     jest.unmock('chalk')
   })
 
-  it.only('should return the context name if specified in the target', () => {
+  it('should return the context name if specified in the target', () => {
     const target = { contextName: 'Test Context' }
 
     expect(getContextName(target)).toEqual('Test Context')
   })
 
-  it.only('should return the default context if context name is not specified', () => {
+  it('should return the default context if context name is not specified', () => {
     const target = { contextName: undefined }
 
     expect(getContextName(target)).toEqual('SAS Job Execution compute context')


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/274

## Intent

Bump adapter to be able to use type declaration files.
Watch for `.ts` file changes and rebuild.

## Implementation
* Added `nodemon` configuration.
* Upped adapter version

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
![image](https://user-images.githubusercontent.com/25773492/100342754-80d40580-2fef-11eb-9c42-c9e6f2d77cbb.png)
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
