### PR TITLE
fix(doc): support case-insensitve filename for 'doxyfile' + escaping double qoutes & escape characters

### DIFF
--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -8,6 +8,7 @@ import {
   createFolder,
   deleteFolder,
   folderExists,
+  fileExists,
   readFile
 } from '../../utils/file'
 import { getLocalConfig } from '../../utils/config'
@@ -117,7 +118,8 @@ export async function generateDocs(targetName: string, outDirectory: string) {
     PROJECT_NAME
   })
 
-  const doxyConfigPath = path.join(doxyContent.path, 'Doxyfile')
+  const doxyConfigPath = await getDoxyConfigPath(doxyContent.path)
+  process.logger?.info(`Using ${doxyConfigPath} as Doxygen Configuration.`)
 
   const spinner = ora(
     chalk.greenBright('Generating docs', chalk.cyanBright(newOutDirectory))
@@ -166,4 +168,20 @@ function setVariableCmd(params: any): string {
     }
   }
   return command
+}
+
+const getDoxyConfigPath = async (doxyContentPath: string): Promise<string> => {
+  let doxyFilePath = path.join(doxyContentPath, 'Doxyfile')
+  if (await fileExists(doxyFilePath)) return doxyFilePath
+
+  doxyFilePath = path.join(doxyContentPath, 'DoxyFile')
+  if (await fileExists(doxyFilePath)) return doxyFilePath
+
+  doxyFilePath = path.join(doxyContentPath, 'doxyfile')
+  if (await fileExists(doxyFilePath)) return doxyFilePath
+
+  doxyFilePath = path.join(doxyContentPath, 'doxyFile')
+  if (await fileExists(doxyFilePath)) return doxyFilePath
+
+  throw 'Doxygen Configuration File is not found!\n  Supported names are "Doxyfile", "DoxyFile", "doxyfile" and "doxyFile"'
 }

--- a/src/commands/docs/internal/createDotFiles.ts
+++ b/src/commands/docs/internal/createDotFiles.ts
@@ -24,8 +24,13 @@ export async function createDotFiles(
   const dotFileContent = await getDotFileContent(folderList, serverUrl)
 
   await createFile(dotFilePath, dotFileContent)
+  process.logger?.success(`File ${dotFilePath} has been created.`)
 
-  const svg = await graphviz.dot(dotFileContent, 'svg')
-
-  await createFile(dotGraphPath, svg)
+  try {
+    const svg = await graphviz.dot(dotFileContent, 'svg')
+    await createFile(dotGraphPath, svg)
+    process.logger?.success(`File ${dotGraphPath} has been created.`)
+  } catch (e) {
+    throw 'Unable to generate graph from generated Dot file.\n' + e
+  }
 }

--- a/src/commands/docs/internal/getDotFileContent.ts
+++ b/src/commands/docs/internal/getDotFileContent.ts
@@ -42,7 +42,9 @@ export async function getDotFileContent(
 
       fileNodes.set(fileName, {
         edges: fileOutputs,
-        label: `${fileName} | ${fileBrief}`.replace(/"/g, '\\"')
+        label: `${fileName} | ${fileBrief}`
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"')
       })
     })
   })

--- a/src/commands/docs/internal/getDotFileContent.ts
+++ b/src/commands/docs/internal/getDotFileContent.ts
@@ -42,7 +42,7 @@ export async function getDotFileContent(
 
       fileNodes.set(fileName, {
         edges: fileOutputs,
-        label: `${fileName} | ${fileBrief}`
+        label: `${fileName} | ${fileBrief}`.replace(/"/g, '\\"')
       })
     })
   })
