### PR TITLE
fix(sasjs-compile): Prevent duplicate dependencies with windows file paths

### DIFF
--- a/src/commands/compile/internal/loadDependencies.ts
+++ b/src/commands/compile/internal/loadDependencies.ts
@@ -91,7 +91,6 @@ export async function loadDependencies(
     fileContent = `* Service Variables start;\n${serviceVars}\n*Service Variables end;\n${fileContent}`
   }
 
-  process.logger?.log('Finished loading dependencies.')
   return fileContent
 }
 

--- a/src/commands/compile/spec/getDependencyPaths.spec.ts
+++ b/src/commands/compile/spec/getDependencyPaths.spec.ts
@@ -136,6 +136,23 @@ describe('getDependencyPaths', () => {
     expect(result).toEqual(['sas/macros/mf_abort.sas'])
   })
 
+  test('it should prioritise overridden dependencies with windows file paths', () => {
+    const dependencyNames = ['mf_abort.sas']
+    const dependencyPaths = [
+      'node_modules\\@sasjs\\core\\core\\mf_abort.sas',
+      'sas\\macros\\mf_abort.sas'
+    ]
+
+    const result = prioritiseDependencyOverrides(
+      dependencyNames,
+      dependencyPaths,
+      [],
+      '\\'
+    )
+
+    expect(result).toEqual(['sas\\macros\\mf_abort.sas'])
+  })
+
   test('it should prioritise overridden dependencies provided specific macros', () => {
     const dependencyNames = ['mf_abort.sas']
     const dependencyPaths = [

--- a/src/commands/shared/dependencies.ts
+++ b/src/commands/shared/dependencies.ts
@@ -73,11 +73,12 @@ export async function getDependencyPaths(
 export function prioritiseDependencyOverrides(
   dependencyNames: string[],
   dependencyPaths: string[],
-  macroPaths: string[] = []
+  macroPaths: string[] = [],
+  pathSeparator = path.sep
 ) {
   dependencyNames.forEach((depFileName) => {
     const paths = dependencyPaths.filter((p) =>
-      p.includes(`${path.sep}${depFileName}`)
+      p.includes(`${pathSeparator}${depFileName}`)
     )
 
     let overriddenDependencyPaths = paths.filter(

--- a/src/commands/shared/dependencies.ts
+++ b/src/commands/shared/dependencies.ts
@@ -76,7 +76,9 @@ export function prioritiseDependencyOverrides(
   macroPaths: string[] = []
 ) {
   dependencyNames.forEach((depFileName) => {
-    const paths = dependencyPaths.filter((p) => p.includes(`/${depFileName}`))
+    const paths = dependencyPaths.filter((p) =>
+      p.includes(`${path.sep}${depFileName}`)
+    )
 
     let overriddenDependencyPaths = paths.filter(
       (p) => !p.includes('node_modules')


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/405

## Intent

Load overridden macros only once regardless of OS platform.

## Implementation

* Used `path.sep` instead of hardcoded `/` when checking file paths for overrides.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
