### PR TITLE
feat: document macroCore as well

### DIFF
--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -11,6 +11,14 @@ import { getConstants } from '../../constants'
 import { getFoldersForDocs } from './internal/getFoldersForDocs'
 import { getFoldersForDocsAllTargets } from './internal/getFoldersForDocsAllTargets'
 
+/**
+ * Generates documentation(Doxygen)
+ * By default the docs will be at 'sasjsbuild/docs' folder
+ * If a target is supplied, generates docs only for the SAS programs / macros / jobs / services in that target (and the root).
+ * If no target is supplied, generates for all sas programs/ macros / jobs / services.
+ * @param {string} targetName- the name of the target to be specific for docs.
+ * @param {string} outDirectory- the name of the output folder, picks from sasjsconfig.docConfig if present.
+ */
 export async function generateDocs(targetName: string, outDirectory: string) {
   const { doxyContent, buildDestinationDocsFolder } = getConstants()
 

--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -17,9 +17,7 @@ export async function generateDocs(targetName: string, outDirectory: string) {
   const config = await getLocalConfig()
 
   if (!outDirectory)
-    outDirectory = config?.docConfig?.outDirectory?.length
-      ? config.docConfig.outDirectory
-      : buildDestinationDocsFolder
+    outDirectory = config?.docConfig?.outDirectory || buildDestinationDocsFolder
 
   const rootFolders = getFoldersForDocs(config, true)
   const targetFolders: string[] = []

--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -13,11 +13,16 @@ import { getFoldersForDocsAllTargets } from './internal/getFoldersForDocsAllTarg
 
 export async function generateDocs(targetName: string, outDirectory: string) {
   const { doxyContent, buildDestinationDocsFolder } = getConstants()
-  if (!outDirectory) outDirectory = buildDestinationDocsFolder
 
   const config = await getLocalConfig()
-  const rootFolders = getFoldersForDocs(config)
 
+  if (!outDirectory)
+    outDirectory =
+      config.docConfig && config.docConfig.outDirectory
+        ? config.docConfig.outDirectory
+        : buildDestinationDocsFolder
+
+  const rootFolders = getFoldersForDocs(config)
   const targetFolders: string[] = []
   if (targetName) {
     const { target } = await findTargetInConfiguration(targetName)
@@ -73,6 +78,8 @@ export async function generateDocs(targetName: string, outDirectory: string) {
       `The Doxygen application is not installed or configured. This external tool is used by 'sasjs doc'.\n${stderr}\nPlease download and install from here: https://www.doxygen.nl/download.html#srcbin`
     )
   }
+
+  return { outDirectory }
 }
 
 function setVariableCmd(params: any): string {

--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 import ora from 'ora'
 
 import { isWindows } from '../../utils/command'
-import { createFolder, deleteFolder } from '../../utils/file'
+import { createFolder, deleteFolder, folderExists } from '../../utils/file'
 import { findTargetInConfiguration, getLocalConfig } from '../../utils/config'
 import { getConstants } from '../../constants'
 
@@ -17,12 +17,9 @@ export async function generateDocs(targetName: string, outDirectory: string) {
   const config = await getLocalConfig()
 
   if (!outDirectory)
-    outDirectory =
-      config.docConfig &&
-      config.docConfig.outDirectory &&
-      config.docConfig.outDirectory.length
-        ? config.docConfig.outDirectory
-        : buildDestinationDocsFolder
+    outDirectory = config?.docConfig?.outDirectory?.length
+      ? config.docConfig.outDirectory
+      : buildDestinationDocsFolder
 
   const rootFolders = getFoldersForDocs(config, true)
   const targetFolders: string[] = []

--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -18,11 +18,13 @@ export async function generateDocs(targetName: string, outDirectory: string) {
 
   if (!outDirectory)
     outDirectory =
-      config.docConfig && config.docConfig.outDirectory
+      config.docConfig &&
+      config.docConfig.outDirectory &&
+      config.docConfig.outDirectory.length
         ? config.docConfig.outDirectory
         : buildDestinationDocsFolder
 
-  const rootFolders = getFoldersForDocs(config)
+  const rootFolders = getFoldersForDocs(config, true)
   const targetFolders: string[] = []
   if (targetName) {
     const { target } = await findTargetInConfiguration(targetName)

--- a/src/commands/docs/initDocs.ts
+++ b/src/commands/docs/initDocs.ts
@@ -1,5 +1,8 @@
 import { setupDoxygen } from '../../utils/utils'
 
+/**
+ * Initiates or reset doxy folder in current sasjs application
+ */
 export async function initDocs() {
   const parentFolderName = '.'
   await setupDoxygen(parentFolderName)

--- a/src/commands/docs/internal/getFoldersForDocs.ts
+++ b/src/commands/docs/internal/getFoldersForDocs.ts
@@ -6,6 +6,12 @@ import { Configuration } from '../../../types/configuration'
 
 export function getFoldersForDocs(config: Target | Configuration) {
   const { buildSourceFolder } = getConstants()
+  const macroCoreFolders =
+    'docConfig' in config &&
+    config.docConfig &&
+    config.docConfig.displayMacroCore
+      ? [path.join(process.projectDir, 'node_modules', '@sasjs', 'core')]
+      : []
   const macroFolders =
     config && config.macroFolders
       ? config.macroFolders.map((f) => path.join(buildSourceFolder, f))
@@ -25,5 +31,11 @@ export function getFoldersForDocs(config: Target | Configuration) {
       ? config.jobConfig.jobFolders.map((f) => path.join(buildSourceFolder, f))
       : []
 
-  return [...macroFolders, ...programFolders, ...serviceFolders, ...jobFolders]
+  return [
+    ...macroCoreFolders,
+    ...macroFolders,
+    ...programFolders,
+    ...serviceFolders,
+    ...jobFolders
+  ]
 }

--- a/src/commands/docs/internal/getFoldersForDocs.ts
+++ b/src/commands/docs/internal/getFoldersForDocs.ts
@@ -4,6 +4,11 @@ import { getConstants } from '../../../constants'
 import { Target } from '@sasjs/utils'
 import { Configuration } from '../../../types/configuration'
 
+/**
+ * Returns list of folders for documentation( macroCore / macros / SAS programs/ services / jobs )
+ * @param {Target | Configuration} config- from which folders list will be extracted
+ * @param {boolean} root- tells if param config is of specific target or not, in case of root level it will add macroCore folder to list conditionally
+ */
 export function getFoldersForDocs(
   config: Target | Configuration,
   root: boolean = false

--- a/src/commands/docs/internal/getFoldersForDocs.ts
+++ b/src/commands/docs/internal/getFoldersForDocs.ts
@@ -4,14 +4,19 @@ import { getConstants } from '../../../constants'
 import { Target } from '@sasjs/utils'
 import { Configuration } from '../../../types/configuration'
 
-export function getFoldersForDocs(config: Target | Configuration) {
+export function getFoldersForDocs(
+  config: Target | Configuration,
+  root: boolean = false
+) {
   const { buildSourceFolder } = getConstants()
-  const macroCoreFolders =
-    'docConfig' in config &&
-    config.docConfig &&
-    config.docConfig.displayMacroCore
-      ? [path.join(process.projectDir, 'node_modules', '@sasjs', 'core')]
-      : []
+  let macroCoreFolders: string[] = []
+  if (root)
+    macroCoreFolders =
+      'docConfig' in config &&
+      config.docConfig &&
+      config.docConfig.displayMacroCore === false
+        ? []
+        : [path.join(process.projectDir, 'node_modules', '@sasjs', 'core')]
   const macroFolders =
     config && config.macroFolders
       ? config.macroFolders.map((f) => path.join(buildSourceFolder, f))

--- a/src/commands/docs/internal/getFoldersForDocs.ts
+++ b/src/commands/docs/internal/getFoldersForDocs.ts
@@ -12,9 +12,7 @@ export function getFoldersForDocs(
   let macroCoreFolders: string[] = []
   if (root)
     macroCoreFolders =
-      'docConfig' in config &&
-      config.docConfig &&
-      config.docConfig.displayMacroCore === false
+      (config as Configuration)?.docConfig?.displayMacroCore === false
         ? []
         : [path.join(process.projectDir, 'node_modules', '@sasjs', 'core')]
   const macroFolders =

--- a/src/commands/docs/internal/getFoldersForDocsAllTargets.ts
+++ b/src/commands/docs/internal/getFoldersForDocsAllTargets.ts
@@ -1,6 +1,10 @@
 import { Configuration } from '../../../types/configuration'
 import { getFoldersForDocs } from './getFoldersForDocs'
 
+/**
+ * Returns list of folders for documentation for all targets
+ * @param {Configuration} config- from which folders list will be extracted
+ */
 export function getFoldersForDocsAllTargets(config: Configuration) {
   const folders: string[] = []
   if (config && config.targets) {

--- a/src/commands/docs/spec/generateDocs.spec.ts
+++ b/src/commands/docs/spec/generateDocs.spec.ts
@@ -82,6 +82,30 @@ describe('sasjs doc', () => {
   )
 
   it(
+    `should generate docs without sasjs/core`,
+    async () => {
+      appName = `test-app-doc-${generateTimestamp()}`
+
+      const docOutputDefault = path.join(
+        __dirname,
+        appName,
+        'sasjsbuild',
+        'docs'
+      )
+
+      await createTestApp(__dirname, appName)
+      await updateConfig({ displayMacroCore: false } as DocConfig)
+
+      await expect(folderExists(docOutputDefault)).resolves.toEqual(false)
+
+      await expect(doc(new Command(`doc`))).resolves.toEqual(0)
+
+      await verifyDocs(docOutputDefault, undefined, false)
+    },
+    60 * 1000
+  )
+
+  it(
     `should generate docs to sasjsconfig.json's outDirectory`,
     async () => {
       appName = `test-app-doc-${generateTimestamp()}`
@@ -147,7 +171,11 @@ const updateConfig = async (docConfig: DocConfig) => {
   await createFile(configPath, JSON.stringify(config, null, 1))
 }
 
-const verifyDocs = async (docsFolder: string, target: string = 'no-target') => {
+const verifyDocs = async (
+  docsFolder: string,
+  target: string = 'no-target',
+  macroCore: boolean = true
+) => {
   const indexHTML = path.join(docsFolder, 'index.html')
   const appInitHTML = path.join(docsFolder, 'appinit_8sas.html')
 
@@ -172,6 +200,8 @@ const verifyDocs = async (docsFolder: string, target: string = 'no-target') => {
     docsFolder,
     'yetanothermacro_8sas_source.html'
   )
+  const macroCoreFile = path.join(docsFolder, 'all_8sas.html')
+  const macroCoreFileSource = path.join(docsFolder, 'all_8sas_source.html')
 
   await expect(folderExists(docsFolder)).resolves.toEqual(true)
 
@@ -196,4 +226,7 @@ const verifyDocs = async (docsFolder: string, target: string = 'no-target') => {
 
   await expect(fileExists(yetAnotherMacro)).resolves.toEqual(true)
   await expect(fileExists(yetAnotherMacroSource)).resolves.toEqual(true)
+
+  await expect(fileExists(macroCoreFile)).resolves.toEqual(macroCore)
+  await expect(fileExists(macroCoreFileSource)).resolves.toEqual(macroCore)
 }

--- a/src/config.json
+++ b/src/config.json
@@ -194,6 +194,9 @@
     }
   ],
   "config": {
+    "docConfig": {
+      "displayMacroCore": true
+    },
     "buildConfig": {
       "initProgram": "build/buildinit.sas",
       "termProgram": "build/buildterm.sas",

--- a/src/config.json
+++ b/src/config.json
@@ -195,7 +195,8 @@
   ],
   "config": {
     "docConfig": {
-      "displayMacroCore": true
+      "displayMacroCore": true,
+      "outDirectory": ""
     },
     "buildConfig": {
       "initProgram": "build/buildinit.sas",

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,11 +69,9 @@ export async function doc(command: Command) {
   const { buildDestinationDocsFolder } = getConstants()
 
   return await generateDocs(targetName, outDirectory)
-    .then(() => {
+    .then((res) => {
       displaySuccess(
-        `Docs have been generated!\nThe docs are located at the '${
-          outDirectory ? outDirectory : buildDestinationDocsFolder
-        }' directory.`
+        `Docs have been generated!\nThe docs are located at the '${res.outDirectory}' directory.`
       )
       return ReturnCode.Success
     })

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,4 +1,5 @@
 import {
+  DocConfig,
   BuildConfig,
   DeployConfig,
   ServiceConfig,
@@ -10,6 +11,7 @@ import { ServerType } from '@sasjs/utils/types/serverType'
 import { Target } from '@sasjs/utils/types/target'
 
 export interface Configuration {
+  docConfig?: DocConfig
   buildConfig?: BuildConfig
   deployConfig?: DeployConfig
   serviceConfig?: ServiceConfig


### PR DESCRIPTION
## Issue

Closes #415 

## Intent

Should document macroCore from `node_modules` conditionally.

## Implementation

Added `DocConfig` to `Configuration` based on it, either @sasjs/core will be added/excluded in `sasjs doc`
 + outDirectory can also be mentioned in `DocConfig`, but command line param has precedence.
 
## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
