### PR TITLE
fix(add-cred): save server URL when adding credentials to a local target

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -6,3 +6,4 @@ groups:
       - YuryShkoda
       - saadjutt01
       - medjedovicm
+      - allanbowe

--- a/src/commands/add/add-credential.ts
+++ b/src/commands/add/add-credential.ts
@@ -1,7 +1,5 @@
 import path from 'path'
-import dotenv from 'dotenv'
 import { Logger, LogLevel } from '@sasjs/utils/logger'
-import { getString } from '@sasjs/utils/input'
 import { SasAuthResponse, Target } from '@sasjs/utils/types'
 
 import SASjs from '@sasjs/adapter/node'
@@ -11,7 +9,8 @@ import {
   saveToGlobalConfig
 } from '../../utils/config-utils'
 import { createFile } from '../../utils/file'
-import { getAndValidateServerUrl } from './input'
+import { getAndValidateServerUrl, getCredentialsInput } from './input'
+import { saveToLocalConfig } from './config'
 
 /**
  * Creates a .env file for the specified target.
@@ -50,6 +49,7 @@ export const addCredential = async (targetName: string): Promise<void> => {
       refresh_token,
       logger
     )
+    await saveToLocalConfig(target)
   } else {
     target.authInfo = { client, secret, access_token, refresh_token }
     await saveToGlobalConfig(target)
@@ -74,42 +74,6 @@ export const validateTargetName = (targetName: string): string => {
     )
 
   return targetName
-}
-
-const getCredentialsInput = async (targetName: string) => {
-  const defaultValues = getDefaultValues(targetName)
-
-  const client = await getString(
-    'Please enter your Client ID: ',
-    (v) => !!v || 'Client ID is required.',
-    defaultValues.client
-  )
-  const secret = await getString(
-    'Please enter your Client Secret: ',
-    (v) => !!v || 'Client Secret is required.',
-    defaultValues.secret
-  )
-
-  return { client, secret }
-}
-
-export const getDefaultValues = (targetName: string) => {
-  dotenv.config({ path: path.join(process.projectDir, `.env.${targetName}`) })
-
-  const defaultClient =
-    process.env.CLIENT === 'undefined' ||
-    process.env.CLIENT === 'null' ||
-    !process.env.CLIENT
-      ? ''
-      : process.env.CLIENT
-  const defaultSecret =
-    process.env.SECRET === 'undefined' ||
-    process.env.SECRET === 'null' ||
-    !process.env.SECRET
-      ? ''
-      : process.env.SECRET
-
-  return { client: defaultClient, secret: defaultSecret }
 }
 
 export const getTokens = async (

--- a/src/commands/add/add-target.ts
+++ b/src/commands/add/add-target.ts
@@ -1,20 +1,16 @@
 import { Logger, LogLevel } from '@sasjs/utils/logger'
 import { Target, ServerType } from '@sasjs/utils/types'
-
-import path from 'path'
-
 import {
   findTargetInConfiguration,
   saveToGlobalConfig
 } from '../../utils/config-utils'
-import { createFile } from '../../utils/file'
 import { TargetScope } from '../../types/TargetScope'
 import {
   getCommonFields,
   getAndValidateSasViyaFields,
   getAndValidateSas9Fields
 } from './input'
-import { getLocalConfig } from './config'
+import { saveToLocalConfig } from './config'
 import { addCredential } from './add-credential'
 
 export async function addTarget(): Promise<boolean> {
@@ -74,31 +70,4 @@ async function saveConfig(scope: TargetScope, target: Target) {
   }
 
   return filePath
-}
-
-async function saveToLocalConfig(buildTarget: Target) {
-  const buildSourceFolder = require('../../constants').get().buildSourceFolder
-  let config = await getLocalConfig()
-  if (config) {
-    if (config.targets && config.targets.length) {
-      const existingTargetIndex = config.targets.findIndex(
-        (t: Target) => t.name === buildTarget.name
-      )
-      if (existingTargetIndex > -1) {
-        config.targets[existingTargetIndex] = buildTarget
-      } else {
-        config.targets.push(buildTarget)
-      }
-    } else {
-      config.targets = [buildTarget]
-    }
-  } else {
-    config = { targets: [buildTarget] }
-  }
-
-  const configPath = path.join(buildSourceFolder, 'sasjsconfig.json')
-
-  await createFile(configPath, JSON.stringify(config, null, 2))
-
-  return configPath
 }

--- a/src/commands/add/config.ts
+++ b/src/commands/add/config.ts
@@ -1,5 +1,7 @@
 import { create } from '../create'
 import path from 'path'
+import { Target } from '@sasjs/utils/types'
+import { createFile } from '../../utils/file'
 import { getConfiguration } from '../../utils/config-utils'
 
 export async function getLocalConfig() {
@@ -9,4 +11,31 @@ export async function getLocalConfig() {
   )
   if (!config) await create('.', 'sasonly')
   return config
+}
+
+export async function saveToLocalConfig(buildTarget: Target) {
+  const buildSourceFolder = require('../../constants').get().buildSourceFolder
+  let config = await getLocalConfig()
+  if (config) {
+    if (config.targets && config.targets.length) {
+      const existingTargetIndex = config.targets.findIndex(
+        (t: Target) => t.name === buildTarget.name
+      )
+      if (existingTargetIndex > -1) {
+        config.targets[existingTargetIndex] = buildTarget
+      } else {
+        config.targets.push(buildTarget)
+      }
+    } else {
+      config.targets = [buildTarget]
+    }
+  } else {
+    config = { targets: [buildTarget] }
+  }
+
+  const configPath = path.join(buildSourceFolder, 'sasjsconfig.json')
+
+  await createFile(configPath, JSON.stringify(config, null, 2))
+
+  return configPath
 }

--- a/src/commands/add/input.ts
+++ b/src/commands/add/input.ts
@@ -1,5 +1,4 @@
 import {
-  getNumber,
   getString,
   getConfirmation,
   getChoice,
@@ -7,7 +6,6 @@ import {
 } from '@sasjs/utils/input'
 import { Target, ServerType } from '@sasjs/utils/types'
 import { Logger, LogLevel } from '@sasjs/utils/logger'
-import chalk from 'chalk'
 import path from 'path'
 import dotenv from 'dotenv'
 import SASjs from '@sasjs/adapter/node'
@@ -51,7 +49,6 @@ async function getAndValidateScope(): Promise<TargetScope> {
 }
 
 async function getAndValidateServerType(): Promise<ServerType> {
-  const errorMessage = 'Server type must be either 1 or 2.'
   const serverType = await getChoice(
     'Please pick a server type: ',
     'Please choose either option 1 or 2.',
@@ -105,8 +102,6 @@ async function getAndValidateTargetName(
     return true
   }
 
-  const errorMessage =
-    'Target name must be alphanumeric, can not contain spaces, and must be unique across your set of targets.'
   const defaultName = serverType === ServerType.SasViya ? 'viya' : 'sas9'
 
   const targetName = await getString(
@@ -194,4 +189,40 @@ async function getAndValidateAppLoc(targetName: string): Promise<string> {
   )
 
   return appLoc
+}
+
+export const getCredentialsInput = async (targetName: string) => {
+  const defaultValues = getDefaultValues(targetName)
+
+  const client = await getString(
+    'Please enter your Client ID: ',
+    (v) => !!v || 'Client ID is required.',
+    defaultValues.client
+  )
+  const secret = await getString(
+    'Please enter your Client Secret: ',
+    (v) => !!v || 'Client Secret is required.',
+    defaultValues.secret
+  )
+
+  return { client, secret }
+}
+
+export const getDefaultValues = (targetName: string) => {
+  dotenv.config({ path: path.join(process.projectDir, `.env.${targetName}`) })
+
+  const defaultClient =
+    process.env.CLIENT === 'undefined' ||
+    process.env.CLIENT === 'null' ||
+    !process.env.CLIENT
+      ? ''
+      : process.env.CLIENT
+  const defaultSecret =
+    process.env.SECRET === 'undefined' ||
+    process.env.SECRET === 'null' ||
+    !process.env.SECRET
+      ? ''
+      : process.env.SECRET
+
+  return { client: defaultClient, secret: defaultSecret }
 }

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -232,6 +232,24 @@ export async function deleteFolder(folderName, debug = false) {
   })
 }
 
+export async function deleteFile(filePath, debug = false) {
+  if (debug) {
+    console.log('Deleting file %s', chalk.cyan(filePath))
+  }
+  return new Promise((resolve, reject) => {
+    rimraf(filePath, function (error) {
+      if (error) {
+        console.log(
+          chalk.red(`Error deleting file %s`),
+          chalk.redBright.bold(filePath)
+        )
+        reject(error)
+      }
+      resolve()
+    })
+  })
+}
+
 export async function copy(source, destination, debug = false) {
   if (debug) {
     console.log('Copying %s to %s', chalk.cyan(source), chalk.cyan(destination))


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/342.

## Intent

Save target URL in target configuration when adding credentials to a local target.

## Implementation

* Saves local `sasjsconfig.json` when adding credentials.
* Added test that captures the behaviour of saving the server URL if missing. 

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
