### PR TITLE
fix: have single home directory .sasjs for sasjsbuild & sasjsresults

### DIFF
--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -186,7 +186,7 @@ describe('sasjs compile single file', () => {
 })
 
 const defaultBuildConfig: BuildConfig = {
-  buildOutputFolder: 'sasjsbuild',
+  buildOutputFolder: '.sasjs/sasjsbuild',
   buildOutputFileName: 'test.sas',
   initProgram: '',
   termProgram: '',
@@ -237,12 +237,12 @@ describe('sasjs compile outside project', () => {
 
     afterAll(async (done) => {
       await removeTestApp(homedir, sharedAppName)
-      await deleteFolder(path.join(homedir, 'sasjsbuild'))
+      await deleteFolder(path.join(homedir, '.sasjs'))
       done()
     })
 
     it('should compile single file', async (done) => {
-      const buildOutputFolder = path.join(homedir, 'sasjsbuild')
+      const buildOutputFolder = path.join(homedir, '.sasjs', 'sasjsbuild')
       const destinationPath = `${buildOutputFolder}/services/services/example1.sas`
       parentOutputFolder = buildOutputFolder
       await expect(
@@ -271,7 +271,7 @@ describe('sasjs compile outside project', () => {
     })
 
     it('should compile single file with absolute macroFolder paths', async (done) => {
-      const buildOutputFolder = path.join(homedir, 'sasjsbuild')
+      const buildOutputFolder = path.join(homedir, '.sasjs', 'sasjsbuild')
       parentOutputFolder = buildOutputFolder
       const destinationPath = `${buildOutputFolder}/services/services/example1.sas`
       const absolutePathToSharedApp = path.join(homedir, sharedAppName)
@@ -310,7 +310,7 @@ describe('sasjs compile outside project', () => {
     })
 
     it('should fail to compile single file', async (done) => {
-      const buildOutputFolder = path.join(homedir, 'sasjsbuild')
+      const buildOutputFolder = path.join(homedir, '.sasjs', 'sasjsbuild')
       parentOutputFolder = buildOutputFolder
       const dependencies = ['examplemacro.sas', 'yetanothermacro.sas']
       await updateConfig(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,9 +24,11 @@ export const getConstants = async (): Promise<Constants> => {
     })
   )
   const buildOutputFolder =
-    configuration?.buildConfig?.buildOutputFolder || 'sasjsbuild'
+    configuration?.buildConfig?.buildOutputFolder ||
+    (isLocal ? 'sasjsbuild' : '.sasjs/sasjsbuild')
   const buildResultsFolder =
-    configuration?.buildConfig?.buildResultsFolder || 'sasjsresults'
+    configuration?.buildConfig?.buildResultsFolder ||
+    (isLocal ? 'sasjsresults' : '.sasjs/sasjsresults')
   const homeDir = require('os').homedir()
   const getMacroCoreGlobalPath = async () => {
     try {


### PR DESCRIPTION
## Issue

Instead of having multiple folders in home directory( ~/sasjsbuild/ and ~/sasjsresults/), need to have ~/.sasjs/ and have both directories in it.

## Implementation

Updated `src/constants.ts` and tests

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
