### PR TITLE
fix: appLoc finder with comment

### DIFF
--- a/src/commands/web/sasjsout.ts
+++ b/src/commands/web/sasjsout.ts
@@ -58,7 +58,8 @@ export const sasjsout = `%macro sasjsout(type,fref=sasjs);
     input;
     if find(_infile_,' appLoc: ') then do;
       pgm="&_program";
-      rootlen=length(trim(pgm))-length(scan(pgm,-2,'/'))-1;
+      /* index is deployed in the /services/ folder under the appLoc */
+      rootlen=length(trim(pgm))-length(scan(pgm,-1,'/'))-10;
       root=quote(substr(pgm,1,rootlen));
       put '    appLoc: ' root ',';
     end;


### PR DESCRIPTION
## Issue

For streaming apps the "clickme" (or whichever name is configured in the [streamConfig](https://cli.sasjs.io/sasjsconfig.html#targets_items_anyOf_i0_streamConfig) is deployed under the services subfolder.

We can use this to auto-detect the appLoc by reference to the _program variable.

This commit fixes the fix that was supposed to address the move from appLoc/{clickme} to /apploc/services/{clickme}

