### PR TITLE
feat(compile): compile single job/service

### DIFF
--- a/src/commands/build/internal/config.ts
+++ b/src/commands/build/internal/config.ts
@@ -7,21 +7,21 @@ import { readFile } from '../../../utils/file'
 export const getBuildInit = async (target: Target) => {
   const { buildSourceFolder } = getConstants()
   let buildInitContent = ''
-  if (target && target.buildConfig && target.buildConfig.initProgram) {
+  if (target?.buildConfig?.initProgram) {
     buildInitContent = await readFile(
-      path.join(buildSourceFolder, target.buildConfig.initProgram)
+      path.isAbsolute(target.buildConfig.initProgram)
+        ? target.buildConfig.initProgram
+        : path.join(buildSourceFolder, target.buildConfig.initProgram)
     )
   } else {
     const configuration = await getConfiguration(
       path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
     )
-    if (
-      configuration &&
-      configuration.buildConfig &&
-      configuration.buildConfig.initProgram
-    ) {
+    if (configuration?.buildConfig?.initProgram) {
       buildInitContent = await readFile(
-        path.join(buildSourceFolder, configuration.buildConfig.initProgram)
+        path.isAbsolute(configuration.buildConfig.initProgram)
+          ? configuration.buildConfig.initProgram
+          : path.join(buildSourceFolder, configuration.buildConfig.initProgram)
       )
     }
   }
@@ -34,21 +34,21 @@ export const getBuildInit = async (target: Target) => {
 export const getBuildTerm = async (target: Target) => {
   const { buildSourceFolder } = getConstants()
   let buildTermContent = ''
-  if (target && target.buildConfig && target.buildConfig.termProgram) {
+  if (target?.buildConfig?.termProgram) {
     buildTermContent = await readFile(
-      path.join(buildSourceFolder, target.buildConfig.termProgram)
+      path.isAbsolute(target.buildConfig.termProgram)
+        ? target.buildConfig.termProgram
+        : path.join(buildSourceFolder, target.buildConfig.termProgram)
     )
   } else {
     const configuration = await getConfiguration(
       path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
     )
-    if (
-      configuration &&
-      configuration.buildConfig &&
-      configuration.buildConfig.termProgram
-    ) {
+    if (configuration?.buildConfig?.termProgram) {
       buildTermContent = await readFile(
-        path.join(buildSourceFolder, configuration.buildConfig.termProgram)
+        path.isAbsolute(configuration.buildConfig.termProgram)
+          ? configuration.buildConfig.termProgram
+          : path.join(buildSourceFolder, configuration.buildConfig.termProgram)
       )
     }
   }

--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -52,13 +52,17 @@ export async function copyFilesToBuildFolder(target: Target) {
     const jobFolders = await getAllJobFolders(target)
 
     await asyncForEach(serviceFolders, async (serviceFolder: string) => {
-      const sourcePath = path.join(buildSourceFolder, serviceFolder)
+      const sourcePath = path.isAbsolute(serviceFolder)
+        ? serviceFolder
+        : path.join(buildSourceFolder, serviceFolder)
       const destinationPath = getDestinationServicePath(sourcePath)
       await copy(sourcePath, destinationPath)
     })
 
     await asyncForEach(jobFolders, async (jobFolder) => {
-      const sourcePath = path.join(buildSourceFolder, jobFolder)
+      const sourcePath = path.isAbsolute(jobFolder)
+        ? jobFolder
+        : path.join(buildSourceFolder, jobFolder)
       const destinationPath = getDestinationJobPath(sourcePath)
       await copy(sourcePath, destinationPath)
     })
@@ -115,7 +119,9 @@ const compileServiceFolder = async (
   programFolders: string[]
 ) => {
   const { buildSourceFolder } = getConstants()
-  const folderPath = path.join(buildSourceFolder, serviceFolder)
+  const folderPath = path.isAbsolute(serviceFolder)
+    ? serviceFolder
+    : path.join(buildSourceFolder, serviceFolder)
   const destinationPath = getDestinationServicePath(folderPath)
   const subFolders = await getSubFoldersInFolder(destinationPath)
   const filesNamesInPath = await getFilesInFolder(destinationPath)
@@ -144,7 +150,9 @@ const compileJobFolder = async (
   programFolders: string[]
 ) => {
   const { buildSourceFolder } = getConstants()
-  const folderPath = path.join(buildSourceFolder, jobFolder)
+  const folderPath = path.isAbsolute(jobFolder)
+    ? jobFolder
+    : path.join(buildSourceFolder, jobFolder)
   const destinationPath = getDestinationJobPath(folderPath)
   const subFolders = await getSubFoldersInFolder(destinationPath)
   const filesNamesInPath = await getFilesInFolder(destinationPath)

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -36,8 +36,12 @@ export async function compileSingleFile(
     throw new Error(`Provide a path to source file (eg '${commandExample}')`)
   }
 
-  const sourcePath = path.resolve(process.projectDir, source)
-  const outputPath = path.resolve(process.projectDir, output ?? './sasjsbuild')
+  const sourcePath = path.isAbsolute(source)
+    ? source
+    : path.join(process.projectDir, source)
+  const outputPath = path.isAbsolute(output)
+    ? output
+    : path.join(process.projectDir, output ?? './sasjsbuild')
 
   process.logger?.info(`Compiling source file:\n- ${sourcePath}`)
 

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -78,7 +78,7 @@ export async function compileSingleFile(
 async function validateSourcePath(path: string) {
   if (!path) return false
 
-  const isSourceFile = /\.sas/i.test(path)
+  const isSourceFile = /\.sas$/i.test(path)
 
   if (!isSourceFile) return false
 

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -36,8 +36,8 @@ export async function compileSingleFile(
     throw new Error(`Provide a path to source file (eg '${commandExample}')`)
   }
 
-  const sourcePath = path.join(process.cwd(), source)
-  const outputPath = output ?? './sasjsbuild'
+  const sourcePath = path.resolve(process.projectDir, source)
+  const outputPath = path.resolve(process.projectDir, output ?? './sasjsbuild')
 
   process.logger?.info(`Compiling source file:\n- ${sourcePath}`)
 
@@ -45,7 +45,7 @@ export async function compileSingleFile(
   await createFolder(outputPath)
 
   const sourceFileName = sourcePath.split(path.sep).pop() as string
-  const destinationPath = path.join(process.cwd(), outputPath, sourceFileName)
+  const destinationPath = path.join(outputPath, sourceFileName)
   await copy(sourcePath, destinationPath)
 
   const macroFolders = target ? target.macroFolders : []
@@ -61,13 +61,13 @@ export async function compileSingleFile(
       )
       break
     case subCommands.job:
-      break
       await compileJobFile(
         target,
         destinationPath,
         macroFolders,
         programFolders
       )
+      break
     default:
       break
   }

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -1,0 +1,86 @@
+import path from 'path'
+import { getProgramFolders } from '../../utils/config'
+import { copy, fileExists, deleteFolder, createFolder } from '../../utils/file'
+import { Target } from '@sasjs/utils/types'
+import { compileServiceFile } from './internal/compileServiceFile'
+import { compileJobFile } from './internal/compileJobFile'
+import { Command } from '../../utils/command'
+
+export async function compileSingleFile(
+  target: Target,
+  command: Command,
+  subCommand: string
+) {
+  const subCommands = {
+    job: 'job',
+    service: 'service'
+  }
+
+  if (!subCommands.hasOwnProperty(subCommand)) {
+    throw new Error(
+      `Unsupported context command. Supported commands are:\n${Object.keys(
+        subCommands
+      ).join('\n')}`
+    )
+  }
+
+  const commandExample =
+    'sasjs compile <command> --source myjob.sas --target targetName -output /some/folder'
+
+  const source = command.getFlagValue('source') as string
+  const output = command.getFlagValue('output') as string
+
+  if (!source) {
+    throw new Error(`'--source' flag is missing (eg '${commandExample}')`)
+  } else if (!(await validateSourcePath(source))) {
+    throw new Error(`Provide a path to source file (eg '${commandExample}')`)
+  }
+
+  const sourcePath = path.join(process.cwd(), source)
+  const outputPath = output ?? './sasjsbuild'
+
+  process.logger?.info(`Compiling source file:\n- ${sourcePath}`)
+
+  await deleteFolder(outputPath)
+  await createFolder(outputPath)
+
+  const sourceFileName = sourcePath.split(path.sep).pop() as string
+  const destinationPath = path.join(process.cwd(), outputPath, sourceFileName)
+  await copy(sourcePath, destinationPath)
+
+  const macroFolders = target ? target.macroFolders : []
+  const programFolders = await getProgramFolders(target)
+
+  switch (subCommand) {
+    case subCommands.service:
+      await compileServiceFile(
+        target,
+        destinationPath,
+        macroFolders,
+        programFolders
+      )
+      break
+    case subCommands.job:
+      break
+      await compileJobFile(
+        target,
+        destinationPath,
+        macroFolders,
+        programFolders
+      )
+    default:
+      break
+  }
+
+  return { destinationPath }
+}
+
+async function validateSourcePath(path: string) {
+  if (!path) return false
+
+  const isSourceFile = /\.sas/i.test(path)
+
+  if (!isSourceFile) return false
+
+  return await fileExists(path)
+}

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -32,16 +32,21 @@ export async function compileSingleFile(
 
   if (!source) {
     throw new Error(`'--source' flag is missing (eg '${commandExample}')`)
-  } else if (!(await validateSourcePath(source))) {
-    throw new Error(`Provide a path to source file (eg '${commandExample}')`)
   }
 
   const sourcePath = path.isAbsolute(source)
     ? source
     : path.join(process.projectDir, source)
-  const outputPath = path.isAbsolute(output)
-    ? output
-    : path.join(process.projectDir, output ?? './sasjsbuild')
+
+  if (!(await validateSourcePath(sourcePath))) {
+    throw new Error(`Provide a path to source file (eg '${commandExample}')`)
+  }
+
+  const outputPath = output
+    ? path.isAbsolute(output)
+      ? output
+      : path.join(process.projectDir, output)
+    : path.join(process.projectDir, './sasjsbuild')
 
   process.logger?.info(`Compiling source file:\n- ${sourcePath}`)
 

--- a/src/commands/compile/internal/checkCompileStatus.ts
+++ b/src/commands/compile/internal/checkCompileStatus.ts
@@ -55,7 +55,9 @@ const checkServiceFolders = async (target: Target) => {
   let areServiceFoldersMatching = true
   const reasons: string[] = []
   await asyncForEach(serviceFolders, async (serviceFolder) => {
-    const sourcePath = path.join(buildSourceFolder, serviceFolder)
+    const sourcePath = path.isAbsolute(serviceFolder)
+      ? serviceFolder
+      : path.join(buildSourceFolder, serviceFolder)
     const destinationPath = getDestinationServicePath(sourcePath)
 
     const { equal, reason } = await compareFolders(sourcePath, destinationPath)
@@ -80,7 +82,9 @@ const checkJobFolders = async (target: Target) => {
   let areJobFoldersMatching = true
   const reasons: string[] = []
   await asyncForEach(jobFolders, async (jobFolder) => {
-    const sourcePath = path.join(buildSourceFolder, jobFolder)
+    const sourcePath = path.isAbsolute(jobFolder)
+      ? jobFolder
+      : path.join(buildSourceFolder, jobFolder)
     const destinationPath = getDestinationJobPath(sourcePath)
 
     const { equal, reason } = await compareFolders(sourcePath, destinationPath)

--- a/src/commands/compile/internal/compileJobFile.ts
+++ b/src/commands/compile/internal/compileJobFile.ts
@@ -1,0 +1,22 @@
+import path from 'path'
+import { Target } from '@sasjs/utils/types'
+
+import { createFile } from '../../../utils/file'
+import { loadDependencies } from './loadDependencies'
+
+export async function compileJobFile(
+  target: Target,
+  filePath: string,
+  macroFolders: string[],
+  programFolders: string[],
+) {
+  const dependencies = await loadDependencies(
+    target,
+    filePath,
+    macroFolders,
+    programFolders,
+    'job'
+  )
+  
+  await createFile(filePath, dependencies)
+}

--- a/src/commands/compile/internal/compileJobFile.ts
+++ b/src/commands/compile/internal/compileJobFile.ts
@@ -8,7 +8,7 @@ export async function compileJobFile(
   target: Target,
   filePath: string,
   macroFolders: string[],
-  programFolders: string[],
+  programFolders: string[]
 ) {
   const dependencies = await loadDependencies(
     target,
@@ -17,6 +17,6 @@ export async function compileJobFile(
     programFolders,
     'job'
   )
-  
+
   await createFile(filePath, dependencies)
 }

--- a/src/commands/compile/internal/compileServiceFile.ts
+++ b/src/commands/compile/internal/compileServiceFile.ts
@@ -1,0 +1,69 @@
+import path from 'path'
+import { Target, ServerType } from '@sasjs/utils/types'
+
+import { getMacroCorePath } from '../../../utils/config'
+import { createFile, readFile } from '../../../utils/file'
+import { loadDependencies } from './loadDependencies'
+import { getServerType } from './getServerType'
+
+export async function compileServiceFile(
+  target: Target,
+  filePath: string,
+  macroFolders: string[],
+  programFolders: string[]
+) {
+  let dependencies = await loadDependencies(
+    target,
+    filePath,
+    macroFolders,
+    programFolders
+  )
+
+  const serverType = await getServerType(target)
+  const preCode = await getPreCodeForServicePack(serverType)
+
+  dependencies = `${preCode}\n${dependencies}`
+
+  if (dependencies) await createFile(filePath, dependencies)
+}
+
+async function getPreCodeForServicePack(serverType: ServerType) {
+  let content = ''
+  const macroCorePath = getMacroCorePath()
+  switch (serverType) {
+    case ServerType.SasViya:
+      content += await readFile(`${macroCorePath}/base/mf_getuser.sas`)
+      content += await readFile(`${macroCorePath}/base/mp_jsonout.sas`)
+      content += await readFile(`${macroCorePath}/viya/mv_webout.sas`)
+      content +=
+        '/* if calling viya service with _job param, _program will conflict */\n' +
+        '/* so we provide instead as __program */\n' +
+        '%global __program _program;\n' +
+        '%let _program=%sysfunc(coalescec(&__program,&_program));\n' +
+        '%macro webout(action,ds,dslabel=,fmt=);\n' +
+        '%mv_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt)\n' +
+        '%mend;\n'
+      break
+
+    case ServerType.Sas9:
+      content += await readFile(`${macroCorePath}/base/mf_getuser.sas`)
+      content += await readFile(`${macroCorePath}/base/mp_jsonout.sas`)
+      content += await readFile(`${macroCorePath}/meta/mm_webout.sas`)
+      content +=
+        '  %macro webout(action,ds,dslabel=,fmt=);\n' +
+        '    %mm_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt)\n' +
+        '  %mend;\n'
+      break
+
+    default:
+      throw new Error(
+        `Invalid server type: valid options are 'SASVIYA' and 'SAS9'.`
+      )
+  }
+  content +=
+    '/* provide additional debug info */\n' +
+    '%put user=%mf_getuser();\n' +
+    '%put pgm=&_program;\n' +
+    '%put timestamp=%sysfunc(datetime(),datetime19.);\n'
+  return content
+}

--- a/src/commands/compile/internal/compileServiceFile.ts
+++ b/src/commands/compile/internal/compileServiceFile.ts
@@ -24,7 +24,7 @@ export async function compileServiceFile(
 
   dependencies = `${preCode}\n${dependencies}`
 
-  if (dependencies) await createFile(filePath, dependencies)
+  await createFile(filePath, dependencies)
 }
 
 async function getPreCodeForServicePack(serverType: ServerType) {

--- a/src/commands/compile/internal/config.ts
+++ b/src/commands/compile/internal/config.ts
@@ -9,7 +9,9 @@ export const getServiceInit = async (target: Target) => {
   let serviceInitContent = ''
   if (target?.serviceConfig?.initProgram) {
     serviceInitContent = await readFile(
-      path.join(buildSourceFolder, target.serviceConfig.initProgram)
+      path.isAbsolute(target.serviceConfig.initProgram)
+        ? target.serviceConfig.initProgram
+        : path.join(buildSourceFolder, target.serviceConfig.initProgram)
     )
   } else {
     const configuration = await getConfiguration(
@@ -17,7 +19,12 @@ export const getServiceInit = async (target: Target) => {
     )
     if (configuration?.serviceConfig?.initProgram) {
       serviceInitContent = await readFile(
-        path.join(buildSourceFolder, configuration.serviceConfig.initProgram)
+        path.isAbsolute(configuration.serviceConfig.initProgram)
+          ? configuration.serviceConfig.initProgram
+          : path.join(
+              buildSourceFolder,
+              configuration.serviceConfig.initProgram
+            )
       )
     }
   }
@@ -32,7 +39,9 @@ export const getServiceTerm = async (target: Target) => {
   let serviceTermContent = ''
   if (target?.serviceConfig?.termProgram) {
     serviceTermContent = await readFile(
-      path.join(buildSourceFolder, target.serviceConfig.termProgram)
+      path.isAbsolute(target.serviceConfig.termProgram)
+        ? target.serviceConfig.termProgram
+        : path.join(buildSourceFolder, target.serviceConfig.termProgram)
     )
   } else {
     const configuration = await getConfiguration(
@@ -40,7 +49,12 @@ export const getServiceTerm = async (target: Target) => {
     )
     if (configuration?.serviceConfig?.termProgram) {
       serviceTermContent = await readFile(
-        path.join(buildSourceFolder, configuration.serviceConfig.termProgram)
+        path.isAbsolute(configuration.serviceConfig.termProgram)
+          ? configuration.serviceConfig.termProgram
+          : path.join(
+              buildSourceFolder,
+              configuration.serviceConfig.termProgram
+            )
       )
     }
   }
@@ -55,7 +69,9 @@ export const getJobInit = async (target: Target) => {
   let jobInitContent = ''
   if (target?.jobConfig?.initProgram) {
     jobInitContent = await readFile(
-      path.join(buildSourceFolder, target.jobConfig.initProgram)
+      path.isAbsolute(target.jobConfig.initProgram)
+        ? target.jobConfig.initProgram
+        : path.join(buildSourceFolder, target.jobConfig.initProgram)
     )
   } else {
     const configuration = await getConfiguration(
@@ -63,7 +79,9 @@ export const getJobInit = async (target: Target) => {
     )
     if (configuration?.jobConfig?.initProgram) {
       jobInitContent = await readFile(
-        path.join(buildSourceFolder, configuration.jobConfig.initProgram)
+        path.isAbsolute(configuration.jobConfig.initProgram)
+          ? configuration.jobConfig.initProgram
+          : path.join(buildSourceFolder, configuration.jobConfig.initProgram)
       )
     }
   }
@@ -78,7 +96,9 @@ export const getJobTerm = async (target: Target) => {
   let jobTermContent = ''
   if (target?.jobConfig?.termProgram) {
     jobTermContent = await readFile(
-      path.join(buildSourceFolder, target.jobConfig.termProgram)
+      path.isAbsolute(target.jobConfig.termProgram)
+        ? target.jobConfig.termProgram
+        : path.join(buildSourceFolder, target.jobConfig.termProgram)
     )
   } else {
     const configuration = await getConfiguration(
@@ -86,7 +106,9 @@ export const getJobTerm = async (target: Target) => {
     )
     if (configuration?.jobConfig?.termProgram) {
       jobTermContent = await readFile(
-        path.join(buildSourceFolder, configuration.jobConfig.termProgram)
+        path.isAbsolute(configuration.jobConfig.termProgram)
+          ? configuration.jobConfig.termProgram
+          : path.join(buildSourceFolder, configuration.jobConfig.termProgram)
       )
     }
   }

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -110,6 +110,19 @@ describe('sasjs compile single file', () => {
       await expect(
         compileSingleFile(
           target,
+          new Command(`compile job -s ./jobs/extract/makedata1.sas`),
+          'job'
+        )
+      ).toResolve()
+      expect(compileJobFile.compileJobFile).toHaveBeenCalled()
+
+      done()
+    })
+
+    it('should compile single file with absolute path', async (done) => {
+      await expect(
+        compileSingleFile(
+          target,
           new Command(
             `compile job -s ${process.projectDir}/jobs/extract/makedata1.sas`
           ),
@@ -131,6 +144,18 @@ describe('sasjs compile single file', () => {
     })
 
     it('should compile single file', async (done) => {
+      await expect(
+        compileSingleFile(
+          target,
+          new Command(`compile service -s sasjs/services/common/example.sas`),
+          'service'
+        )
+      ).toResolve()
+      expect(compileServiceFile.compileServiceFile).toHaveBeenCalled()
+
+      done()
+    })
+    it('should compile single file with absolute path', async (done) => {
       await expect(
         compileSingleFile(
           target,

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -87,7 +87,7 @@ describe('sasjs compile', () => {
   })
 })
 
-describe('sasjs compile', () => {
+describe('sasjs compile single file', () => {
   let appName: string
   let target: Target
 

--- a/src/commands/compile/spec/compileJobFile.spec.ts
+++ b/src/commands/compile/spec/compileJobFile.spec.ts
@@ -1,0 +1,112 @@
+import path from 'path'
+import { Target } from '@sasjs/utils/types'
+import * as internalModule from '../internal/config'
+import * as compileModule from '../compile'
+import { removeFromGlobalConfig } from '../../../utils/config'
+import {
+  createTestGlobalTarget,
+  createTestMinimalApp,
+  removeTestApp
+} from '../../../utils/test'
+import { generateTimestamp } from '../../../utils/utils'
+import { compileJobFile } from '../internal/compileJobFile'
+import { copy, fileExists, createFolder, readFile } from '../../../utils/file'
+
+const fakeJobInit = `/**
+  @file
+  @brief This code is inserted into the beginning of each Viya Job.
+  @details Inserted during the \`sasjs compile\` step.  Add any code here that
+  should go at the beginning of every deployed job.
+
+  The path to this file should be listed in the \`jobInit\` property of the
+  sasjsconfig file.
+
+  <h4> SAS Programs </h4>
+  @li test.sas TEST
+
+  <h4> SAS Macros </h4>
+  @li example.sas
+
+**/
+
+%example(Job Init is executing!)
+
+%let mylib=WORK;`
+
+const fakeJobTerm = `/**
+  @file serviceterm.sas
+  @brief this file is called at the end of every service
+  @details  This file is included at the *end* of every service.
+
+  <h4> SAS Macros </h4>
+  @li mf_abort.sas
+  @li mf_existds.sas
+
+**/
+
+%put service is finishing.  Thanks, SASjs!;`
+
+const fakeProgramLines = [
+  'filename TEST temp;',
+  'data _null_;',
+  'file TEST lrecl=32767;',
+  "put '%put ''Hello, world!'';';",
+  'run;'
+]
+
+describe('compileJobFile', () => {
+  let target: Target
+
+  beforeAll(async () => {
+    const appName = `cli-tests-compile-job-file-${generateTimestamp()}`
+    target = await createTestGlobalTarget(appName, '/Public/app')
+    await createTestMinimalApp(__dirname, target.name)
+  })
+
+  afterAll(async (done) => {
+    await removeFromGlobalConfig(target.name)
+    await removeTestApp(__dirname, target.name)
+    done()
+  })
+
+  test('it should compile and create file', async (done) => {
+    spyOn(internalModule, 'getJobInit').and.returnValue(
+      `\n* JobInit start;\n${fakeJobInit}\n* JobInit end;`
+    )
+    spyOn(internalModule, 'getJobTerm').and.returnValue(
+      `\n* JobTerm start;\n${fakeJobTerm}\n* JobTerm end;`
+    )
+
+    const filePath = path.join(__dirname, './service.sas')
+    const buildPath = path.join(process.projectDir, 'sasjsbuild-test')
+    const destinationPath = path.join(buildPath, 'service.sas')
+
+    await createFolder(buildPath)
+
+    await copy(filePath, destinationPath)
+
+    await expect(
+      compileJobFile(
+        target,
+        destinationPath,
+        [],
+        ['../', '../services']
+      )
+    ).toResolve()
+
+    const compiledContent = await readFile(destinationPath)
+
+    expect(/\* JobInit start;/.test(compiledContent)).toEqual(true)
+    expect(/\* JobInit end;/.test(compiledContent)).toEqual(true)
+    expect(/\* JobTerm start;/.test(compiledContent)).toEqual(true)
+    expect(/\* JobTerm end;/.test(compiledContent)).toEqual(true)
+    expect(/%macro mf_abort/.test(compiledContent)).toEqual(true)
+    expect(/%macro mf_existds/.test(compiledContent)).toEqual(true)
+
+    expect(compiledContent).toEqual(
+      expect.stringContaining(fakeProgramLines.join('\n'))
+    )
+
+    done()
+  })
+})

--- a/src/commands/compile/spec/compileJobFile.spec.ts
+++ b/src/commands/compile/spec/compileJobFile.spec.ts
@@ -78,7 +78,7 @@ describe('compileJobFile', () => {
     )
 
     const filePath = path.join(__dirname, './service.sas')
-    const buildPath = path.join(process.projectDir, 'sasjsbuild-test')
+    const buildPath = path.join(process.projectDir, 'sasjsbuild')
     const destinationPath = path.join(buildPath, 'service.sas')
 
     await createFolder(buildPath)

--- a/src/commands/compile/spec/compileJobFile.spec.ts
+++ b/src/commands/compile/spec/compileJobFile.spec.ts
@@ -70,12 +70,14 @@ describe('compileJobFile', () => {
   })
 
   test('it should compile and create file', async (done) => {
-    spyOn(internalModule, 'getJobInit').and.returnValue(
-      `\n* JobInit start;\n${fakeJobInit}\n* JobInit end;`
-    )
-    spyOn(internalModule, 'getJobTerm').and.returnValue(
-      `\n* JobTerm start;\n${fakeJobTerm}\n* JobTerm end;`
-    )
+    spyOn(internalModule, 'getJobInit').and.returnValue({
+      content: `\n* JobInit start;\n${fakeJobInit}\n* JobInit end;`,
+      filepath: ''
+    })
+    spyOn(internalModule, 'getJobTerm').and.returnValue({
+      content: `\n* JobTerm start;\n${fakeJobTerm}\n* JobTerm end;`,
+      filepath: ''
+    })
 
     const filePath = path.join(__dirname, './service.sas')
     const buildPath = path.join(process.projectDir, 'sasjsbuild')

--- a/src/commands/compile/spec/compileJobFile.spec.ts
+++ b/src/commands/compile/spec/compileJobFile.spec.ts
@@ -86,12 +86,7 @@ describe('compileJobFile', () => {
     await copy(filePath, destinationPath)
 
     await expect(
-      compileJobFile(
-        target,
-        destinationPath,
-        [],
-        ['../', '../services']
-      )
+      compileJobFile(target, destinationPath, [], ['../', '../services'])
     ).toResolve()
 
     const compiledContent = await readFile(destinationPath)

--- a/src/commands/compile/spec/compileServiceFile.spec.ts
+++ b/src/commands/compile/spec/compileServiceFile.spec.ts
@@ -81,7 +81,7 @@ describe('compileServiceFile', () => {
     )
 
     const filePath = path.join(__dirname, './service.sas')
-    const buildPath = path.join(process.projectDir, 'sasjsbuild-test')
+    const buildPath = path.join(process.projectDir, 'sasjsbuild')
     const destinationPath = path.join(buildPath, 'service.sas')
 
     await createFolder(buildPath)

--- a/src/commands/compile/spec/compileServiceFile.spec.ts
+++ b/src/commands/compile/spec/compileServiceFile.spec.ts
@@ -1,0 +1,111 @@
+import path from 'path'
+import { Target } from '@sasjs/utils/types'
+import * as internalModule from '../internal/config'
+import * as compileModule from '../compile'
+import { removeFromGlobalConfig } from '../../../utils/config'
+import {
+  createTestGlobalTarget,
+  createTestMinimalApp,
+  removeTestApp
+} from '../../../utils/test'
+import { generateTimestamp } from '../../../utils/utils'
+import { compileServiceFile } from '../internal/compileServiceFile'
+import { copy, fileExists, createFolder, readFile } from '../../../utils/file'
+
+const fakeJobInit = `/**
+  @file
+  @brief This code is inserted into the beginning of each Viya Job.
+  @details Inserted during the \`sasjs compile\` step.  Add any code here that
+  should go at the beginning of every deployed job.
+
+  The path to this file should be listed in the \`jobInit\` property of the
+  sasjsconfig file.
+
+  <h4> SAS Programs </h4>
+  @li test.sas TEST
+
+  <h4> SAS Macros </h4>
+  @li example.sas
+
+**/
+
+%example(Job Init is executing!)
+
+%let mylib=WORK;`
+
+const fakeJobTerm = `/**
+  @file serviceterm.sas
+  @brief this file is called at the end of every service
+  @details  This file is included at the *end* of every service.
+
+  <h4> SAS Macros </h4>
+  @li mf_abort.sas
+  @li mf_existds.sas
+
+**/
+
+%put service is finishing.  Thanks, SASjs!;`
+
+const fakeProgramLines = [
+  'filename TEST temp;',
+  'data _null_;',
+  'file TEST lrecl=32767;',
+  "put '%put ''Hello, world!'';';",
+  'run;'
+]
+
+const preCode =
+  '/* provide additional debug info */\n%put user=%mf_getuser();\n%put pgm=&_program;\n%put timestamp=%sysfunc(datetime(),datetime19.);\n'
+
+describe('compileServiceFile', () => {
+  let target: Target
+
+  beforeAll(async () => {
+    const appName = `cli-tests-compile-service-file-${generateTimestamp()}`
+    target = await createTestGlobalTarget(appName, '/Public/app')
+    await createTestMinimalApp(__dirname, target.name)
+  })
+
+  afterAll(async (done) => {
+    await removeFromGlobalConfig(target.name)
+    await removeTestApp(__dirname, target.name)
+    done()
+  })
+
+  test('it should compile and create file', async (done) => {
+    spyOn(internalModule, 'getServiceInit').and.returnValue(
+      `\n* ServiceInit start;\n${fakeJobInit}\n* ServiceInit end;`
+    )
+    spyOn(internalModule, 'getServiceTerm').and.returnValue(
+      `\n* ServiceTerm start;\n${fakeJobTerm}\n* ServiceTerm end;`
+    )
+
+    const filePath = path.join(__dirname, './service.sas')
+    const buildPath = path.join(process.projectDir, 'sasjsbuild-test')
+    const destinationPath = path.join(buildPath, 'service.sas')
+
+    await createFolder(buildPath)
+
+    await copy(filePath, destinationPath)
+
+    await expect(
+      compileServiceFile(target, destinationPath, [], ['../', '../services'])
+    ).toResolve()
+
+    const compiledContent = await readFile(destinationPath)
+
+    expect(/\* ServiceInit start;/.test(compiledContent)).toEqual(true)
+    expect(/\* ServiceInit end;/.test(compiledContent)).toEqual(true)
+    expect(/\* ServiceTerm start;/.test(compiledContent)).toEqual(true)
+    expect(/\* ServiceTerm end;/.test(compiledContent)).toEqual(true)
+    expect(/%macro mf_abort/.test(compiledContent)).toEqual(true)
+    expect(/%macro mf_existds/.test(compiledContent)).toEqual(true)
+
+    expect(compiledContent).toEqual(
+      expect.stringContaining(fakeProgramLines.join('\n'))
+    )
+    expect(compiledContent).toEqual(expect.stringContaining(preCode))
+
+    done()
+  })
+})

--- a/src/commands/compile/spec/compileServiceFile.spec.ts
+++ b/src/commands/compile/spec/compileServiceFile.spec.ts
@@ -73,12 +73,14 @@ describe('compileServiceFile', () => {
   })
 
   test('it should compile and create file', async (done) => {
-    spyOn(internalModule, 'getServiceInit').and.returnValue(
-      `\n* ServiceInit start;\n${fakeJobInit}\n* ServiceInit end;`
-    )
-    spyOn(internalModule, 'getServiceTerm').and.returnValue(
-      `\n* ServiceTerm start;\n${fakeJobTerm}\n* ServiceTerm end;`
-    )
+    spyOn(internalModule, 'getServiceInit').and.returnValue({
+      content: `\n* ServiceInit start;\n${fakeJobInit}\n* ServiceInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getServiceTerm').and.returnValue({
+      content: `\n* ServiceTerm start;\n${fakeJobTerm}\n* ServiceTerm end;`,
+      filePath: ''
+    })
 
     const filePath = path.join(__dirname, './service.sas')
     const buildPath = path.join(process.projectDir, 'sasjsbuild')

--- a/src/commands/context/index.ts
+++ b/src/commands/context/index.ts
@@ -42,7 +42,7 @@ export async function processContext(command: Command) {
       process.logger?.error(message)
 
       return
-    } else if (!validateConfigPath(configPath)) {
+    } else if (!(await validateConfigPath(configPath))) {
       const message = `Provide a path to context config file (eg '${commandExample}')`
 
       process.logger?.error(message)

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -37,14 +37,16 @@ export async function deploy(target: Target, isLocal: boolean) {
 
   const logFilePath = buildDestinationFolder
   await asyncForEach(deployScripts, async (deployScript) => {
+    const deployScriptPath = path.isAbsolute(deployScript)
+      ? deployScript
+      : path.join(process.projectDir, deployScript)
+
     if (isSasFile(deployScript)) {
       process.logger?.info(
         `Processing SAS file ${path.basename(deployScript)} ...`
       )
       // get content of file
-      const deployScriptFile = await readFile(
-        path.join(process.projectDir, deployScript)
-      )
+      const deployScriptFile = await readFile(deployScriptPath)
       // split into lines
       const linesToExecute = deployScriptFile.replace(/\r\n/g, '\n').split('\n')
       if (target.serverType === ServerType.SasViya) {
@@ -61,7 +63,6 @@ export async function deploy(target: Target, isLocal: boolean) {
     } else if (isShellScript(deployScript)) {
       process.logger?.info(`Executing shell script ${deployScript} ...`)
 
-      const deployScriptPath = path.join(process.projectDir, deployScript)
       const logPath = path.join(
         process.projectDir,
         'sasjsbuild',

--- a/src/commands/docs/internal/getFoldersForDocs.ts
+++ b/src/commands/docs/internal/getFoldersForDocs.ts
@@ -38,21 +38,27 @@ function extractFoldersForDocs(config: Target | Configuration) {
 
   const macroFolders =
     config && config.macroFolders
-      ? config.macroFolders.map((f) => path.join(buildSourceFolder, f))
+      ? config.macroFolders.map((f) =>
+          path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
+        )
       : []
   const programFolders =
     config && config.programFolders
-      ? config.programFolders.map((f) => path.join(buildSourceFolder, f))
+      ? config.programFolders.map((f) =>
+          path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
+        )
       : []
   const serviceFolders =
     config && config.serviceConfig && config.serviceConfig.serviceFolders
       ? config.serviceConfig.serviceFolders.map((f) =>
-          path.join(buildSourceFolder, f)
+          path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
         )
       : []
   const jobFolders =
     config && config.jobConfig && config.jobConfig.jobFolders
-      ? config.jobConfig.jobFolders.map((f) => path.join(buildSourceFolder, f))
+      ? config.jobConfig.jobFolders.map((f) =>
+          path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
+        )
       : []
 
   return {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,9 @@
 export { addTarget } from './add/addTarget'
 export { addCredential } from './add/addCredential'
 
+export { compile } from './compile/compile'
+export { compileSingleFile } from './compile/compileSingleFile'
+
 export { build, getBuildVars } from './build/build'
 
 export { processContext } from './context'

--- a/src/commands/job/spec/job.spec.server.ts
+++ b/src/commands/job/spec/job.spec.server.ts
@@ -379,19 +379,15 @@ const createGlobalTarget = async () => {
     serverUrl: process.env.SERVER_URL as string,
     appLoc: `/Public/app/cli-tests/${targetName}`,
     serviceConfig: {
-      serviceFolders: [
-        '/sasjs/testServices',
-        'sasjs/testJob',
-        'sasjs/services'
-      ],
-      initProgram: '/sasjs/testServices/serviceinit.sas',
-      termProgram: '/sasjs/testServices/serviceterm.sas',
+      serviceFolders: ['sasjs/testServices', 'sasjs/testJob', 'sasjs/services'],
+      initProgram: 'sasjs/testServices/serviceinit.sas',
+      termProgram: 'sasjs/testServices/serviceterm.sas',
       macroVars: {}
     },
     jobConfig: {
-      jobFolders: ['/sasjs/testJob'],
-      initProgram: '/sasjs/testServices/serviceinit.sas',
-      termProgram: '/sasjs/testServices/serviceterm.sas',
+      jobFolders: ['sasjs/testJob'],
+      initProgram: 'sasjs/testServices/serviceinit.sas',
+      termProgram: 'sasjs/testServices/serviceterm.sas',
       macroVars: {}
     },
     authConfig: {

--- a/src/commands/request/request.ts
+++ b/src/commands/request/request.ts
@@ -30,7 +30,11 @@ export async function runSasJob(command: Command) {
       throw new Error('Provided data file must be valid json.')
     }
 
-    const dataFile = await readFile(path.join(process.projectDir, dataFilePath))
+    const dataFile = await readFile(
+      path.isAbsolute(dataFilePath)
+        ? dataFilePath
+        : path.join(process.projectDir, dataFilePath)
+    )
 
     try {
       dataJson = JSON.parse(dataFile)
@@ -45,7 +49,9 @@ export async function runSasJob(command: Command) {
     }
 
     const configFile = await readFile(
-      path.join(process.projectDir, configFilePath)
+      path.isAbsolute(configFilePath)
+        ? configFilePath
+        : path.join(process.projectDir, configFilePath)
     )
 
     try {

--- a/src/commands/run/run.ts
+++ b/src/commands/run/run.ts
@@ -25,7 +25,9 @@ export async function runSasCode(command: Command) {
   if (!target) {
     throw new Error('Target not found! Please try again with another target.')
   }
-  const sasFile = await readFile(path.join(process.cwd(), filePath))
+  const sasFile = await readFile(
+    path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath)
+  )
   const linesToExecute = sasFile.replace(/\r\n/g, '\n').split('\n')
   if (target.serverType === 'SASVIYA') {
     return await executeOnSasViya(filePath, target, linesToExecute)

--- a/src/commands/servicepack/deploy.ts
+++ b/src/commands/servicepack/deploy.ts
@@ -65,7 +65,11 @@ async function deployToSasViyaWithServicePack(
   let jsonContent
 
   if (jsonFilePath) {
-    jsonContent = await readFile(path.join(process.cwd(), jsonFilePath))
+    jsonContent = await readFile(
+      path.isAbsolute(jsonFilePath)
+        ? jsonFilePath
+        : path.join(process.cwd(), jsonFilePath)
+    )
   } else {
     jsonContent = await readFile(finalFilePathJSON)
   }

--- a/src/commands/shared/dependencies.ts
+++ b/src/commands/shared/dependencies.ts
@@ -16,7 +16,9 @@ export async function getDependencyPaths(
 
   if (macroFolders.length) {
     macroFolders.forEach((macroFolder) => {
-      const macroPath = path.join(buildSourceFolder, macroFolder)
+      const macroPath = path.isAbsolute(macroFolder)
+        ? macroFolder
+        : path.join(buildSourceFolder, macroFolder)
       sourcePaths.push(macroPath)
     })
   }
@@ -129,14 +131,19 @@ export async function getProgramDependencies(
     const foundProgramNames: string[] = []
     await asyncForEach(programFolders, async (programFolder) => {
       await asyncForEach(programs, async (program) => {
-        const filePath = path.join(buildSourceFolder, programFolder)
-        const filePaths = find.fileSync(program.fileName, filePath)
+        const folderPath = path.isAbsolute(programFolder)
+          ? programFolder
+          : path.join(buildSourceFolder, programFolder)
+        const filePaths = find.fileSync(program.fileName, folderPath)
         if (filePaths.length) {
           const fileContent = await readFile(filePaths[0])
 
           if (!fileContent) {
             process.logger?.warn(
-              `Program file ${path.join(filePath, program.fileName)} is empty.`
+              `Program file ${path.join(
+                folderPath,
+                program.fileName
+              )} is empty.`
             )
           }
 

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -51,7 +51,6 @@ const initialFlags = arrToObj([
     'target',
     'source',
     'template',
-    'source',
     'datafile',
     'configfile',
     'wait',
@@ -103,7 +102,10 @@ const commandFlags = [
   },
   { command: initialCommands.web, flags: [initialFlags.target] },
   { command: initialCommands['build-DB'], flags: [initialFlags.target] },
-  { command: initialCommands.compile, flags: [initialFlags.target] },
+  {
+    command: initialCommands.compile,
+    flags: [initialFlags.target, initialFlags.source, initialFlags.output]
+  },
   { command: initialCommands.build, flags: [initialFlags.target] },
   { command: initialCommands.compilebuild, flags: [initialFlags.target] },
   { command: initialCommands.deploy, flags: [initialFlags.target] },

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -29,6 +29,15 @@ export const createTestApp = async (parentFolder: string, appName: string) => {
   process.projectDir = path.join(parentFolder, appName)
 }
 
+export const createTestJobsApp = async (
+  parentFolder: string,
+  appName: string
+) => {
+  process.projectDir = parentFolder
+  await create(appName, 'jobs')
+  process.projectDir = path.join(parentFolder, appName)
+}
+
 export const createTestMinimalApp = async (
   parentFolder: string,
   appName: string


### PR DESCRIPTION
## Issue

Closes #469 
Closes #486 

## Intent

Compile single job/service.
And to support absolute paths wherever possible

## Implementation

Code refactored:
- extracted code from compile to internals, `compileServiceFile.ts` and `compileJobFile.ts`
- used these to newly introduced command file `compileSingleFile.ts`

Fix in context index.ts
`command.ts` utility updated accordingly to new supported flags for subcommand(`job` and `service`)

changed `path.join` to if `path.isAbsolute` use it else use `path.join`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
