### PR TITLE
fix(*): fix saving of global targets after authentication, add server-specific attributes to target JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1543,9 +1543,9 @@
       "integrity": "sha512-CLICF0+ZUorKXct+4eU4ij1D5JCt4FZLwIyrUmfIA55XZJZxerS8pffh8BvXNi0x8MvtfKM12MCrpbtWTaX+Mw=="
     },
     "@sasjs/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-pWiTThkE7GYvUDA9gvNWsBLzI2VLk8YupZ4eDqjn2fLIcUZ0cHB+7wibCnA7Nkl4Z1fpGfKsLvGyPsC0R8h7vA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.0.2.tgz",
+      "integrity": "sha512-FyY/MyeeLP0+OhJWCbiVmV3Mz/mRcrc4oNbw1xhO7CR3DLpiPSmAHaq3sf+1NKCk2AzXbVPqgZM5NVKzvd2wrA==",
       "requires": {
         "consola": "^2.15.0",
         "prompts": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@sasjs/adapter": "^2.0.2",
     "@sasjs/core": "^2.0.0",
-    "@sasjs/utils": "^2.0.1",
+    "@sasjs/utils": "^2.0.2",
     "base64-img": "^1.0.4",
     "btoa": "^1.2.1",
     "chalk": "^4.1.0",

--- a/src/commands/add/addCredential.ts
+++ b/src/commands/add/addCredential.ts
@@ -47,8 +47,8 @@ export const addCredential = async (targetName: string): Promise<void> => {
     await saveToLocalConfig(target)
   } else {
     target = new Target({
-      ...target,
-      authInfo: { client, secret, access_token, refresh_token }
+      ...target.toJson(),
+      authConfig: { client, secret, access_token, refresh_token }
     })
     await saveToGlobalConfig(target)
   }

--- a/src/commands/add/addTarget.ts
+++ b/src/commands/add/addTarget.ts
@@ -17,7 +17,7 @@ export async function addTarget(): Promise<boolean> {
 
   let targetJson: any = {
     name,
-    serverType: serverType,
+    serverType,
     serverUrl,
     appLoc
   }


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/399

## Intent

Save auth config correctly when authenticating against a global target.

## Implementation

* Convert target to JSON before saving.
* Bump `@sasjs/utils` to fix saving of server-specific attributes like `contextName`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested. - Tests are [here](https://github.com/sasjs/utils/blob/main/src/types/target.spec.ts#L311)
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
