### PR TITLE
fix(create): fetching template info without curl

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -407,10 +407,10 @@ async function getPreCodeForServicePack(serverType) {
       )
   }
   content +=
-        '/* provide additional debug info */\n' +
-        '%put user=%mf_getuser();\n' +
-        '%put pgm=&_program;\n' +
-        '%put timestamp=%sysfunc(datetime(),datetime19.);\n'
+    '/* provide additional debug info */\n' +
+    '%put user=%mf_getuser();\n' +
+    '%put pgm=&_program;\n' +
+    '%put timestamp=%sysfunc(datetime(),datetime19.);\n'
   return content
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -38,18 +38,14 @@ export async function createMinimalApp(folderPath) {
 
 export async function createTemplateApp(folderPath, template) {
   const { stdout, stderr, code } = shelljs.exec(
-    `git ls-remote git@github.com:sasjs/template_${template}`,
+    `git ls-remote https://username:password@github.com/sasjs/template_${template}.git`,
     {
       silent: true
     }
   )
 
-  if (stderr.startsWith('ERROR: Repository not found.')) {
+  if (stderr.includes('Repository not found') || code) {
     throw `Template "${template}" is not sasjs template`
-  }
-
-  if (code) {
-    throw `\n${stderr}`
   }
 
   if (!stdout) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -37,19 +37,24 @@ export async function createMinimalApp(folderPath) {
 }
 
 export async function createTemplateApp(folderPath, template) {
-  const {
-    stdout
-  } = shelljs.exec(
-    `curl https://api.github.com/repos/sasjs/template_${template}`,
-    { silent: true }
+  const { stdout, stderr, code } = shelljs.exec(
+    `git ls-remote git@github.com:sasjs/template_${template}`,
+    {
+      silent: true
+    }
   )
-  const response = JSON.parse(stdout)
 
-  if (response.message && response.message === 'Not Found')
-    throw 'Template provided is not found'
+  if (stderr.startsWith('ERROR: Repository not found.')) {
+    throw `Template "${template}" is not sasjs template`
+  }
 
-  if (response.full_name !== `sasjs/template_${template}`)
-    throw 'Template provided is not sasjs template'
+  if (code) {
+    throw `\n${stderr}`
+  }
+
+  if (!stdout) {
+    throw `Unable to fetch template "${template}"`
+  }
 
   return new Promise(async (resolve, _) => {
     createApp(folderPath, `https://github.com/sasjs/template_${template}.git`)

--- a/test/commands/add-target.spec.ts
+++ b/test/commands/add-target.spec.ts
@@ -39,41 +39,45 @@ describe('addTarget', () => {
     const sasjsDirPath = path.join(process.projectDir, 'sasjs')
     await deleteFolder(sasjsDirPath)
   }, 60 * 1000)
-  it('should create a target in the local sasjsconfig.json file', async (done) => {
-    const commonFields = {
-      scope: TargetScope.Local,
-      serverType: ServerType.SasViya,
-      name: targetName,
-      appLoc: '/Public/app',
-      serverUrl: process.env.SERVER_URL as string
-    }
-    jest
-      .spyOn(inputModule, 'getCommonFields')
-      .mockImplementation(() => Promise.resolve(commonFields))
-    jest
-      .spyOn(inputModule, 'getAndValidateSasViyaFields')
-      .mockImplementation(() =>
-        Promise.resolve({ contextName: 'Test Context' })
+  it(
+    'should create a target in the local sasjsconfig.json file',
+    async (done) => {
+      const commonFields = {
+        scope: TargetScope.Local,
+        serverType: ServerType.SasViya,
+        name: targetName,
+        appLoc: '/Public/app',
+        serverUrl: process.env.SERVER_URL as string
+      }
+      jest
+        .spyOn(inputModule, 'getCommonFields')
+        .mockImplementation(() => Promise.resolve(commonFields))
+      jest
+        .spyOn(inputModule, 'getAndValidateSasViyaFields')
+        .mockImplementation(() =>
+          Promise.resolve({ contextName: 'Test Context' })
+        )
+
+      await expect(addTarget()).resolves.toEqual(true)
+
+      const buildSourceFolder = require('../../src/constants').get()
+        .buildSourceFolder
+      const config = await getConfiguration(
+        path.join(buildSourceFolder, 'sasjsconfig.json')
       )
-
-    await expect(addTarget()).resolves.toEqual(true)
-
-    const buildSourceFolder = require('../../src/constants').get()
-      .buildSourceFolder
-    const config = await getConfiguration(
-      path.join(buildSourceFolder, 'sasjsconfig.json')
-    )
-    expect(config).toBeTruthy()
-    expect(config.targets).toBeTruthy()
-    const target: Target = config.targets.find(
-      (t: Target) => t.name === targetName
-    )
-    expect(target.name).toEqual(targetName)
-    expect(target.serverType).toEqual(ServerType.SasViya)
-    expect(target.appLoc).toEqual('/Public/app')
-    expect(target.serverUrl).toEqual(process.env.SERVER_URL)
-    done()
-  })
+      expect(config).toBeTruthy()
+      expect(config.targets).toBeTruthy()
+      const target: Target = config.targets.find(
+        (t: Target) => t.name === targetName
+      )
+      expect(target.name).toEqual(targetName)
+      expect(target.serverType).toEqual(ServerType.SasViya)
+      expect(target.appLoc).toEqual('/Public/app')
+      expect(target.serverUrl).toEqual(process.env.SERVER_URL)
+      done()
+    },
+    10 * 1000
+  )
 
   it('should create a target in the global .sasjsrc file', async (done) => {
     const commonFields = {

--- a/test/commands/create.spec.ts
+++ b/test/commands/create.spec.ts
@@ -191,7 +191,7 @@ describe('sasjs create', () => {
           createFileStructure(
             `create ${parentFolderNameTimeStamped} --template xyz`
           )
-        ).resolves.toEqual('Template provided is not found')
+        ).resolves.toEqual('Template "xyz" is not sasjs template')
       },
       2 * 60 * 1000
     )

--- a/test/commands/create.spec.ts
+++ b/test/commands/create.spec.ts
@@ -178,7 +178,7 @@ describe('sasjs create', () => {
       `should fail having unknown apptype 'xyz'`,
       async () => {
         const timestamp = generateTimestamp()
-        const parentFolderNameTimeStamped = `test-app-${timestamp}-xyz`
+        const parentFolderNameTimeStamped = `test-app-create-${timestamp}-xyz`
 
         process.projectDir = path.join(
           process.cwd(),


### PR DESCRIPTION
## Issue

Closes #321 

## Intent

Remove `curl`'s only existence from code, it requires certificates to be configured. Some users have issue on windows with portable git-bash

## Implementation

removed `curl` (calling github api), replaced with `git ls-remote`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
![image](https://user-images.githubusercontent.com/8914650/102289710-24fefb80-3f61-11eb-9adb-c8e999a553ac.png)

To test:
checkout branch `issue321` and `npm start`