### PR TITLE
fix(docs): escaping param and prevent from executing command

### DIFF
--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -75,7 +75,8 @@ export async function generateDocs(targetName: string, outDirectory: string) {
     try {
       const packageJson = JSON.parse(packageJsonContent)
       PROJECT_NAME = packageJson.name || PROJECT_NAME
-      PROJECT_BRIEF = packageJson.description || PROJECT_BRIEF
+      PROJECT_BRIEF =
+        packageJson.description.replace(/`/g, '\\`') || PROJECT_BRIEF
     } catch (e) {
       process.logger?.info(`Unable to parse content of 'package.json'`)
     }


### PR DESCRIPTION
## Issue

docs header is not populating well with project's description

## Intent

For template jobs, we having following description
- "description": "The template used by SASjs when running `sasjs create myProject -t jobs`",

While passing description to doxygen-cli, it executes `sasjs create myProject -t jobs`.

Escaped description string and prevent execution

## Implementation

What code changes have been made to achieve the intent.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
