### PR TITLE
fix(build): valid compile + tests

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -61,7 +61,7 @@ export async function addTarget() {
 }
 
 async function getLocalConfig() {
-  const buildSourceFolder = require('../constants').buildSourceFolder
+  const buildSourceFolder = require('../constants').get().buildSourceFolder
   const config = await getConfiguration(
     path.join(buildSourceFolder, 'sasjsconfig.json')
   )
@@ -70,7 +70,7 @@ async function getLocalConfig() {
 }
 
 async function saveToLocalConfig(buildTarget) {
-  const buildSourceFolder = require('../constants').buildSourceFolder
+  const buildSourceFolder = require('../constants').get().buildSourceFolder
   let config = await getLocalConfig()
   if (config) {
     if (config.targets && config.targets.length) {

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -41,7 +41,7 @@ export async function build(
   compileBuildOnly = false,
   compileBuildDeployOnly = false
 ) {
-  const CONSTANTS = require('../constants')
+  const CONSTANTS = require('../constants').get()
 
   buildSourceFolder = CONSTANTS.buildSourceFolder
   buildDestinationFolder = CONSTANTS.buildDestinationFolder
@@ -114,6 +114,9 @@ async function compile(targetName) {
 
   const jobFoldersToCompile = jobPathsToCompile.map((s) => s.split('/').pop())
   const jobFoldersToCompileUniq = [...new Set(jobFoldersToCompile)]
+
+  if (serviceFoldersToCompileUniq.length == 0 && jobFoldersToCompileUniq == 0)
+    throw 'Either Services or Jobs should be present'
 
   const tgtMacros = targetToBuild ? targetToBuild.tgtMacros : []
   const programFolders = await getProgramFolders(targetName)
@@ -974,54 +977,64 @@ async function validCompiled(servicesBuildFolders, jobsBuildFolders) {
       message: `Build Folder doesn't exists: ${buildDestinationFolder}`
     }
 
-  const serviceSubFolders = await getSubFoldersInFolder(buildDestinationServ)
+  if (servicesBuildFolders.length) {
+    const serviceSubFolders = await getSubFoldersInFolder(buildDestinationServ)
+    const servicesPresent = servicesBuildFolders.every((folder) =>
+      serviceSubFolders.includes(folder)
+    )
+    if (!servicesPresent)
+      return { compiled: false, message: 'All services are not present.' }
+  }
 
-  const servicesPresent = servicesBuildFolders.every((folder) =>
-    serviceSubFolders.includes(folder)
-  )
+  if (jobsBuildFolders.length) {
+    const jobSubFolders = await getSubFoldersInFolder(buildDestinationJobs)
 
-  const jobSubFolders = await getSubFoldersInFolder(buildDestinationJobs)
+    const jobsPresent = jobsBuildFolders.every((folder) =>
+      jobSubFolders.includes(folder)
+    )
+    if (!jobsPresent)
+      return { compiled: false, message: 'All jobs are not present.' }
+  }
 
-  const jobsPresent = jobsBuildFolders.every((folder) =>
-    jobSubFolders.includes(folder)
-  )
-
-  if (servicesPresent && jobsPresent) {
-    let returnObj = {
-      compiled: true,
-      message: `All services and jobs are already present.`
+  if (servicesBuildFolders.length == 0 && jobsBuildFolders.length == 0) {
+    return {
+      compiled: false,
+      message: 'Either Services or Jobs should be present'
     }
+  }
 
-    await asyncForEach(servicesBuildFolders, async (buildFolder) => {
-      if (returnObj.compiled) {
-        const folderPath = path.join(buildDestinationServ, buildFolder)
-        const subFolders = await getSubFoldersInFolder(folderPath)
-        const filesNamesInPath = await getFilesInFolder(folderPath)
-        if (subFolders.length == 0 && filesNamesInPath.length == 0) {
-          returnObj = {
-            compiled: false,
-            message: `Service folder ${buildFolder} is empty.`
-          }
+  let returnObj = {
+    compiled: true,
+    message: `All services and jobs are already present.`
+  }
+
+  await asyncForEach(servicesBuildFolders, async (buildFolder) => {
+    if (returnObj.compiled) {
+      const folderPath = path.join(buildDestinationServ, buildFolder)
+      const subFolders = await getSubFoldersInFolder(folderPath)
+      const filesNamesInPath = await getFilesInFolder(folderPath)
+      if (subFolders.length == 0 && filesNamesInPath.length == 0) {
+        returnObj = {
+          compiled: false,
+          message: `Service folder ${buildFolder} is empty.`
+        }
+      }
+    }
+  })
+
+  if (returnObj.compiled) {
+    await asyncForEach(jobsBuildFolders, async (buildFolder) => {
+      const folderPath = path.join(buildDestinationJobs, buildFolder)
+      const subFolders = await getSubFoldersInFolder(folderPath)
+      const filesNamesInPath = await getFilesInFolder(folderPath)
+      if (subFolders.length == 0 && filesNamesInPath.length == 0) {
+        returnObj = {
+          compiled: false,
+          message: `Jobs folder ${buildFolder} is empty.`
         }
       }
     })
-
-    if (returnObj.compiled) {
-      await asyncForEach(jobsBuildFolders, async (buildFolder) => {
-        const folderPath = path.join(buildDestinationJobs, buildFolder)
-        const subFolders = await getSubFoldersInFolder(folderPath)
-        const filesNamesInPath = await getFilesInFolder(folderPath)
-        if (subFolders.length == 0 && filesNamesInPath.length == 0) {
-          returnObj = {
-            compiled: false,
-            message: `Jobs folder ${buildFolder} is empty.`
-          }
-        }
-      })
-    }
-
-    return returnObj
   }
 
-  return { compiled: false, message: 'All services and jobs are not present.' }
+  return returnObj
 }

--- a/src/commands/db.js
+++ b/src/commands/db.js
@@ -18,7 +18,7 @@ let buildSourceDBFolder = ''
 let buildDestinationDBFolder = ''
 
 export async function buildDB() {
-  const CONSTANTS = require('../constants')
+  const CONSTANTS = require('../constants').get()
   buildDestinationFolder = CONSTANTS.buildDestinationFolder
   buildSourceDBFolder = CONSTANTS.buildSourceDBFolder
   buildDestinationDBFolder = CONSTANTS.buildDestinationDBFolder

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -156,7 +156,7 @@ async function deployToSasViyaWithServicePack(buildTarget) {
     serverType: buildTarget.serverType
   })
 
-  const CONSTANTS = require('../constants')
+  const CONSTANTS = require('../constants').get()
   const buildDestinationFolder = CONSTANTS.buildDestinationFolder
   const finalFilePathJSON = path.join(
     buildDestinationFolder,

--- a/src/commands/servicepack/deploy.js
+++ b/src/commands/servicepack/deploy.js
@@ -67,7 +67,7 @@ async function deployToSasViyaWithServicePack(
     serverType: buildTarget.serverType
   })
 
-  const CONSTANTS = require('../../constants')
+  const CONSTANTS = require('../../constants').get()
   const buildDestinationFolder = CONSTANTS.buildDestinationFolder
 
   const finalFilePathJSON = path.join(

--- a/src/commands/web/index.js
+++ b/src/commands/web/index.js
@@ -33,7 +33,7 @@ export async function createWebAppServices(
   let targetName = command.getFlagValue('target')
   targetName = targetName ? targetName : null
 
-  const CONSTANTS = require('../../constants')
+  const CONSTANTS = require('../../constants').get()
   buildDestinationFolder = CONSTANTS.buildDestinationFolder
 
   console.log(chalk.greenBright('Building web app services...'))

--- a/src/commands/web/index.js
+++ b/src/commands/web/index.js
@@ -28,10 +28,19 @@ export async function createWebAppServices(
   commandLine = null,
   preTargetToBuild = null
 ) {
-  const command = new Command(commandLine)
+  let targetToBuild = null
 
-  let targetName = command.getFlagValue('target')
-  targetName = targetName ? targetName : null
+  if (commandLine === null && typeof preTargetToBuild === 'object') {
+    targetToBuild = preTargetToBuild
+  } else {
+    const command = new Command(commandLine)
+
+    let targetName = command.getFlagValue('target')
+    targetName = targetName ? targetName : null
+
+    const { target } = await findTargetInConfiguration(targetName)
+    targetToBuild = target
+  }
 
   const CONSTANTS = require('../../constants').get()
   buildDestinationFolder = CONSTANTS.buildDestinationFolder
@@ -39,14 +48,6 @@ export async function createWebAppServices(
   console.log(chalk.greenBright('Building web app services...'))
 
   await createBuildDestinationFolder()
-
-  let targetToBuild = null
-
-  if (preTargetToBuild) targetToBuild = preTargetToBuild
-  else {
-    const { target } = await findTargetInConfiguration(targetName)
-    targetToBuild = target
-  }
 
   if (targetToBuild) {
     console.log(

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,26 +1,33 @@
 import path from 'path'
 
 // process.projectDir sets in cli.js
-const buildSourceFolder = path.join(process.projectDir, 'sasjs')
-const buildSourceDBFolder = path.join(process.projectDir, 'sasjs', 'db')
-const buildDestinationFolder = path.join(process.projectDir, 'sasjsbuild')
-const buildDestinationServ = path.join(
-  process.projectDir,
-  'sasjsbuild',
-  'services'
-)
-const buildDestinationJobs = path.join(process.projectDir, 'sasjsbuild', 'jobs')
-const buildDestinationDBFolder = path.join(
-  process.projectDir,
-  'sasjsbuild',
-  'db'
-)
-
 module.exports = {
-  buildSourceFolder,
-  buildSourceDBFolder,
-  buildDestinationFolder,
-  buildDestinationServ,
-  buildDestinationJobs,
-  buildDestinationDBFolder
+  get: function () {
+    const buildSourceFolder = path.join(process.projectDir, 'sasjs')
+    const buildSourceDBFolder = path.join(process.projectDir, 'sasjs', 'db')
+    const buildDestinationFolder = path.join(process.projectDir, 'sasjsbuild')
+    const buildDestinationServ = path.join(
+      process.projectDir,
+      'sasjsbuild',
+      'services'
+    )
+    const buildDestinationJobs = path.join(
+      process.projectDir,
+      'sasjsbuild',
+      'jobs'
+    )
+    const buildDestinationDBFolder = path.join(
+      process.projectDir,
+      'sasjsbuild',
+      'db'
+    )
+    return {
+      buildSourceFolder,
+      buildSourceDBFolder,
+      buildDestinationFolder,
+      buildDestinationServ,
+      buildDestinationJobs,
+      buildDestinationDBFolder
+    }
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -67,8 +67,10 @@ export async function buildServices(commandLine) {
     targetName = command.getTargetWithoutFlag()
   }
 
+  let result
   await build(targetName)
-    .then(() =>
+    .then(() => {
+      result = true
       console.log(
         chalk.greenBright.bold.italic(
           `Services have been successfully built!\nThe build output is located in the ${chalk.cyanBright(
@@ -76,8 +78,9 @@ export async function buildServices(commandLine) {
           )} directory.`
         )
       )
-    )
+    })
     .catch((err) => {
+      result = err
       if (err.hasOwnProperty('body')) {
         const body = JSON.parse(err.body)
         const message = body.message || ''
@@ -95,6 +98,7 @@ export async function buildServices(commandLine) {
         )
       }
     })
+  return result
 }
 
 export async function compileServices(targetName) {

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -223,7 +223,7 @@ export async function getBuildTargets(buildSourceFolder) {
  * @param {string} targetName - name of the configuration.
  */
 export async function getBuildTarget(targetName) {
-  const { buildSourceFolder } = require('../constants')
+  const { buildSourceFolder } = require('../constants').get()
   let targets = await getBuildTargets(buildSourceFolder)
 
   if (targets.length === 0) {
@@ -321,7 +321,7 @@ export async function getTargetSpecificFile(typeOfFile, targetToBuild = {}) {
   const isJob = typeOfFile.includes('job')
   const tgtPrefix = 'tgt'
   const cmnPrefix = 'cmn'
-  const { buildSourceFolder } = require('../constants')
+  const { buildSourceFolder } = require('../constants').get()
   let toBuildPath = ''
 
   if (targetToBuild[`${isJob ? '' : tgtPrefix}${typeOfFile}`] == undefined) {
@@ -357,7 +357,7 @@ export async function getProjectRoot() {
   let root = '',
     rootFound = false,
     i = 1
-  let currentLocation = process.cwd()
+  let currentLocation = process.projectDir
   const maxLevels = 4
   while (!rootFound && i <= maxLevels) {
     const isRoot = await folderExists(path.join(currentLocation, 'sasjs'))

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -57,6 +57,7 @@ function createApp(folderPath, repoUrl, installDependencies = true) {
 }
 
 export async function setupNpmProject(folderPath) {
+  folderPath = path.join(process.projectDir, folderPath)
   return new Promise(async (resolve, _) => {
     const isExistingProject = await inExistingProject(folderPath)
     if (!isExistingProject) {

--- a/test/commands/add.spec.js
+++ b/test/commands/add.spec.js
@@ -50,7 +50,7 @@ describe('sasjs add', () => {
 
         await expect(add('add')).resolves.toEqual(true)
 
-        const buildSourceFolder = require('../../src/constants')
+        const buildSourceFolder = require('../../src/constants').get()
           .buildSourceFolder
         const config = await getConfiguration(
           path.join(buildSourceFolder, 'sasjsconfig.json')

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -1,0 +1,63 @@
+import dotenv from 'dotenv'
+import path from 'path'
+import rimraf from 'rimraf'
+import {
+  createFileStructure,
+  buildServices,
+  compileServices
+} from '../../src/main'
+import { createFolder } from '../../src/utils/file-utils'
+import { generateTimestamp } from '../../src/utils/utils'
+
+describe('sasjs build', () => {
+  beforeAll(() => {
+    dotenv.config()
+  })
+
+  describe('test-app-timestamp', () => {
+    it(
+      `should build with minimal template`,
+      async () => {
+        const timestamp = generateTimestamp()
+        const parentFolderNameTimeStamped = `test-app-${timestamp}-minimal`
+
+        process.projectDir = path.join(
+          process.cwd(),
+          parentFolderNameTimeStamped
+        )
+
+        await createFolder(process.projectDir)
+
+        await createFileStructure(`create --template minimal`)
+
+        await expect(buildServices(`build`)).resolves.toEqual(true)
+      },
+      2 * 60 * 1000
+    )
+
+    it(
+      `should compile and build(skipping compile)`,
+      async () => {
+        const timestamp = generateTimestamp()
+        const parentFolderNameTimeStamped = `test-app-${timestamp}`
+
+        process.projectDir = path.join(
+          process.cwd(),
+          parentFolderNameTimeStamped
+        )
+
+        await createFolder(process.projectDir)
+
+        await createFileStructure(`create`)
+
+        await compileServices(`compile`)
+        await expect(buildServices(`build`)).resolves.toEqual(true)
+      },
+      2 * 60 * 1000
+    )
+  })
+
+  afterAll(async () => {
+    rimraf.sync('./test-app-*')
+  }, 60 * 1000)
+})

--- a/test/config-utils.spec.js
+++ b/test/config-utils.spec.js
@@ -8,6 +8,11 @@ jest.mock('@sasjs/adapter/node')
 
 describe('Config Utils', () => {
   let authUtils
+
+  beforeAll(() => {
+    process.projectDir = process.cwd()
+  })
+
   beforeEach(() => {
     process.env.ACCESS_TOKEN = null
 


### PR DESCRIPTION
## Issue

Closes #291 

## Intent

`build` looks for valid compile present in order to skip `compile` step
valid compile has checks for services folder + jobs folder

## Implementation

updated valid compile code
added extra check for compile to have either jobs or services folders in source
added tests for `build` and `cb`(skipping build)
updated constants file to have updated projectDir for `build` to work in their folders
updated `setupNpmProject` same as `setupGitIgnore` relative path covered in tests
updated `getRootFolder` folder, if already in root, as we run tests in our sasjs/cli/<test-folder-name>
updated `web` as well we are also using during `build` if `streamWeb` is true ( is case of [fileUploader](https://github.com/sasjs/fileuploader/))

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
