### PR TITLE
fix(read-file): remove unnecessary error log

### DIFF
--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -55,7 +55,6 @@ export async function readFile(fileName) {
   return new Promise((resolve, reject) => {
     fs.readFile(fileName, 'utf8', function (error, data) {
       if (error) {
-        process.logger?.error(`Error accessing file: ${fileName}`)
         return reject(error)
       }
       return resolve(data)


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/496.
Fixes https://github.com/sasjs/cli/issues/516.

## Intent

Alleviate any confusion caused by file access errors being displayed in the terminal.

## Implementation

* Removed `logger.error` from `readFile` - the error is always going to be caught upstream.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
