### PR TITLE
fix: process.projectDir needed for other commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,13 +46,9 @@ export async function cli(args: string[]) {
 
       break
     case 'compile':
-      break
     case 'build':
-      break
     case 'db':
-      break
     case 'compilebuild':
-      break
     case 'compilebuilddeploy':
     case 'deploy':
     case 'web':


### PR DESCRIPTION
## Issue

`sasjs compile` is not working

## Intent

Found issue is due to `process.projectDir` was not set, behavior was changed in [PR](https://github.com/sasjs/cli/pull/453/files)

## Implementation

Updated `cli.js` only

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
