### PR TITLE
fix(env-vars): get client, secret and refresh token from env vars

### DIFF
--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -435,10 +435,13 @@ export async function getAccessToken(target, checkIfExpiring = true) {
       serverType: target.serverType
     })
 
-    const client =
+    let client =
       target.authInfo && target.authInfo.client
         ? target.authInfo.client
         : await getVariable('client', target)
+
+    client = client || process.env.CLIENT
+
     if (!client) {
       throw new Error(
         `Client ID was not found.
@@ -446,10 +449,13 @@ export async function getAccessToken(target, checkIfExpiring = true) {
       )
     }
 
-    const secret =
+    let secret =
       target.authInfo && target.authInfo.secret
         ? target.authInfo.secret
         : await getVariable('secret', target)
+
+    secret = secret || process.env.SECRET
+
     if (!secret) {
       throw new Error(
         `Client secret was not found.
@@ -457,10 +463,13 @@ export async function getAccessToken(target, checkIfExpiring = true) {
       )
     }
 
-    const refreshToken =
+    let refreshToken =
       target.authInfo && target.authInfo.refresh_token
         ? target.authInfo.refresh_token
         : await getVariable('refresh_token', target)
+
+    refreshToken = refreshToken || process.env.REFRESH_TOKEN
+
     let authInfo
 
     if (refreshToken) {

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -441,6 +441,7 @@ export async function getAccessToken(target, checkIfExpiring = true) {
         : await getVariable('client', target)
 
     client = client || process.env.CLIENT
+    client = client && client.trim() === 'null' ? null : client
 
     if (!client) {
       throw new Error(
@@ -455,6 +456,7 @@ export async function getAccessToken(target, checkIfExpiring = true) {
         : await getVariable('secret', target)
 
     secret = secret || process.env.SECRET
+    secret = secret && secret.trim() === 'null' ? null : secret
 
     if (!secret) {
       throw new Error(
@@ -469,6 +471,8 @@ export async function getAccessToken(target, checkIfExpiring = true) {
         : await getVariable('refresh_token', target)
 
     refreshToken = refreshToken || process.env.REFRESH_TOKEN
+    refreshToken =
+      refreshToken && refreshToken.trim() === 'null' ? null : refreshToken
 
     let authInfo
 

--- a/test/utils/config-utils.spec.js
+++ b/test/utils/config-utils.spec.js
@@ -102,6 +102,7 @@ describe('Config Utils', () => {
           secret: '53CR3T'
         }
       }
+      process.env.REFRESH_TOKEN = null
 
       const token = await getAccessToken(target, true)
 

--- a/test/utils/config-utils.spec.js
+++ b/test/utils/config-utils.spec.js
@@ -4,13 +4,15 @@ import {
   refreshTokens,
   getNewAccessToken
 } from '../../src/utils/auth-utils'
+import dotenv from 'dotenv'
 jest.mock('@sasjs/adapter/node')
 
 describe('Config Utils', () => {
   let authUtils
 
-  beforeAll(() => {
+  beforeEach(() => {
     process.projectDir = process.cwd()
+    dotenv.config()
   })
 
   beforeEach(() => {
@@ -120,6 +122,7 @@ describe('Config Utils', () => {
           secret: '53CR3T'
         }
       }
+      process.env.CLIENT = null
 
       await expect(getAccessToken(target)).rejects.toThrow()
     })
@@ -132,6 +135,7 @@ describe('Config Utils', () => {
           client: 'CL13NT'
         }
       }
+      process.env.SECRET = null
 
       await expect(getAccessToken(target)).rejects.toThrow()
     })


### PR DESCRIPTION
## Issue

https://github.com/sasjs/cli/issues/327

## Intent

Read `CLIENT`, `SECRET` and `REFRESH_TOKEN` from env variables.

## Implementation

Read `CLIENT`, `SECRET` and `REFRESH_TOKEN` from env variables if not available as part of the target's `authInfo` - this will make it work for local as well as global targets.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