@@ -64,7 +64,7 @@ export async function getDotFileContent(
     const attrURL = serverUrl ? `URL="${serverUrl + key}"` : ''
 
     const NDkey = nodeDictionary.get(key)
-    dotNodes += `${NDkey} [label="${node.label}" ${attrURL} shape="cylinder" style="filled" color="${color}"]\n`
+    dotNodes += `${NDkey} [ label="${node.label}" ${attrURL} shape="cylinder" style="filled" color="${color}"]\n`
 
     if (node.edges.length) {
       const dotFormatEdges = node.edges

--- a/src/commands/docs/spec/generateDot.spec.ts
+++ b/src/commands/docs/spec/generateDot.spec.ts
@@ -173,7 +173,7 @@ describe('sasjs doc lineage', () => {
   )
 
   it(
-    `should generate dot-files custom jobs`,
+    `should generate dot-files custom jobs having double qoutes`,
     async () => {
       appName = `test-app-doc-${generateTimestamp()}`
       const docOutputDefault = path.join(
@@ -188,6 +188,36 @@ describe('sasjs doc lineage', () => {
         {
           jobConfig: {
             jobFolders: ['../testJobHavingDoubleQoutes']
+          } as JobConfig
+        },
+        'viya'
+      )
+
+      await expect(folderExists(docOutputDefault)).resolves.toEqual(false)
+
+      await expect(doc(new Command(`doc lineage -t viya`))).resolves.toEqual(0)
+
+      await verifyDotFiles(docOutputDefault)
+    },
+    60 * 1000
+  )
+
+  it(
+    `should generate dot-files custom jobs having back slashes`,
+    async () => {
+      appName = `test-app-doc-${generateTimestamp()}`
+      const docOutputDefault = path.join(
+        __dirname,
+        appName,
+        'sasjsbuild',
+        'docs'
+      )
+
+      await createTestApp(__dirname, appName)
+      await updateTarget(
+        {
+          jobConfig: {
+            jobFolders: ['../testJobHavingBackSlashes']
           } as JobConfig
         },
         'viya'

--- a/src/commands/docs/spec/generateDot.spec.ts
+++ b/src/commands/docs/spec/generateDot.spec.ts
@@ -171,6 +171,36 @@ describe('sasjs doc lineage', () => {
     },
     60 * 1000
   )
+
+  it(
+    `should generate dot-files custom jobs`,
+    async () => {
+      appName = `test-app-doc-${generateTimestamp()}`
+      const docOutputDefault = path.join(
+        __dirname,
+        appName,
+        'sasjsbuild',
+        'docs'
+      )
+
+      await createTestApp(__dirname, appName)
+      await updateTarget(
+        {
+          jobConfig: {
+            jobFolders: ['../testJobHavingDoubleQoutes']
+          } as JobConfig
+        },
+        'viya'
+      )
+
+      await expect(folderExists(docOutputDefault)).resolves.toEqual(false)
+
+      await expect(doc(new Command(`doc lineage -t viya`))).resolves.toEqual(0)
+
+      await verifyDotFiles(docOutputDefault)
+    },
+    60 * 1000
+  )
 })
 
 const verifyCustomDotFiles = async (docsFolder: string) => {

--- a/src/commands/docs/spec/testJobHavingBackSlashes/runjob2.sas
+++ b/src/commands/docs/spec/testJobHavingBackSlashes/runjob2.sas
@@ -1,0 +1,32 @@
+/**
+  @file
+  @brief runjob2 \some text\\more
+  @details Get a list of Viya users
+
+
+  <h4> SAS Macros </h4>
+  @li example.sas
+  @li mv_getusers.sas
+
+  <h4> Data Inputs </h4>
+  @li sas9hrdb.test
+  @li mylib.example
+  @li mylib.demotable3
+
+  <h4> Data Outputs </h4>
+  @li mylib.users
+
+**/
+
+%let input1=sas9hrdb.test; /* example */
+%let output1=&mylib..users;
+
+%example(runjob2 is executing)
+
+/* here we are using one of the @sasjs/core macros */
+%mv_getusers(outds=users)
+
+data &output1;
+  set work.users;
+run;
+

--- a/src/commands/docs/spec/testJobHavingDoubleQoutes/runjob1.sas
+++ b/src/commands/docs/spec/testJobHavingDoubleQoutes/runjob1.sas
@@ -1,0 +1,23 @@
+/**
+  @file
+  @brief runjob1 " t"est"
+  @details In the flow this is defined to run after the dependent flows have
+  finished (successfully)
+
+
+  <h4> SAS Macros </h4>
+  @li example.sas
+  @li mf_nobs.sas
+
+  <h4> Data Outputs </h4>
+  @li sas9hrdb.test
+
+**/
+
+%example(runjob1 is executing)
+
+/* here we are using one of the @sasjs/core macros */
+data work.somedata;
+  x=%mf_nobs(sashelp.class);
+run;
+


### PR DESCRIPTION
## Issue

Closes #578
Support case-insensitive filename for doxygen configuration, currently its `Doxyfile`

## Intent

`sasjs doc`  should not fail when @brief attribute contains double quotes
doxygen configuration filename should be case-insensitive

## Implementation

Updated `createDotFiles.ts` 
- Added try catch for future unknown errors
- Added file creation logger messages

Updated `getDotFileContent.ts `
- embedded quotes escaped before writing to DOT file

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
