### PR TITLE
fix(flow-execute): fixed log link for Windows

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
-    "trailingComma": "none",
-    "tabWidth": 2,
-    "semi": false,
-    "singleQuote": true,
-    "endOfLine": "auto"
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "endOfLine": "auto"
 }

--- a/src/commands/flow/execute.ts
+++ b/src/commands/flow/execute.ts
@@ -139,9 +139,9 @@ export async function execute(
               ).catch((err) =>
                 displayError(err, 'Error while saving log file.')
               )
-              console.log(`[logName]`, logName)
-              console.log(`[logFolder]`, logFolder)
-              logName = logName ? path.join(logFolder, logName as string) : ''
+              console.log(`[2 logName]`, logName)
+              console.log(`[2 logFolder]`, logFolder)
+              logName = logName ? `${logFolder}/${logName}` : ''
 
               await saveToCsv(
                 flowName,
@@ -188,9 +188,9 @@ export async function execute(
             ).catch((err: any) =>
               displayError(err, 'Error while saving log file.')
             )
-            console.log(`[logName]`, logName)
-            console.log(`[logFolder]`, logFolder)
-            logName = logName ? path.join(logFolder, logName as string) : ''
+            console.log(`[3 logName]`, logName)
+            console.log(`[3 logFolder]`, logFolder)
+            logName = logName ? `${logFolder}/${logName}` : ''
 
             await saveToCsv(
               flowName,
@@ -502,9 +502,9 @@ export async function execute(
                 ).catch((err: any) => {
                   displayError(err, 'Error while saving log file.')
                 })
-                console.log(`[logName]`, logName)
-                console.log(`[logFolder]`, logFolder)
-                logName = logName ? path.join(logFolder, logName as string) : ''
+                console.log(`[4 logName]`, logName)
+                console.log(`[4 logFolder]`, logFolder)
+                logName = logName ? `${logFolder}/${logName}` : ''
 
                 await saveToCsv(
                   successor,
@@ -599,9 +599,9 @@ export async function execute(
               ).catch((err) =>
                 displayError(err, 'Error while saving log file.')
               )
-              console.log(`[logName]`, logName)
-              console.log(`[logFolder]`, logFolder)
-              logName = logName ? path.join(logFolder, logName as string) : ''
+              console.log(`[1 logName]`, logName)
+              console.log(`[1 logFolder]`, logFolder)
+              logName = logName ? `${logFolder}/${logName}` : ''
 
               await saveToCsv(
                 successor,

--- a/src/commands/flow/execute.ts
+++ b/src/commands/flow/execute.ts
@@ -139,6 +139,8 @@ export async function execute(
               ).catch((err) =>
                 displayError(err, 'Error while saving log file.')
               )
+              console.log(`[logName]`, logName)
+              console.log(`[logFolder]`, logFolder)
               logName = logName ? path.join(logFolder, logName as string) : ''
 
               await saveToCsv(
@@ -186,6 +188,8 @@ export async function execute(
             ).catch((err: any) =>
               displayError(err, 'Error while saving log file.')
             )
+            console.log(`[logName]`, logName)
+            console.log(`[logFolder]`, logFolder)
             logName = logName ? path.join(logFolder, logName as string) : ''
 
             await saveToCsv(
@@ -498,6 +502,8 @@ export async function execute(
                 ).catch((err: any) => {
                   displayError(err, 'Error while saving log file.')
                 })
+                console.log(`[logName]`, logName)
+                console.log(`[logFolder]`, logFolder)
                 logName = logName ? path.join(logFolder, logName as string) : ''
 
                 await saveToCsv(
@@ -593,6 +599,8 @@ export async function execute(
               ).catch((err) =>
                 displayError(err, 'Error while saving log file.')
               )
+              console.log(`[logName]`, logName)
+              console.log(`[logFolder]`, logFolder)
               logName = logName ? path.join(logFolder, logName as string) : ''
 
               await saveToCsv(

--- a/src/commands/flow/execute.ts
+++ b/src/commands/flow/execute.ts
@@ -139,8 +139,7 @@ export async function execute(
               ).catch((err) =>
                 displayError(err, 'Error while saving log file.')
               )
-              console.log(`[2 logName]`, logName)
-              console.log(`[2 logFolder]`, logFolder)
+
               logName = logName ? `${logFolder}/${logName}` : ''
 
               await saveToCsv(
@@ -188,8 +187,7 @@ export async function execute(
             ).catch((err: any) =>
               displayError(err, 'Error while saving log file.')
             )
-            console.log(`[3 logName]`, logName)
-            console.log(`[3 logFolder]`, logFolder)
+
             logName = logName ? `${logFolder}/${logName}` : ''
 
             await saveToCsv(
@@ -502,8 +500,7 @@ export async function execute(
                 ).catch((err: any) => {
                   displayError(err, 'Error while saving log file.')
                 })
-                console.log(`[4 logName]`, logName)
-                console.log(`[4 logFolder]`, logFolder)
+
                 logName = logName ? `${logFolder}/${logName}` : ''
 
                 await saveToCsv(
@@ -599,8 +596,7 @@ export async function execute(
               ).catch((err) =>
                 displayError(err, 'Error while saving log file.')
               )
-              console.log(`[1 logName]`, logName)
-              console.log(`[1 logFolder]`, logFolder)
+
               logName = logName ? `${logFolder}/${logName}` : ''
 
               await saveToCsv(

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -183,7 +183,10 @@ export async function createFile(fileName, content, debug = false) {
   }
 
   return new Promise(async (resolve, reject) => {
-    console.log(`[path.sep]`, path.sep)
+    console.log(`[fileName]`, fileName)
+    fileName = fileName.split('/').join(path.sep)
+    console.log(`[fileName]`, fileName)
+
     if (fileName.split(path.sep).length > 1) {
       let folderPath = fileName.split(path.sep)
       folderPath.pop()

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -207,8 +207,23 @@ export async function createFile(fileName, content, debug = false) {
   })
 }
 
-export function unifyFilePath(filePath, separator = path.sep) {
-  return filePath.split('/').join(separator)
+export function unifyFilePath(filePath, separator = path.sep, replace = '/') {
+  const separators = { unix: '/', win: '\\' }
+
+  let osSeparator = Object.keys(separators).find(
+    (key) => separators[key] === separator
+  )
+
+  if (osSeparator) {
+    const notValidSeparator =
+      separators[Object.keys(separators).find((key) => key !== osSeparator)]
+
+    osSeparator = separators[osSeparator]
+
+    return filePath.split(notValidSeparator).join(osSeparator)
+  }
+
+  return filePath.split(replace).join(separator)
 }
 
 export async function deleteFolder(folderName, debug = false) {

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -183,6 +183,7 @@ export async function createFile(fileName, content, debug = false) {
   }
 
   return new Promise(async (resolve, reject) => {
+    console.log(`[path.sep]`, path.sep)
     if (fileName.split(path.sep).length > 1) {
       let folderPath = fileName.split(path.sep)
       folderPath.pop()

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -183,9 +183,7 @@ export async function createFile(fileName, content, debug = false) {
   }
 
   return new Promise(async (resolve, reject) => {
-    console.log(`[fileName]`, fileName)
     fileName = fileName.split('/').join(path.sep)
-    console.log(`[fileName]`, fileName)
 
     if (fileName.split(path.sep).length > 1) {
       let folderPath = fileName.split(path.sep)

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -183,7 +183,7 @@ export async function createFile(fileName, content, debug = false) {
   }
 
   return new Promise(async (resolve, reject) => {
-    fileName = fileName.split('/').join(path.sep)
+    fileName = unifyFilePath(fileName)
 
     if (fileName.split(path.sep).length > 1) {
       let folderPath = fileName.split(path.sep)
@@ -205,6 +205,10 @@ export async function createFile(fileName, content, debug = false) {
       resolve(content)
     })
   })
+}
+
+export function unifyFilePath(filePath, separator = path.sep) {
+  return filePath.split('/').join(separator)
 }
 
 export async function deleteFolder(folderName, debug = false) {

--- a/src/utils/spec/file.spec.ts
+++ b/src/utils/spec/file.spec.ts
@@ -4,7 +4,8 @@ import {
   readFile,
   fileExists,
   deleteFile,
-  deleteFolder
+  deleteFolder,
+  unifyFilePath
 } from '../file'
 import { generateTimestamp } from '../utils'
 
@@ -39,6 +40,21 @@ describe('file utility', () => {
       await expect(readFile(filePath)).resolves.toEqual(content)
 
       deleteFolder(path.join(process.cwd(), 'testFolder_1'))
+    })
+  })
+
+  describe('unifyFilePath', () => {
+    it('should unify file path in Unix-like systems', () => {
+      const filePath = '/folder/subFolder/file.txt'
+
+      expect(unifyFilePath(filePath, '/')).toEqual(filePath)
+    })
+
+    it('should unify file path in Windows system', () => {
+      const filePath = '/folder/subFolder/file.txt'
+      const expectedFilePath = filePath.replace(/\//g, '\\')
+
+      expect(unifyFilePath(filePath, '\\')).toEqual(expectedFilePath)
     })
   })
 })

--- a/src/utils/spec/file.spec.ts
+++ b/src/utils/spec/file.spec.ts
@@ -56,5 +56,28 @@ describe('file utility', () => {
 
       expect(unifyFilePath(filePath, '\\')).toEqual(expectedFilePath)
     })
+
+    it('should unify file path with mixed separators', () => {
+      const filePath = '/folder/subFolder\\file.txt'
+      const unixSeparator = '/'
+      const winSeparator = '\\'
+      const expectedUnixPath = filePath.replace(/\\/g, unixSeparator)
+      const expectedWinPath = filePath.replace(/\//g, winSeparator)
+
+      expect(unifyFilePath(filePath, unixSeparator)).toEqual(expectedUnixPath)
+      expect(unifyFilePath(filePath, winSeparator)).toEqual(expectedWinPath)
+    })
+
+    it('should return file path with custom separator', () => {
+      let filePath = '/folder/subFolder/file.txt'
+      let expectedFilePath = filePath.replace(/\//g, '$')
+
+      expect(unifyFilePath(filePath, '$')).toEqual(expectedFilePath)
+
+      filePath = '\\folder\\subFolder\\file.txt'
+      expectedFilePath = filePath.replace(/\\/g, '$')
+
+      expect(unifyFilePath(filePath, '$', '\\')).toEqual(expectedFilePath)
+    })
   })
 })


### PR DESCRIPTION
## Intent

1. Fix log link for Windows.
2. Fix creating files on Windows.

## Implementation

1. Updated `flow execute` logic.
2. Updated `createFile` utility.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/25773492/104610018-b793d700-5694-11eb-9f67-1da04a6c2d86.png)
Server:
![image](https://user-images.githubusercontent.com/25773492/104610066-c11d3f00-5694-11eb-9541-3587652ceda8.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
