### PR TITLE
fix(deploy): no need of access_token in all cases

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -41,25 +41,21 @@ export async function deploy(targetName = null, preTargetToBuild = null) {
   const deployScripts = getDeployScripts()
 
   if (deployScripts.length === 0 && !targetToBuild.deployServicePack) {
-    console.log(
-      chalk.redBright.bold(
-        `Deployment failed. Enable 'deployServicePack' option or add deployment script to 'tgtDeployScripts'.`
-      )
+    throw new Error(
+      `Deployment failed. Enable 'deployServicePack' option or add deployment script to 'tgtDeployScripts'.`
     )
-
-    return
   }
 
   const pathExistsInCurrentFolder = await folderExists(
-    path.join(process.cwd(), 'sasjsbuild')
+    path.join(process.projectDir, 'sasjsbuild')
   )
   const pathExistsInParentFolder = await folderExists(
-    path.join(process.cwd(), '..', 'sasjsbuild')
+    path.join(process.projectDir, '..', 'sasjsbuild')
   )
   const logFilePath = pathExistsInCurrentFolder
-    ? path.join(process.cwd(), 'sasjsbuild')
+    ? path.join(process.projectDir, 'sasjsbuild')
     : pathExistsInParentFolder
-    ? path.join(process.cwd(), '..', 'sasjsbuild')
+    ? path.join(process.projectDir, '..', 'sasjsbuild')
     : null
   await asyncForEach(deployScripts, async (deployScript) => {
     if (isSasFile(deployScript)) {
@@ -72,7 +68,7 @@ export async function deploy(targetName = null, preTargetToBuild = null) {
       )
       // get content of file
       const deployScriptFile = await readFile(
-        path.join(process.cwd(), deployScript)
+        path.join(process.projectDir, deployScript)
       )
       // split into lines
       const linesToExecute = deployScriptFile.replace(/\r\n/g, '\n').split('\n')
@@ -102,7 +98,7 @@ export async function deploy(targetName = null, preTargetToBuild = null) {
       await executeShellScript(
         deployScript,
         path.join(
-          process.cwd(),
+          process.projectDir,
           'sasjsbuild',
           `${path.basename(deployScript).replace('.sh', '')}.log`
         )

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -131,7 +131,13 @@ async function getSASjsAndAccessToken(buildTarget) {
     serverType: buildTarget.serverType
   })
 
-  const accessToken = await getAccessToken(buildTarget)
+  try {
+    const accessToken = await getAccessToken(buildTarget)
+  } catch (e) {
+    throw new Error(
+      `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
+    )
+  }
   return {
     sasjs,
     accessToken
@@ -154,7 +160,13 @@ async function deployToSasViyaWithServicePack(buildTarget) {
   const jsonContent = await readFile(finalFilePathJSON)
   const jsonObject = JSON.parse(jsonContent)
 
-  const accessToken = await getAccessToken(buildTarget)
+  try {
+    const accessToken = await getAccessToken(buildTarget)
+  } catch (e) {
+    throw new Error(
+      `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
+    )
+  }
 
   return await sasjs.deployServicePack(
     jsonObject,

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -131,8 +131,9 @@ async function getSASjsAndAccessToken(buildTarget) {
     serverType: buildTarget.serverType
   })
 
+  let accessToken = null
   try {
-    const accessToken = await getAccessToken(buildTarget)
+    accessToken = await getAccessToken(buildTarget)
   } catch (e) {
     throw new Error(
       `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
@@ -160,8 +161,9 @@ async function deployToSasViyaWithServicePack(buildTarget) {
   const jsonContent = await readFile(finalFilePathJSON)
   const jsonObject = JSON.parse(jsonContent)
 
+  let accessToken = null
   try {
-    const accessToken = await getAccessToken(buildTarget)
+    accessToken = await getAccessToken(buildTarget)
   } catch (e) {
     throw new Error(
       `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -25,17 +25,6 @@ export async function deploy(targetName = null, preTargetToBuild = null) {
     targetToBuild = target
   }
 
-  const accessToken = await getAccessToken(targetToBuild)
-  if (targetToBuild.serverType === 'SASVIYA' && !accessToken) {
-    console.log(
-      chalk.redBright.bold(
-        `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
-      )
-    )
-
-    return
-  }
-
   if (
     targetToBuild.serverType === 'SASVIYA' &&
     targetToBuild.deployServicePack

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -153,10 +153,16 @@ export function getUniqServicesObj(services) {
 
 export async function executeShellScript(filePath, logFilePath) {
   return new Promise(async (resolve, reject) => {
-    const result = shelljs.exec(`bash ${filePath}`, {
-      silent: true,
-      async: false
-    })
+    // fix for cli test executions
+    // using cli, process.cwd() and process.projectDir should be same
+    const currentCWD = process.cwd()
+    const result = shelljs.exec(
+      `cd ${process.projectDir} && bash ${filePath} && cd ${currentCWD}`,
+      {
+        silent: true,
+        async: false
+      }
+    )
     if (result.code) {
       console.error(chalk.redBright('Error:\n'), chalk.red(result.stderr))
       reject(result.code)

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -14,48 +14,40 @@ describe('sasjs build', () => {
     dotenv.config()
   })
 
-  describe('test-app-timestamp', () => {
-    it(
-      `should build with minimal template`,
-      async () => {
-        const timestamp = generateTimestamp()
-        const parentFolderNameTimeStamped = `test-app-${timestamp}-minimal`
+  it(
+    `should build with minimal template`,
+    async () => {
+      const timestamp = generateTimestamp()
+      const parentFolderNameTimeStamped = `test-app-${timestamp}-minimal`
 
-        process.projectDir = path.join(
-          process.cwd(),
-          parentFolderNameTimeStamped
-        )
+      process.projectDir = path.join(process.cwd(), parentFolderNameTimeStamped)
 
-        await createFolder(process.projectDir)
+      await createFolder(process.projectDir)
 
-        await createFileStructure(`create --template minimal`)
+      await createFileStructure(`create --template minimal`)
 
-        await expect(buildServices(`build`)).resolves.toEqual(true)
-      },
-      2 * 60 * 1000
-    )
+      await expect(buildServices(`build`)).resolves.toEqual(true)
+    },
+    2 * 60 * 1000
+  )
 
-    it(
-      `should compile and build(skipping compile)`,
-      async () => {
-        const timestamp = generateTimestamp()
-        const parentFolderNameTimeStamped = `test-app-${timestamp}`
+  it(
+    `should compile and build(skipping compile)`,
+    async () => {
+      const timestamp = generateTimestamp()
+      const parentFolderNameTimeStamped = `test-app-${timestamp}`
 
-        process.projectDir = path.join(
-          process.cwd(),
-          parentFolderNameTimeStamped
-        )
+      process.projectDir = path.join(process.cwd(), parentFolderNameTimeStamped)
 
-        await createFolder(process.projectDir)
+      await createFolder(process.projectDir)
 
-        await createFileStructure(`create`)
+      await createFileStructure(`create`)
 
-        await compileServices(`compile`)
-        await expect(buildServices(`build`)).resolves.toEqual(true)
-      },
-      2 * 60 * 1000
-    )
-  })
+      await compileServices(`compile`)
+      await expect(buildServices(`build`)).resolves.toEqual(true)
+    },
+    2 * 60 * 1000
+  )
 
   afterAll(async () => {
     rimraf.sync('./test-app-*')

--- a/test/commands/cbd/cbd.spec.js
+++ b/test/commands/cbd/cbd.spec.js
@@ -191,7 +191,6 @@ describe('sasjs cbd (creating new app)', () => {
 
         process.projectDir = path.join(
           process.cwd(),
-          'cli-tests-cbd-with-app', // extra level of directory to avoid reading .env file from parent
           parentFolderNameTimeStamped
         )
 
@@ -305,6 +304,6 @@ describe('sasjs cbd (creating new app)', () => {
   })
 
   afterAll(async () => {
-    rimraf.sync('./cli-tests-cbd-with-app*')
+    rimraf.sync('./cli-tests-cbd-with-app-*')
   }, 60 * 1000)
 })

--- a/test/commands/cbd/testConfig/config.json
+++ b/test/commands/cbd/testConfig/config.json
@@ -1,0 +1,18 @@
+{
+  "cmnMacros": ["macros"],
+  "cmnServices": ["services/common"],
+  "useMacroCore": true,
+  "targets": [
+    {
+      "name": "",
+      "serverType": "",
+      "serverUrl": "",
+      "appLoc": "/Public/app/cli-tests",
+      "deployServicePack": false,
+      "assetPaths": [],
+      "streamWeb": true,
+      "streamWebFolder": "webv",
+      "webSourcePath": "src"
+    }
+  ]
+}

--- a/test/commands/cbd/testScript/copyscript.sh
+++ b/test/commands/cbd/testScript/copyscript.sh
@@ -1,0 +1,2 @@
+echo "sasjs: copying deploy script to repo root"
+cp sasjsbuild/build.sas runme.sas


### PR DESCRIPTION
## Issue

Closes #297 

## Intent

while deploying through deploy script, it is throwing error for not having `access_token`, which is not required

## Implementation

removed `access_token` requirement check from deploy in all cases.
Getting `access_token` throws error itself if not found, replaced better console message.
Written couple of tests for `deploy` (`cbd`), by creating new app, having it's own `sasjsconfig.json`, changes made to `src` related for these tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
