### PR TITLE
fix: throw error if target not found with name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,9 +1559,9 @@
       "integrity": "sha512-T3fXhP1KhYvRArlEYuRlLo8j7zDUlloqRKN+QpDHzArlY81BRVXxwax3U2w42WQPFeTf2WUz9j/qFpo7PgUr6w=="
     },
     "@sasjs/utils": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.5.1.tgz",
-      "integrity": "sha512-a3ISiUX8Yz7au4XYxq2KWf9ODT6nsIDbE4FEqS+AQ3McxZkfuAk4v+REXjOmIlcyQd4R4bufEK8XoB6AROn9sA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.6.2.tgz",
+      "integrity": "sha512-upJjcySB/B3hYb7YD4ep9E7I4n7iJPjD/dxVn7grtrst0B+8nCxP9fCaezuAST6jf6JIvlvreMieUYKSpGQHoQ==",
       "requires": {
         "@types/prompts": "^2.0.9",
         "consola": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@sasjs/adapter": "^2.2.3",
     "@sasjs/core": "^2.9.3",
-    "@sasjs/utils": "^2.5.1",
+    "@sasjs/utils": "^2.6.2",
     "btoa": "^1.2.1",
     "chalk": "^4.1.0",
     "csv-stringify": "^5.6.1",

--- a/src/commands/add/addCredential.ts
+++ b/src/commands/add/addCredential.ts
@@ -32,7 +32,7 @@ export const addCredential = async (
   if (insecure) process.logger?.warn('Executing with insecure connection.')
 
   if (!target.serverUrl) {
-    const serverUrl = await getAndValidateServerUrl()
+    const serverUrl = await getAndValidateServerUrl(target)
     target = new Target({ ...target.toJson(), serverUrl })
   }
 

--- a/src/commands/add/addTarget.ts
+++ b/src/commands/add/addTarget.ts
@@ -13,15 +13,23 @@ import {
 import { addCredential } from './addCredential'
 
 /**
- * Creates new target for either local config or global config file.
+ * Creates new target/ updates current target(if found) for either local config or global config file.
  * @param {boolean} insecure- boolean to use insecure connection, default is false. lf true the server will not reject any connection which is not authorized with the list of supplied CAs
  */
 export async function addTarget(insecure: boolean = false): Promise<boolean> {
   if (insecure) process.logger?.warn('Executing with insecure connection.')
 
-  const { scope, serverType, name, appLoc, serverUrl } = await getCommonFields()
+  const {
+    scope,
+    serverType,
+    name,
+    appLoc,
+    serverUrl,
+    existingTarget
+  } = await getCommonFields()
 
   let targetJson: any = {
+    ...existingTarget,
     name,
     serverType,
     serverUrl,

--- a/src/commands/add/internal/input.ts
+++ b/src/commands/add/internal/input.ts
@@ -10,6 +10,7 @@ import path from 'path'
 import dotenv from 'dotenv'
 import SASjs from '@sasjs/adapter/node'
 import { TargetScope } from '../../../types/targetScope'
+import { CommonFields } from '../../../types/commonFields'
 import {
   findTargetInConfiguration,
   getGlobalRcFile,
@@ -17,14 +18,7 @@ import {
 } from '../../../utils/config'
 import { TargetJson } from '../../../types/configuration'
 
-export async function getCommonFields(): Promise<{
-  scope: TargetScope
-  serverType: ServerType
-  name: string
-  appLoc: string
-  serverUrl: string
-  existingTarget: TargetJson
-}> {
+export async function getCommonFields(): Promise<CommonFields> {
   const scope = await getAndValidateScope()
   const serverType = await getAndValidateServerType()
   const name = await getAndValidateTargetName(serverType)
@@ -63,11 +57,10 @@ async function getAndValidateScope(): Promise<TargetScope> {
     throw new Error(errorMessage)
   })
 
-  if (scope === null || scope === undefined || Number.isNaN(scope)) {
+  if (!scope) {
     throw new Error(errorMessage)
   }
 
-  console.log('Scope: ', scope)
   return scope === 1 ? TargetScope.Local : TargetScope.Global
 }
 
@@ -150,11 +143,10 @@ async function getAndValidateUpdateExisting(
       throw new Error(errorMessage)
     })
 
-    if (choice === null || choice === undefined || Number.isNaN(choice)) {
+    if (!choice) {
       throw new Error(errorMessage)
     }
 
-    console.log('Choice: ', choice)
     return { targetJson, retry: choice === 2 }
   }
 

--- a/src/commands/add/internal/input.ts
+++ b/src/commands/add/internal/input.ts
@@ -144,7 +144,7 @@ async function getAndValidateUpdateExisting(
       'Please choose either option 1 or 2.',
       [
         { title: '1. Update this target', value: 1 },
-        { title: '2. Re-enter target name for new', value: 2 }
+        { title: '2. Go back and create a new target', value: 2 }
       ]
     ).catch(() => {
       throw new Error(errorMessage)

--- a/src/commands/add/spec/add-target.spec.ts
+++ b/src/commands/add/spec/add-target.spec.ts
@@ -15,6 +15,15 @@ import { TargetJson } from '../../../types/configuration'
 import { TargetScope } from '../../../types/targetScope'
 import { createTestMinimalApp, removeTestApp } from '../../../utils/test'
 
+interface CommonFields {
+  scope: TargetScope
+  serverType: ServerType
+  name: string
+  appLoc: string
+  serverUrl: string
+  existingTarget: TargetJson
+}
+
 describe('addTarget', () => {
   const appName = `cli-tests-add-${generateTimestamp()}`
   const viyaTargetName = `test-viya-${generateTimestamp()}`
@@ -39,12 +48,13 @@ describe('addTarget', () => {
   })
 
   it('should create a Viya target in the local sasjsconfig.json file', async (done) => {
-    const commonFields = {
+    const commonFields: CommonFields = {
       scope: TargetScope.Local,
       serverType: ServerType.SasViya,
       name: viyaTargetName,
       appLoc: '/Public/app',
-      serverUrl: process.env.SERVER_URL as string
+      serverUrl: process.env.SERVER_URL as string,
+      existingTarget: {} as TargetJson
     }
     jest
       .spyOn(inputModule, 'getCommonFields')
@@ -57,30 +67,19 @@ describe('addTarget', () => {
 
     await expect(addTarget()).resolves.toEqual(true)
 
-    const { buildSourceFolder } = getConstants()
-    const config = await getConfiguration(
-      path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
-    )
-    expect(config).toBeTruthy()
-    expect(config!.targets).toBeTruthy()
-    const target: TargetJson = (config!.targets || []).find(
-      (t: TargetJson) => t.name === viyaTargetName
-    ) as TargetJson
-    expect(target.name).toEqual(viyaTargetName)
-    expect(target.serverType).toEqual(ServerType.SasViya)
-    expect(target.appLoc).toEqual('/Public/app')
-    expect(target.serverUrl).toEqual(process.env.SERVER_URL)
+    await verifyTarget(commonFields, true)
 
     done()
   })
 
   it('should create a SAS9 target in the local sasjsconfig.json file', async (done) => {
-    const commonFields = {
+    const commonFields: CommonFields = {
       scope: TargetScope.Local,
       serverType: ServerType.Sas9,
       name: sas9TargetName,
       appLoc: '/Public/app',
-      serverUrl: process.env.SERVER_URL as string
+      serverUrl: process.env.SERVER_URL as string,
+      existingTarget: {} as TargetJson
     }
     jest
       .spyOn(inputModule, 'getCommonFields')
@@ -94,38 +93,19 @@ describe('addTarget', () => {
 
     await expect(addTarget()).resolves.toEqual(true)
 
-    const { buildSourceFolder } = getConstants()
-    const config = await getConfiguration(
-      path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
-    )
-
-    expect(config).toBeTruthy()
-    expect(config!.targets).toBeTruthy()
-
-    const target: TargetJson = (config!.targets || []).find(
-      (t: TargetJson) => t.name === sas9TargetName
-    ) as TargetJson
-
-    expect(target.name).toEqual(sas9TargetName)
-    expect(target.serverType).toEqual(ServerType.Sas9)
-    expect(target.appLoc).toEqual('/Public/app')
-    expect(target.serverUrl).toEqual(process.env.SERVER_URL)
-
-    const buildFileName = target.buildConfig
-      ? target.buildConfig.buildOutputFileName
-      : ''
-    expect(buildFileName).toEqual(`${sas9TargetName}.sas`)
+    await verifyTarget(commonFields, true)
 
     done()
   })
 
   it('should create a target in the global .sasjsrc file', async (done) => {
-    const commonFields = {
+    const commonFields: CommonFields = {
       scope: TargetScope.Global,
       serverType: ServerType.SasViya,
       name: viyaTargetName,
       appLoc: '/Public/app',
-      serverUrl: process.env.SERVER_URL as string
+      serverUrl: process.env.SERVER_URL as string,
+      existingTarget: {} as TargetJson
     }
     jest
       .spyOn(inputModule, 'getCommonFields')
@@ -138,19 +118,128 @@ describe('addTarget', () => {
 
     await expect(addTarget()).resolves.toEqual(true)
 
-    const config = await getGlobalRcFile()
-    expect(config).toBeTruthy()
-    expect(config.targets).toBeTruthy()
-    const matchingTargets: Target[] = config.targets.filter(
-      (t: Target) => t.name === viyaTargetName
+    await verifyTarget(commonFields, false)
+
+    done()
+  })
+
+  it('should update a Viya target in the local sasjsconfig.json file', async (done) => {
+    const { buildSourceFolder } = getConstants()
+    const config = await getConfiguration(
+      path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
     )
-    expect(matchingTargets.length).toEqual(1)
-    const target = matchingTargets[0]
-    expect(target.name).toEqual(viyaTargetName)
-    expect(target.serverType).toEqual(ServerType.SasViya)
-    expect(target.appLoc).toEqual('/Public/app')
-    expect(target.serverUrl).toEqual(process.env.SERVER_URL)
+    const target: TargetJson = (config!.targets || []).find(
+      (t: TargetJson) => t.name === 'viya'
+    ) as TargetJson
+
+    const commonFields: CommonFields = {
+      scope: TargetScope.Local,
+      serverType: ServerType.SasViya,
+      name: 'viya',
+      appLoc: '/Public/app/new/location',
+      serverUrl: process.env.SERVER_URL as string,
+      existingTarget: target
+    }
+    jest
+      .spyOn(inputModule, 'getCommonFields')
+      .mockImplementation(() => Promise.resolve(commonFields))
+    jest
+      .spyOn(inputModule, 'getAndValidateSasViyaFields')
+      .mockImplementation(() =>
+        Promise.resolve({ contextName: 'Test Context' })
+      )
+
+    await expect(addTarget()).resolves.toEqual(true)
+
+    await verifyTarget(commonFields, true)
+
+    done()
+  })
+
+  it('should update a SAS9 target in the local sasjsconfig.json file', async (done) => {
+    const { buildSourceFolder } = getConstants()
+    const config = await getConfiguration(
+      path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
+    )
+    const target: TargetJson = (config!.targets || []).find(
+      (t: TargetJson) => t.name === 'sas9'
+    ) as TargetJson
+
+    const commonFields: CommonFields = {
+      scope: TargetScope.Local,
+      serverType: ServerType.Sas9,
+      name: 'sas9',
+      appLoc: '/Public/app/new/location/2',
+      serverUrl: process.env.SERVER_URL as string,
+      existingTarget: target
+    }
+    jest
+      .spyOn(inputModule, 'getCommonFields')
+      .mockImplementation(() => Promise.resolve(commonFields))
+    jest.spyOn(inputModule, 'getAndValidateSas9Fields').mockImplementation(() =>
+      Promise.resolve({
+        serverName: 'testServer',
+        repositoryName: 'testRepo'
+      })
+    )
+
+    await expect(addTarget()).resolves.toEqual(true)
+
+    await verifyTarget(commonFields, true)
+
+    done()
+  })
+
+  it('should update a target in the global .sasjsrc file', async (done) => {
+    const config = await getGlobalRcFile()
+    const target: TargetJson = (config!.targets || []).find(
+      (t: TargetJson) => t.name === 'viya'
+    ) as TargetJson
+
+    const commonFields: CommonFields = {
+      scope: TargetScope.Global,
+      serverType: ServerType.SasViya,
+      name: 'viya',
+      appLoc: '/Public/app/new/location/3',
+      serverUrl: process.env.SERVER_URL as string,
+      existingTarget: target
+    }
+    jest
+      .spyOn(inputModule, 'getCommonFields')
+      .mockImplementation(() => Promise.resolve(commonFields))
+    jest
+      .spyOn(inputModule, 'getAndValidateSasViyaFields')
+      .mockImplementation(() =>
+        Promise.resolve({ contextName: 'Test Context' })
+      )
+
+    await expect(addTarget()).resolves.toEqual(true)
+
+    await verifyTarget(commonFields, false)
 
     done()
   })
 })
+
+async function verifyTarget(commonFields: CommonFields, isLocal: boolean) {
+  let config
+  if (isLocal) {
+    const { buildSourceFolder } = getConstants()
+    config = await getConfiguration(
+      path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
+    )
+  } else {
+    config = await getGlobalRcFile()
+  }
+
+  const matchingTargets: Target[] = config.targets.filter(
+    (t: Target) => t.name === commonFields.name
+  )
+  expect(matchingTargets.length).toEqual(1)
+  const target = matchingTargets[0]
+
+  expect(target.name).toEqual(commonFields.name)
+  expect(target.serverType).toEqual(commonFields.serverType)
+  expect(target.appLoc).toEqual(commonFields.appLoc)
+  expect(target.serverUrl).toEqual(commonFields.serverUrl)
+}

--- a/src/commands/add/spec/add-target.spec.ts
+++ b/src/commands/add/spec/add-target.spec.ts
@@ -13,16 +13,8 @@ import { generateTimestamp } from '../../../utils/utils'
 import { getConstants } from '../../../constants'
 import { TargetJson } from '../../../types/configuration'
 import { TargetScope } from '../../../types/targetScope'
+import { CommonFields } from '../../../types/commonFields'
 import { createTestMinimalApp, removeTestApp } from '../../../utils/test'
-
-interface CommonFields {
-  scope: TargetScope
-  serverType: ServerType
-  name: string
-  appLoc: string
-  serverUrl: string
-  existingTarget: TargetJson
-}
 
 describe('addTarget', () => {
   const appName = `cli-tests-add-${generateTimestamp()}`

--- a/src/types/commonFields.ts
+++ b/src/types/commonFields.ts
@@ -1,0 +1,12 @@
+import { ServerType } from '@sasjs/utils/types'
+import { TargetScope } from './targetScope'
+import { TargetJson } from './configuration'
+
+export interface CommonFields {
+  scope: TargetScope
+  serverType: ServerType
+  name: string
+  appLoc: string
+  serverUrl: string
+  existingTarget: TargetJson
+}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,4 @@
-import { getString, Target } from '@sasjs/utils'
+import { getString, Target, SasAuthResponse } from '@sasjs/utils'
 import jwtDecode from 'jwt-decode'
 import SASjs from '@sasjs/adapter/node'
 
@@ -37,7 +37,7 @@ export async function refreshTokens(
   clientId: string,
   clientSecret: string,
   refreshToken: string
-) {
+): Promise<SasAuthResponse> {
   const authResponse = await sasjsInstance.refreshTokens(
     clientId,
     clientSecret,
@@ -52,7 +52,7 @@ export async function getNewAccessToken(
   clientId: string,
   clientSecret: string,
   target: Target
-) {
+): Promise<SasAuthResponse> {
   const authUrl = getAuthUrl(target.serverUrl, clientId)
   const authCode = await getAuthCode(authUrl)
   const authResponse = await sasjsInstance.getAccessToken(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -99,7 +99,7 @@ export async function findTargetInConfiguration(
       : undefined
 
     if (fallBackTargetJson) {
-      process.logger?.warn(
+      process.logger?.info(
         `Target ${targetName || ''} was not found. Falling back to target ${
           fallBackTargetJson.name
         } from your local sasjsconfig.json file.`
@@ -122,7 +122,7 @@ export async function findTargetInConfiguration(
     : undefined
 
   if (fallBackTargetJson) {
-    process.logger?.warn(
+    process.logger?.info(
       `Target ${targetName || ''} was not found. Falling back to target ${
         fallBackTargetJson.name
       } from your global .sasjsrc file.`

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -84,6 +84,11 @@ export async function findTargetInConfiguration(
     }
   }
 
+  if (targetName)
+    throw new Error(
+      `Target \`${targetName}\` was not found.\nPlease check the target name and try again, or use \`sasjs add\` to add a new target.`
+    )
+
   let fallBackTargetJson
 
   if (localConfig?.targets) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -256,7 +256,9 @@ export async function getSourcePaths(buildSourceFolder: string) {
 
   const sourcePaths = configuration.macroFolders
     ? configuration.macroFolders.map((macroPath: string) =>
-        path.join(buildSourceFolder, macroPath)
+        path.isAbsolute(macroPath)
+          ? macroPath
+          : path.join(buildSourceFolder, macroPath)
       )
     : []
   const macroCorePath = path.join(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -100,9 +100,7 @@ export async function findTargetInConfiguration(
 
     if (fallBackTargetJson) {
       process.logger?.info(
-        `Target ${targetName || ''} was not found. Falling back to target ${
-          fallBackTargetJson.name
-        } from your local sasjsconfig.json file.`
+        `No target was specified. Falling back to target '${fallBackTargetJson.name}' from your local sasjsconfig.json file.`
       )
       fallBackTargetJson.allowInsecureRequests = getPrecedenceOfInsecureRequests(
         localConfig,
@@ -123,9 +121,7 @@ export async function findTargetInConfiguration(
 
   if (fallBackTargetJson) {
     process.logger?.info(
-      `Target ${targetName || ''} was not found. Falling back to target ${
-        fallBackTargetJson.name
-      } from your global .sasjsrc file.`
+      `No target was specified. Falling back to target '${fallBackTargetJson.name}' from your global .sasjsrc file.`
     )
     fallBackTargetJson.allowInsecureRequests = getPrecedenceOfInsecureRequests(
       globalConfig,


### PR DESCRIPTION
## Issue

Closes #332
Closes #500 
Closes #495

## Intent

- If target is specified in any `sasjs <command>`, and not found it should stop and do not fall back to first.
- if target name is not specifed in any `sasjs <command`, then fallback message should be _INFO_ not _WARN_
- While `sasjs add target`, if specified `targetName` is found, instead of giving error, show option to update this `target`

## Implementation

Error throw in `findTargetInConfiguration`, if targetName is provided and not found and changed logger warning -> info
`getCommonFields` in `addTarget.ts` is changed and also returns `existingTarget`, added new user input `getAndValidateUpdateExisting`
`add-target.spec.ts` is refactored and added more tests to it.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).

mocked: 
![image](https://user-images.githubusercontent.com/8914650/110049019-cdf41000-7d72-11eb-8bf6-bfab15a6b0de.png)


server:
![image](https://user-images.githubusercontent.com/8914650/110048998-c2a0e480-7d72-11eb-9110-ade7965442f9.png)


- [ ] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
