### PR TITLE
halt on missing sas program + init/term support for programs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1515,9 +1515,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.2.0.tgz",
-      "integrity": "sha512-+EVbR6Ih7XI99uvWZUVCuiHuxmhp8C//DC0MAErmuAONSQLWr1NQrAPOBqGn6s5xJwgJEyo7dPO2vCHZD3h/1g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.2.1.tgz",
+      "integrity": "sha512-adZg5WKhxg5OU+OtDC9afAa41fc+mKbR5aIurKwgNO310zshtXum9KBRzZsnt95/OO2Res1ujlwLBNCPvUEHyw==",
       "requires": {
         "@sasjs/utils": "^2.5.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "^2.2.0",
+    "@sasjs/adapter": "^2.2.1",
     "@sasjs/core": "^2.9.3",
     "@sasjs/utils": "^2.5.1",
     "btoa": "^1.2.1",

--- a/src/commands/compile/internal/loadDependencies.ts
+++ b/src/commands/compile/internal/loadDependencies.ts
@@ -77,6 +77,18 @@ export async function loadDependencies(
     ...fileDependencyPaths,
     ...termDependencyPaths
   ]
+
+  const initProgramDependencies = await getProgramDependencies(
+    init,
+    programFolders,
+    buildSourceFolder
+  )
+  const termProgramDependencies = await getProgramDependencies(
+    term,
+    programFolders,
+    buildSourceFolder
+  )
+
   const programDependencies = await getProgramDependencies(
     fileContent,
     programFolders,
@@ -85,7 +97,7 @@ export async function loadDependencies(
 
   const dependenciesContent = await getDependencies(allDependencyPaths)
 
-  fileContent = `* Dependencies start;\n${dependenciesContent}\n* Dependencies end;\n* Programs start;\n${programDependencies}\n*Programs end;${init}${fileContent}${term}`
+  fileContent = `* Dependencies start;\n${initProgramDependencies}\n${termProgramDependencies}\n${dependenciesContent}\n* Dependencies end;\n* Programs start;\n${programDependencies}\n*Programs end;${init}${fileContent}${term}`
 
   if (type === 'service') {
     fileContent = `* Service Variables start;\n${serviceVars}\n*Service Variables end;\n${fileContent}`

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -46,6 +46,27 @@ describe('sasjs compile', () => {
     done()
   })
 
+  it('should fail to compile for missing program file', async (done) => {
+    let newTarget = {
+      ...target,
+      serviceConfig: {
+        serviceFolders: ['../services']
+      }
+    } as Target
+
+    const errorMessage =
+      'The following files were listed under SAS Programs but could not be found:\n' +
+      "1. 'doesnotexist.sas' with fileRef 'SOMEREF'\n" +
+      'Please check that they exist in the folder(s) listed in the `programFolders` array in your sasjsconfig.json file.\n' +
+      'Program Folders:\n' +
+      '- sasjs/programs'
+    await expect(compileModule.compile(newTarget)).rejects.toThrow(errorMessage)
+    expect(compileModule.copyFilesToBuildFolder).toHaveBeenCalled()
+    expect(compileModule.compileJobsAndServices).toHaveBeenCalled()
+
+    done()
+  })
+
   it('should skip compilation if a project is already compiled', async (done) => {
     await expect(compileModule.compile(target)).toResolve()
     expect(compileModule.copyFilesToBuildFolder).toHaveBeenCalled()

--- a/src/commands/compile/spec/services/example.sas
+++ b/src/commands/compile/spec/services/example.sas
@@ -1,0 +1,23 @@
+/**
+  @file example.sas
+  @brief example service - for example 
+  @details  This is a longer description.
+
+  <h4> SAS Macros </h4>
+  @li mf_nobs.sas
+  @li examplemacro.sas
+  @li yetanothermacro.sas
+  
+  <h4> SAS Programs </h4>
+  @li doesnotexist.sas SOMEREF
+
+**/
+
+%put %mf_nobs(sashelp.class);
+
+%examplemacro()
+%yetanothermacro()
+
+%webout(OPEN)
+%webout(OBJ,areas)
+%webout(CLOSE)

--- a/src/commands/shared/dependencies.ts
+++ b/src/commands/shared/dependencies.ts
@@ -161,10 +161,13 @@ export async function getProgramDependencies(
         )
         .join('\n')
 
-      process.logger
-        ?.warn(`The following files were listed under SAS Programs but could not be found:
-${programList}
-Please check that they exist in the folder(s) listed in the \`programFolders\` array in your sasjsconfig.json file.\n`)
+      throw new Error(
+        `The following files were listed under SAS Programs but could not be found:\n` +
+          `${programList}\n` +
+          `Please check that they exist in the folder(s) listed in the \`programFolders\` array in your sasjsconfig.json file.\n` +
+          `Program Folders:\n` +
+          programFolders.map((pf) => `- ${pf}`).join('\n')
+      )
     }
 
     return foundPrograms.join('\n')


### PR DESCRIPTION
## Issue

1. Closes #439 
2. Closes #434 

## Intent

1. Instead of showing warning, show error and stop execution
2. get program dependencies from init/term for job/service and add to all jobs/services

## Implementation

1. Logger's warning turned into Error. also displaying `programFolders` in bullet list
2. Extracted `init`/`term` for `job`/`service` same way as currently for `job`/`service`, and place at the start of dependencies section.

Applicable to below files
- jobInit
- jobTerm
- serviceInit
- serviceTerm

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
