### PR TITLE
fix(build): prepend `/services` folder to service paths

### DIFF
--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -128,9 +128,9 @@ async function getCreateWebServiceScript(serverType: ServerType) {
 function getWebServiceScriptInvocation(serverType: ServerType) {
   switch (serverType) {
     case ServerType.SasViya:
-      return '%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode ,replace=yes)'
+      return '%mv_createwebservice(path=&appLoc/services/&path, name=&service, code=sascode ,replace=yes)'
     case ServerType.Sas9:
-      return '%mm_createwebservice(path=&appLoc/&path, name=&service, code=sascode ,replace=yes)'
+      return '%mm_createwebservice(path=&appLoc/services/&path, name=&service, code=sascode ,replace=yes)'
     default:
       throw new Error(
         `Invalid server type: valid options are ${ServerType.SasViya} and ${ServerType.Sas9}`


### PR DESCRIPTION
## Issue

No issue raised.

## Intent

When deploying using the generated `.sas` file, the services are deployed at the root and not in a `services` subfolder.
This needs to be fixed to deploy to the correct folder.

## Implementation

* Added `/services` to service paths

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
