### PR TITLE
feat: extra debug statements in the sasjs CLI deployed services - clo…

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -384,7 +384,7 @@ async function getPreCodeForServicePack(serverType) {
         '/* so we provide instead as __program */\n' +
         '%global __program _program;\n' +
         '%let _program=%sysfunc(coalescec(&__program,&_program));\n' +
-        '%macro (action,ds,dslabel=,fmt=);\n' +
+        '%macro webout(action,ds,dslabel=,fmt=);\n' +
         '%mv_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt)\n' +
         '%mend;\n'
       break

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -384,7 +384,7 @@ async function getPreCodeForServicePack(serverType) {
         '/* so we provide instead as __program */\n' +
         '%global __program _program;\n' +
         '%let _program=%sysfunc(coalescec(&__program,&_program));\n' +
-        '%macro webout(action,ds,dslabel=,fmt=);\n' +
+        '%macro (action,ds,dslabel=,fmt=);\n' +
         '%mv_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt)\n' +
         '%mend;\n'
       break
@@ -406,6 +406,11 @@ async function getPreCodeForServicePack(serverType) {
         )} and ${chalk.cyanBright('SAS9')}`
       )
   }
+  content +=
+        '/* provide additional debug info */\n' +
+        '%put user=%mf_getuser();\n' +
+        '%put pgm=&_program;\n' +
+        '%put timestamp=%sysfunc(datetime(),datetime19.);\n'
   return content
 }
 


### PR DESCRIPTION
…ses #344

## Issue

Relates to issue #344 - adding extra debug in the log

## Intent

When investigating server logs, it is not evident which service was called, and who called it.  This PR addresses that by instructing SAS to print this information to the log, with each service invocation.

## Implementation

The build.js file has been updated with a new string constant - this will apply both to SAS Viya and SAS 9.

## Checks

- n/a Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- n/a JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
