### PR TITLE
fix: inherit streamConfig for building web app

### DIFF
--- a/src/commands/web/spec/web.spec.ts
+++ b/src/commands/web/spec/web.spec.ts
@@ -1,0 +1,62 @@
+import { buildWebApp } from '../../../main'
+import { Command } from '../../../utils/command'
+import {
+  createTestMinimalApp,
+  removeTestApp,
+  updateConfig,
+  updateTarget,
+  verifyFolder
+} from '../../../utils/test'
+import { generateTimestamp } from '../../../utils/utils'
+import { Folder } from '../../../types'
+import { StreamConfig } from '@sasjs/utils/types/config'
+
+export const webBuiltFiles: Folder = {
+  folderName: 'sasjsbuild',
+  files: [],
+  subFolders: [
+    {
+      folderName: 'services',
+      files: [{ fileName: 'clickme.sas' }],
+      subFolders: [
+        {
+          folderName: 'webv',
+          files: [{ fileName: 'scriptsjs.sas' }, { fileName: 'stylecss.sas' }],
+          subFolders: []
+        }
+      ]
+    }
+  ]
+}
+
+describe('sasjs web', () => {
+  let appName: string
+
+  afterEach(async () => {
+    await removeTestApp(__dirname, appName)
+  })
+
+  it(
+    `should create web app with minimal template`,
+    async () => {
+      appName = `cli-test-web-minimal-${generateTimestamp()}`
+      await createTestMinimalApp(__dirname, appName)
+
+      await updateConfig({
+        streamConfig: {
+          assetPaths: [],
+          streamWeb: true,
+          streamWebFolder: 'webv',
+          webSourcePath: 'src',
+          streamServiceName: 'clickme'
+        }
+      })
+      await updateTarget({ streamConfig: undefined }, 'viya')
+
+      await expect(buildWebApp(new Command(`web -t viya`))).resolves.toEqual(0)
+
+      await expect(verifyFolder(webBuiltFiles)).resolves.toEqual(true)
+    },
+    2 * 60 * 1000
+  )
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,7 +133,13 @@ export async function compileServices(command: Command) {
   let target: Target = {} as Target
   try {
     target = (await findTargetInConfiguration(targetName)).target
-  } catch (error) {}
+  } catch (error) {
+    if (targetName) {
+      displayError(error, 'An error has occurred when compiling services.')
+      return ReturnCode.InternalError
+    }
+    process.logger.info(`Proceeding without any Target`)
+  }
 
   if (subCommand) {
     return await executeSingleFileCompile(target, command, subCommand)
@@ -148,7 +154,13 @@ export async function buildServices(command: Command) {
     targetName = command.getTargetWithoutFlag() as string
   }
 
-  const { target } = await findTargetInConfiguration(targetName)
+  let target: Target
+  try {
+    ;({ target } = await findTargetInConfiguration(targetName))
+  } catch (error) {
+    displayError(error, 'An error has occurred when building services.')
+    return ReturnCode.InternalError
+  }
 
   return await executeBuild(target)
 }
@@ -160,7 +172,13 @@ export async function deployServices(command: Command) {
     targetName = command.getTargetWithoutFlag() as string
   }
 
-  const { target, isLocal } = await findTargetInConfiguration(targetName)
+  let target: Target, isLocal: boolean
+  try {
+    ;({ target, isLocal } = await findTargetInConfiguration(targetName))
+  } catch (error) {
+    displayError(error, 'An error has occurred when deploying services.')
+    return ReturnCode.InternalError
+  }
 
   return await executeDeploy(target, isLocal)
 }
@@ -172,7 +190,16 @@ export async function compileBuildServices(command: Command) {
     targetName = command.getTargetWithoutFlag() as string
   }
 
-  const { target } = await findTargetInConfiguration(targetName)
+  let target: Target
+  try {
+    ;({ target } = await findTargetInConfiguration(targetName))
+  } catch (error) {
+    displayError(
+      error,
+      'An error has occurred when compiling/building services.'
+    )
+    return ReturnCode.InternalError
+  }
 
   return await executeCompile(target).then(async (returnCode) => {
     if (returnCode === ReturnCode.Success) {
@@ -190,7 +217,16 @@ export async function compileBuildDeployServices(command: Command) {
     targetName = command.getTargetWithoutFlag() as string
   }
 
-  const { target, isLocal } = await findTargetInConfiguration(targetName)
+  let target: Target, isLocal: boolean
+  try {
+    ;({ target, isLocal } = await findTargetInConfiguration(targetName))
+  } catch (error) {
+    displayError(
+      error,
+      'An error has occurred when compiling/building/deploying services.'
+    )
+    return ReturnCode.InternalError
+  }
 
   return await executeCompile(target)
     .then(async (returnCode) => {
@@ -239,7 +275,13 @@ export async function buildWebApp(command: Command) {
     targetName = command.getTargetWithoutFlag() as string
   }
 
-  const { target } = await findTargetInConfiguration(targetName)
+  let target: Target
+  try {
+    ;({ target } = await findTargetInConfiguration(targetName))
+  } catch (error) {
+    displayError(error, 'An error has occurred when building web app.')
+    return ReturnCode.InternalError
+  }
 
   return await createWebAppServices(target)
     .then(() => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -94,7 +94,7 @@ export async function findTargetInConfiguration(
     if (target) return { target, isLocal: false }
 
     throw new Error(
-      `No target was found.\nPlease check the target name and try again, or use \`sasjs add\` to add a new target.`
+      `Unable to find any default target.\nPlease check the target name and try again, or use \`sasjs add\` to add a new target.`
     )
   }
 }

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -112,7 +112,6 @@ export const createTestGlobalTarget = async (
 export const verifyStep = async (
   step: 'db' | 'compile' | 'build' = 'compile'
 ) => {
-  let everythingPresent = false
   const fileStructure: Folder =
     step === 'db'
       ? dbFiles
@@ -122,9 +121,7 @@ export const verifyStep = async (
       ? builtFiles
       : compiledFiles
 
-  everythingPresent = await verifyFolder(fileStructure)
-
-  expect(everythingPresent).toEqual(true)
+  await expect(verifyFolder(fileStructure)).resolves.toEqual(true)
 }
 
 export const mockProcessExit = () =>
@@ -195,7 +192,7 @@ export const updateTarget = async (
   }
 }
 
-export const updateConfig = async (config: Configuration) => {
+export const updateConfig = async (config: Partial<Configuration>) => {
   const { buildSourceFolder } = getConstants()
   const configPath = path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
 


### PR DESCRIPTION
## Issue

Closes #553

## Intent

`StreamConfig` should be inherited to target from root level, for all actions in `sasjs web`
Also resolve _unhandled promise rejections_ in `main.ts`

## Implementation

- Updated `main.ts`,  `unhandled promise rejections` were due to `findTargetInConfiugaration`.
- Passed down inherited `StreamConfig` to all actions in _src/commands/web/index.ts_
- Added test for `sasjs web`, with configuration having `streamConfig` at root level and not at target.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
