### PR TITLE
fix(compile): show file name in error when getting programDependencies

### DIFF
--- a/src/commands/compile/internal/config.ts
+++ b/src/commands/compile/internal/config.ts
@@ -4,94 +4,134 @@ import path from 'path'
 import { getConstants } from '../../../constants'
 import { getConfiguration } from '../../../utils/config'
 
-export const getServiceInit = async (target: Target) => {
+export const getServiceInit = async (
+  target: Target
+): Promise<{ content: string; filePath: string }> => {
   const { buildSourceFolder } = getConstants()
-  let serviceInitContent = ''
+  let serviceInitContent = '',
+    filePath = ''
   if (target?.serviceConfig?.initProgram) {
-    serviceInitContent = await readFile(
-      path.join(buildSourceFolder, target.serviceConfig.initProgram)
-    )
+    filePath = path.join(buildSourceFolder, target.serviceConfig.initProgram)
+    serviceInitContent = await readFile(filePath)
   } else {
     const configuration = await getConfiguration(
       path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
     )
     if (configuration?.serviceConfig?.initProgram) {
-      serviceInitContent = await readFile(
-        path.join(buildSourceFolder, configuration.serviceConfig.initProgram)
+      filePath = path.join(
+        buildSourceFolder,
+        configuration.serviceConfig.initProgram
       )
+      serviceInitContent = await readFile(filePath)
     }
   }
 
   return serviceInitContent
-    ? `\n* ServiceInit start;\n${serviceInitContent}\n* ServiceInit end;`
-    : ''
+    ? {
+        content: `\n* ServiceInit start;\n${serviceInitContent}\n* ServiceInit end;`,
+        filePath
+      }
+    : {
+        content: '',
+        filePath: ''
+      }
 }
 
-export const getServiceTerm = async (target: Target) => {
+export const getServiceTerm = async (
+  target: Target
+): Promise<{ content: string; filePath: string }> => {
   const { buildSourceFolder } = getConstants()
-  let serviceTermContent = ''
+  let serviceTermContent = '',
+    filePath = ''
   if (target?.serviceConfig?.termProgram) {
-    serviceTermContent = await readFile(
-      path.join(buildSourceFolder, target.serviceConfig.termProgram)
-    )
+    filePath = path.join(buildSourceFolder, target.serviceConfig.termProgram)
+    serviceTermContent = await readFile(filePath)
   } else {
     const configuration = await getConfiguration(
       path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
     )
     if (configuration?.serviceConfig?.termProgram) {
-      serviceTermContent = await readFile(
-        path.join(buildSourceFolder, configuration.serviceConfig.termProgram)
+      filePath = path.join(
+        buildSourceFolder,
+        configuration.serviceConfig.termProgram
       )
+      serviceTermContent = await readFile(filePath)
     }
   }
 
   return serviceTermContent
-    ? `\n* ServiceTerm start;\n${serviceTermContent}\n* ServiceTerm end;`
-    : ''
+    ? {
+        content: `\n* ServiceTerm start;\n${serviceTermContent}\n* ServiceTerm end;`,
+        filePath
+      }
+    : {
+        content: '',
+        filePath: ''
+      }
 }
 
-export const getJobInit = async (target: Target) => {
+export const getJobInit = async (
+  target: Target
+): Promise<{ content: string; filePath: string }> => {
   const { buildSourceFolder } = getConstants()
-  let jobInitContent = ''
+  let jobInitContent = '',
+    filePath = ''
   if (target?.jobConfig?.initProgram) {
-    jobInitContent = await readFile(
-      path.join(buildSourceFolder, target.jobConfig.initProgram)
-    )
+    filePath = path.join(buildSourceFolder, target.jobConfig.initProgram)
+    jobInitContent = await readFile(filePath)
   } else {
     const configuration = await getConfiguration(
       path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
     )
     if (configuration?.jobConfig?.initProgram) {
-      jobInitContent = await readFile(
-        path.join(buildSourceFolder, configuration.jobConfig.initProgram)
+      filePath = path.join(
+        buildSourceFolder,
+        configuration.jobConfig.initProgram
       )
+      jobInitContent = await readFile(filePath)
     }
   }
 
   return jobInitContent
-    ? `\n* JobInit start;\n${jobInitContent}\n* JobInit end;`
-    : ''
+    ? {
+        content: `\n* JobInit start;\n${jobInitContent}\n* JobInit end;`,
+        filePath
+      }
+    : {
+        content: '',
+        filePath: ''
+      }
 }
 
-export const getJobTerm = async (target: Target) => {
+export const getJobTerm = async (
+  target: Target
+): Promise<{ content: string; filePath: string }> => {
   const { buildSourceFolder } = getConstants()
-  let jobTermContent = ''
+  let jobTermContent = '',
+    filePath = ''
   if (target?.jobConfig?.termProgram) {
-    jobTermContent = await readFile(
-      path.join(buildSourceFolder, target.jobConfig.termProgram)
-    )
+    filePath = path.join(buildSourceFolder, target.jobConfig.termProgram)
+    jobTermContent = await readFile(filePath)
   } else {
     const configuration = await getConfiguration(
       path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
     )
     if (configuration?.jobConfig?.termProgram) {
-      jobTermContent = await readFile(
-        path.join(buildSourceFolder, configuration.jobConfig.termProgram)
+      filePath = path.join(
+        buildSourceFolder,
+        configuration.jobConfig.termProgram
       )
+      jobTermContent = await readFile(filePath)
     }
   }
 
   return jobTermContent
-    ? `\n* JobTerm start;\n${jobTermContent}\n* JobTerm end;`
-    : ''
+    ? {
+        content: `\n* JobTerm start;\n${jobTermContent}\n* JobTerm end;`,
+        filePath
+      }
+    : {
+        content: '',
+        filePath: ''
+      }
 }

--- a/src/commands/compile/internal/loadDependencies.ts
+++ b/src/commands/compile/internal/loadDependencies.ts
@@ -42,24 +42,21 @@ export async function loadDependencies(
     }
   }
 
-  let init
-  let term
+  let init, initPath
+  let term, termPath
   let serviceVars = ''
 
   if (type === 'service') {
     serviceVars = await getServiceVars(target)
-
-    init = await getServiceInit(target)
-
-    term = await getServiceTerm(target)
+    ;({ content: init, filePath: initPath } = await getServiceInit(target))
+    ;({ content: term, filePath: termPath } = await getServiceTerm(target))
 
     fileContent = fileContent
       ? `\n* Service start;\n${fileContent}\n* Service end;`
       : ''
   } else {
-    init = await getJobInit(target)
-
-    term = await getJobTerm(target)
+    ;({ content: init, filePath: initPath } = await getJobInit(target))
+    ;({ content: term, filePath: termPath } = await getJobTerm(target))
 
     fileContent = fileContent
       ? `\n* Job start;\n${fileContent}\n* Job end;`
@@ -81,18 +78,21 @@ export async function loadDependencies(
   const initProgramDependencies = await getProgramDependencies(
     init,
     programFolders,
-    buildSourceFolder
+    buildSourceFolder,
+    initPath
   )
   const termProgramDependencies = await getProgramDependencies(
     term,
     programFolders,
-    buildSourceFolder
+    buildSourceFolder,
+    termPath
   )
 
   const programDependencies = await getProgramDependencies(
     fileContent,
     programFolders,
-    buildSourceFolder
+    buildSourceFolder,
+    filePath
   )
 
   const dependenciesContent = await getDependencies(allDependencyPaths)

--- a/src/commands/compile/spec/getProgramDependencies.spec.ts
+++ b/src/commands/compile/spec/getProgramDependencies.spec.ts
@@ -19,12 +19,14 @@ describe('getProgramDependencies', () => {
   ]
 
   test('it should get all program dependencies', async (done) => {
-    const fileContent = await readFile(path.join(__dirname, './example.sas'))
+    const filePath = path.join(__dirname, './example.sas')
+    const fileContent = await readFile(filePath)
 
     const dependencies = await getProgramDependencies(
       fileContent,
       ['programs'],
-      __dirname
+      __dirname,
+      filePath
     )
     const actualLines = dependencies.split('\n')
 
@@ -34,12 +36,14 @@ describe('getProgramDependencies', () => {
   })
 
   test('it should choose the first dependency when there are duplicates', async (done) => {
-    const fileContent = await readFile(path.join(__dirname, './duplicates.sas'))
+    const filePath = path.join(__dirname, './duplicates.sas')
+    const fileContent = await readFile(filePath)
 
     const dependencies = await getProgramDependencies(
       fileContent,
       ['programs'],
-      __dirname
+      __dirname,
+      filePath
     )
     const actualLines = dependencies.split('\n')
 
@@ -49,9 +53,8 @@ describe('getProgramDependencies', () => {
   })
 
   test('it should handle duplicate filenames with different extensions', async (done) => {
-    const fileContent = await readFile(
-      path.join(__dirname, './duplicates-extensions.sas')
-    )
+    const filePath = path.join(__dirname, './duplicates-extensions.sas')
+    const fileContent = await readFile(filePath)
     const expectedOutput = [
       'filename TEST temp;',
       'data _null_;',
@@ -69,7 +72,8 @@ describe('getProgramDependencies', () => {
     const dependencies = await getProgramDependencies(
       fileContent,
       ['programs'],
-      __dirname
+      __dirname,
+      filePath
     )
     const actualLines = dependencies.split('\n')
 
@@ -79,12 +83,11 @@ describe('getProgramDependencies', () => {
   })
 
   test('it should throw an error when a fileref is not specified', async (done) => {
-    const fileContent = await readFile(
-      path.join(__dirname, './missing-fileref.sas')
-    )
+    const filePath = path.join(__dirname, './missing-fileref.sas')
+    const fileContent = await readFile(filePath)
 
     await expect(
-      getProgramDependencies(fileContent, ['programs'], __dirname)
+      getProgramDependencies(fileContent, ['programs'], __dirname, filePath)
     ).rejects.toThrow(
       `SAS Program test.sas is missing fileref. Please specify SAS program dependencies in the format: @li <filename> <fileref>`
     )

--- a/src/commands/compile/spec/loadDependencies.spec.ts
+++ b/src/commands/compile/spec/loadDependencies.spec.ts
@@ -114,12 +114,14 @@ describe('loadDependencies', () => {
   })
 
   test('it should load dependencies for a service with <h4> Dependencies </h4>', async (done) => {
-    spyOn(internalModule, 'getServiceInit').and.returnValue(
-      `\n* ServiceInit start;\n${fakeServiceInit}\n* ServiceInit end;`
-    )
-    spyOn(internalModule, 'getServiceTerm').and.returnValue(
-      `\n* ServiceTerm start;\n${fakeServiceTerm}\n* ServiceTerm end;`
-    )
+    spyOn(internalModule, 'getServiceInit').and.returnValue({
+      content: `\n* ServiceInit start;\n${fakeServiceInit}\n* ServiceInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getServiceTerm').and.returnValue({
+      content: `\n* ServiceTerm start;\n${fakeServiceTerm}\n* ServiceTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,
@@ -140,12 +142,14 @@ describe('loadDependencies', () => {
   })
 
   test('it should load dependencies for a job <h4> Dependencies </h4>', async (done) => {
-    spyOn(internalModule, 'getJobInit').and.returnValue(
-      `\n* JobInit start;\n${fakeServiceInit}\n* JobInit end;`
-    )
-    spyOn(internalModule, 'getJobTerm').and.returnValue(
-      `\n* JobTerm start;\n${fakeServiceTerm}\n* JobTerm end;`
-    )
+    spyOn(internalModule, 'getJobInit').and.returnValue({
+      content: `\n* JobInit start;\n${fakeServiceInit}\n* JobInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getJobTerm').and.returnValue({
+      content: `\n* JobTerm start;\n${fakeServiceTerm}\n* JobTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,
@@ -166,12 +170,14 @@ describe('loadDependencies', () => {
   })
 
   test('it should load dependencies for a service with <h4> SAS MAcros </h4>', async (done) => {
-    spyOn(internalModule, 'getServiceInit').and.returnValue(
-      `\n* ServiceInit start;\n${fakeServiceInit2}\n* ServiceInit end;`
-    )
-    spyOn(internalModule, 'getServiceTerm').and.returnValue(
-      `\n* ServiceTerm start;\n${fakeServiceTerm2}\n* ServiceTerm end;`
-    )
+    spyOn(internalModule, 'getServiceInit').and.returnValue({
+      content: `\n* ServiceInit start;\n${fakeServiceInit2}\n* ServiceInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getServiceTerm').and.returnValue({
+      content: `\n* ServiceTerm start;\n${fakeServiceTerm2}\n* ServiceTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,
@@ -191,12 +197,14 @@ describe('loadDependencies', () => {
   })
 
   test('it should load dependencies for a job <h4> SAS MAcros </h4>', async (done) => {
-    spyOn(internalModule, 'getJobInit').and.returnValue(
-      `\n* JobInit start;\n${fakeServiceInit2}\n* JobInit end;`
-    )
-    spyOn(internalModule, 'getJobTerm').and.returnValue(
-      `\n* JobTerm start;\n${fakeServiceTerm2}\n* JobTerm end;`
-    )
+    spyOn(internalModule, 'getJobInit').and.returnValue({
+      content: `\n* JobInit start;\n${fakeServiceInit2}\n* JobInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getJobTerm').and.returnValue({
+      content: `\n* JobTerm start;\n${fakeServiceTerm2}\n* JobTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,
@@ -217,12 +225,14 @@ describe('loadDependencies', () => {
   })
 
   test("it should load dependencies for a job having jobInit's <h4> SAS Programs </h4>", async (done) => {
-    spyOn(internalModule, 'getJobInit').and.returnValue(
-      `\n* JobInit start;\n${fakeJobInit}\n* JobInit end;`
-    )
-    spyOn(internalModule, 'getJobTerm').and.returnValue(
-      `\n* JobTerm start;\n${fakeServiceTerm2}\n* JobTerm end;`
-    )
+    spyOn(internalModule, 'getJobInit').and.returnValue({
+      content: `\n* JobInit start;\n${fakeJobInit}\n* JobInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getJobTerm').and.returnValue({
+      content: `\n* JobTerm start;\n${fakeServiceTerm2}\n* JobTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,
@@ -247,12 +257,14 @@ describe('loadDependencies', () => {
   })
 
   test("it should load dependencies for a job having jobTerm's <h4> SAS Programs </h4>", async (done) => {
-    spyOn(internalModule, 'getJobInit').and.returnValue(
-      `\n* JobInit start;\n${fakeServiceInit2}\n* JobInit end;`
-    )
-    spyOn(internalModule, 'getJobTerm').and.returnValue(
-      `\n* JobTerm start;\n${fakeJobInit}\n* JobTerm end;`
-    )
+    spyOn(internalModule, 'getJobInit').and.returnValue({
+      content: `\n* JobInit start;\n${fakeServiceInit2}\n* JobInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getJobTerm').and.returnValue({
+      content: `\n* JobTerm start;\n${fakeJobInit}\n* JobTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,
@@ -276,12 +288,14 @@ describe('loadDependencies', () => {
   })
 
   test("it should load dependencies for a service having serviceInit's <h4> SAS Programs </h4>", async (done) => {
-    spyOn(internalModule, 'getServiceInit').and.returnValue(
-      `\n* ServiceInit start;\n${fakeJobInit}\n* ServiceInit end;`
-    )
-    spyOn(internalModule, 'getServiceTerm').and.returnValue(
-      `\n* ServiceTerm start;\n${fakeServiceTerm2}\n* ServiceTerm end;`
-    )
+    spyOn(internalModule, 'getServiceInit').and.returnValue({
+      content: `\n* ServiceInit start;\n${fakeJobInit}\n* ServiceInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getServiceTerm').and.returnValue({
+      content: `\n* ServiceTerm start;\n${fakeServiceTerm2}\n* ServiceTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,
@@ -305,12 +319,14 @@ describe('loadDependencies', () => {
   })
 
   test("it should load dependencies for a service having serviceTerm's <h4> SAS Programs </h4>", async (done) => {
-    spyOn(internalModule, 'getServiceInit').and.returnValue(
-      `\n* ServiceInit start;\n${fakeServiceInit2}\n* ServiceInit end;`
-    )
-    spyOn(internalModule, 'getServiceTerm').and.returnValue(
-      `\n* ServiceTerm start;\n${fakeJobInit}\n* ServiceTerm end;`
-    )
+    spyOn(internalModule, 'getServiceInit').and.returnValue({
+      content: `\n* ServiceInit start;\n${fakeServiceInit2}\n* ServiceInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getServiceTerm').and.returnValue({
+      content: `\n* ServiceTerm start;\n${fakeJobInit}\n* ServiceTerm end;`,
+      filePath: ''
+    })
 
     const dependencies = await loadDependencies(
       target,

--- a/src/commands/compile/spec/loadDependencies.spec.ts
+++ b/src/commands/compile/spec/loadDependencies.spec.ts
@@ -11,7 +11,7 @@ import {
 import { generateTimestamp } from '../../../utils/utils'
 import { loadDependencies } from '../internal/loadDependencies'
 
-const fakeServiceInit = `/**
+const fakeInit = `/**
   @file serviceinit.sas
   @brief this file is called with every service
   @details  This file is included in *every* service, *after* the macros and *before* the service code.
@@ -27,7 +27,7 @@ options
 ;
 %put service is starting!!;`
 
-const fakeServiceTerm = `/**
+const fakeTerm = `/**
   @file serviceterm.sas
   @brief this file is called at the end of every service
   @details  This file is included at the *end* of every service.
@@ -40,7 +40,7 @@ const fakeServiceTerm = `/**
 
 %put service is finishing.  Thanks, SASjs!;`
 
-const fakeServiceInit2 = `/**
+const fakeInit2 = `/**
   @file serviceinit.sas
   @brief this file is called with every service
   @details  This file is included in *every* service, *after* the macros and *before* the service code.
@@ -56,7 +56,7 @@ options
 ;
 %put service is starting!!;`
 
-const fakeServiceTerm2 = `/**
+const fakeTerm2 = `/**
   @file serviceterm.sas
   @brief this file is called at the end of every service
   @details  This file is included at the *end* of every service.
@@ -115,11 +115,11 @@ describe('loadDependencies', () => {
 
   test('it should load dependencies for a service with <h4> Dependencies </h4>', async (done) => {
     spyOn(internalModule, 'getServiceInit').and.returnValue({
-      content: `\n* ServiceInit start;\n${fakeServiceInit}\n* ServiceInit end;`,
+      content: `\n* ServiceInit start;\n${fakeInit}\n* ServiceInit end;`,
       filePath: ''
     })
     spyOn(internalModule, 'getServiceTerm').and.returnValue({
-      content: `\n* ServiceTerm start;\n${fakeServiceTerm}\n* ServiceTerm end;`,
+      content: `\n* ServiceTerm start;\n${fakeTerm}\n* ServiceTerm end;`,
       filePath: ''
     })
 
@@ -143,11 +143,11 @@ describe('loadDependencies', () => {
 
   test('it should load dependencies for a job <h4> Dependencies </h4>', async (done) => {
     spyOn(internalModule, 'getJobInit').and.returnValue({
-      content: `\n* JobInit start;\n${fakeServiceInit}\n* JobInit end;`,
+      content: `\n* JobInit start;\n${fakeInit}\n* JobInit end;`,
       filePath: ''
     })
     spyOn(internalModule, 'getJobTerm').and.returnValue({
-      content: `\n* JobTerm start;\n${fakeServiceTerm}\n* JobTerm end;`,
+      content: `\n* JobTerm start;\n${fakeTerm}\n* JobTerm end;`,
       filePath: ''
     })
 
@@ -171,11 +171,11 @@ describe('loadDependencies', () => {
 
   test('it should load dependencies for a service with <h4> SAS MAcros </h4>', async (done) => {
     spyOn(internalModule, 'getServiceInit').and.returnValue({
-      content: `\n* ServiceInit start;\n${fakeServiceInit2}\n* ServiceInit end;`,
+      content: `\n* ServiceInit start;\n${fakeInit2}\n* ServiceInit end;`,
       filePath: ''
     })
     spyOn(internalModule, 'getServiceTerm').and.returnValue({
-      content: `\n* ServiceTerm start;\n${fakeServiceTerm2}\n* ServiceTerm end;`,
+      content: `\n* ServiceTerm start;\n${fakeTerm2}\n* ServiceTerm end;`,
       filePath: ''
     })
 
@@ -198,11 +198,11 @@ describe('loadDependencies', () => {
 
   test('it should load dependencies for a job <h4> SAS MAcros </h4>', async (done) => {
     spyOn(internalModule, 'getJobInit').and.returnValue({
-      content: `\n* JobInit start;\n${fakeServiceInit2}\n* JobInit end;`,
+      content: `\n* JobInit start;\n${fakeInit2}\n* JobInit end;`,
       filePath: ''
     })
     spyOn(internalModule, 'getJobTerm').and.returnValue({
-      content: `\n* JobTerm start;\n${fakeServiceTerm2}\n* JobTerm end;`,
+      content: `\n* JobTerm start;\n${fakeTerm2}\n* JobTerm end;`,
       filePath: ''
     })
 
@@ -230,7 +230,7 @@ describe('loadDependencies', () => {
       filePath: ''
     })
     spyOn(internalModule, 'getJobTerm').and.returnValue({
-      content: `\n* JobTerm start;\n${fakeServiceTerm2}\n* JobTerm end;`,
+      content: `\n* JobTerm start;\n${fakeTerm2}\n* JobTerm end;`,
       filePath: ''
     })
 
@@ -258,7 +258,7 @@ describe('loadDependencies', () => {
 
   test("it should load dependencies for a job having jobTerm's <h4> SAS Programs </h4>", async (done) => {
     spyOn(internalModule, 'getJobInit').and.returnValue({
-      content: `\n* JobInit start;\n${fakeServiceInit2}\n* JobInit end;`,
+      content: `\n* JobInit start;\n${fakeInit2}\n* JobInit end;`,
       filePath: ''
     })
     spyOn(internalModule, 'getJobTerm').and.returnValue({
@@ -293,7 +293,7 @@ describe('loadDependencies', () => {
       filePath: ''
     })
     spyOn(internalModule, 'getServiceTerm').and.returnValue({
-      content: `\n* ServiceTerm start;\n${fakeServiceTerm2}\n* ServiceTerm end;`,
+      content: `\n* ServiceTerm start;\n${fakeTerm2}\n* ServiceTerm end;`,
       filePath: ''
     })
 
@@ -320,7 +320,7 @@ describe('loadDependencies', () => {
 
   test("it should load dependencies for a service having serviceTerm's <h4> SAS Programs </h4>", async (done) => {
     spyOn(internalModule, 'getServiceInit').and.returnValue({
-      content: `\n* ServiceInit start;\n${fakeServiceInit2}\n* ServiceInit end;`,
+      content: `\n* ServiceInit start;\n${fakeInit2}\n* ServiceInit end;`,
       filePath: ''
     })
     spyOn(internalModule, 'getServiceTerm').and.returnValue({

--- a/src/commands/shared/dependencies.ts
+++ b/src/commands/shared/dependencies.ts
@@ -120,7 +120,8 @@ export function prioritiseDependencyOverrides(
 export async function getProgramDependencies(
   fileContent: string,
   programFolders: string[],
-  buildSourceFolder: string
+  buildSourceFolder: string,
+  filePath: string
 ) {
   programFolders = (uniqBy as any)(programFolders)
   const programs = getProgramList(fileContent)
@@ -162,7 +163,8 @@ export async function getProgramDependencies(
         .join('\n')
 
       throw new Error(
-        `The following files were listed under SAS Programs but could not be found:\n` +
+        `Unable to load dependencies for: ${filePath}\n` +
+          `The following files were listed under SAS Programs but could not be found:\n` +
           `${programList}\n` +
           `Please check that they exist in the folder(s) listed in the \`programFolders\` array in your sasjsconfig.json file.\n` +
           `Program Folders:\n` +


### PR DESCRIPTION
## Issue

In `sasjs compile`, while getting programDependencies, we are now throwing error for not getting dependency in listed program folders. Also need to display source file name in main error.

## Intent

Display file name along error message for missing dependency

## Implementation

Changed `getProgramDependencies` in _src/shared/dependencies.ts_, passed `filePath` to it.
Also getting programDependencies for `init`/`term`, needed their paths, so updated following functions in _src/compile/internals/config.ts_
- `getServiceInit`
- `getServiceTerm`
- `getJobInit`
- `getJobTerm`


## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).

mocked: 
![image](https://user-images.githubusercontent.com/8914650/109161228-a0b6c900-7798-11eb-954c-96e6bf9b766c.png)

server:
![image](https://user-images.githubusercontent.com/8914650/109162365-efb12e00-7799-11eb-9c64-c8a06d614b96.png)


- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
