### PR TITLE
fix: utils/lint version updated + removed cli logic for lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,9 +1554,9 @@
       "integrity": "sha512-OiR0lG3sBJAVumgONlb52L6+t0HRYqF30LJKWqJNCrR62XnN0jXQLtPGGiiAi98AU7cUJTCWtV/+JBUe00kjyA=="
     },
     "@sasjs/lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.4.1.tgz",
-      "integrity": "sha512-865n0mVb6tQnu25X6iKGcSpadkbu7i4zXzY4zfSGx1B3ifCt+C8BLCeqd1EqvClsPfvpIYQWFPkDtWT9zofFTQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.5.0.tgz",
+      "integrity": "sha512-mNg+zJ6114J3/CrkmIK9JJF5PU3Orc2qg2RUuLy0+KrOGM33Pbxe4kkquaHZ/A9qJt5Klk3mCTh9M3zwAzTjrA==",
       "requires": {
         "@sasjs/utils": "^2.10.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,30 +1554,17 @@
       "integrity": "sha512-OiR0lG3sBJAVumgONlb52L6+t0HRYqF30LJKWqJNCrR62XnN0jXQLtPGGiiAi98AU7cUJTCWtV/+JBUe00kjyA=="
     },
     "@sasjs/lint": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.2.0.tgz",
-      "integrity": "sha512-APvKLZnJPulRO6LoBPg7tNBO5Ye2NIhMrmeqlFMdC4mRuIfTLos8U7BjEc1TjHycIlZE8QKNxo+iqQcpvnD3Iw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.4.1.tgz",
+      "integrity": "sha512-865n0mVb6tQnu25X6iKGcSpadkbu7i4zXzY4zfSGx1B3ifCt+C8BLCeqd1EqvClsPfvpIYQWFPkDtWT9zofFTQ==",
       "requires": {
-        "@sasjs/utils": "^2.9.0"
-      },
-      "dependencies": {
-        "@sasjs/utils": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.9.0.tgz",
-          "integrity": "sha512-j7ssEmb8OSZHUUL0PGVgoby0j0ClCcsLsydDCk/C4OAoWPAUPFI5HgGFPSEipz9+P8OlL/EBnglj4LGtlFHCpw==",
-          "requires": {
-            "@types/prompts": "^2.0.9",
-            "consola": "^2.15.0",
-            "prompts": "^2.4.0",
-            "valid-url": "^1.0.9"
-          }
-        }
+        "@sasjs/utils": "^2.10.1"
       }
     },
     "@sasjs/utils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.8.0.tgz",
-      "integrity": "sha512-rVquLqs81oDE+itxCmrPXiEvSDmlrBGyrzFc9+YPOySDbi6NKVOgNY5g/PKfYNvrCuM7F1FBuJNpi+QYEX2lQw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.10.1.tgz",
+      "integrity": "sha512-T54jx6NEMLu2+R/ux4qcb3dDJ7nFrKkPCkmPXEfZxPQBkbq4C0kmaZv6dC63RDH68wYhoXR2S5fION5fFh91iw==",
       "requires": {
         "@types/prompts": "^2.0.9",
         "consola": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "copy:files": "copyfiles -u 1 ./src/config.json ./build/ && npm run copy:doxy",
     "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/",
     "test": "npm run test:mocked && npm run test:server",
-    "test:server": "jest --silent --runInBand --config=jest.server.config.js",
+    "test:server": "jest --silent --config=jest.server.config.js",
     "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
     "semantic-release": "semantic-release -d",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@sasjs/adapter": "^2.2.13",
     "@sasjs/core": "^2.13.2",
-    "@sasjs/lint": "^1.2.0",
+    "@sasjs/lint": "^1.4.1",
     "@sasjs/utils": "^2.8.0",
     "btoa": "^1.2.1",
     "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "copy:files": "copyfiles -u 1 ./src/config.json ./build/ && npm run copy:doxy",
     "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/",
     "test": "npm run test:mocked && npm run test:server",
-    "test:server": "jest --silent --config=jest.server.config.js",
+    "test:server": "jest --silent --runInBand --config=jest.server.config.js",
     "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
     "semantic-release": "semantic-release -d",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",

--- a/src/commands/job/spec/job.spec.server.ts
+++ b/src/commands/job/spec/job.spec.server.ts
@@ -92,7 +92,7 @@ describe('sasjs job execute', () => {
     const folderPath = path.join(process.projectDir, 'testOutput')
     const filePath = path.join(process.projectDir, 'testOutput/output.json')
 
-    await processJob(command)
+    await expect(processJob(command)).toResolve()
 
     await expect(folderExists(folderPath)).resolves.toEqual(true)
     await expect(fileExists(filePath)).resolves.toEqual(true)
@@ -108,7 +108,7 @@ describe('sasjs job execute', () => {
     const folderPath = path.join(process.projectDir, 'testOutput')
     const filePath = path.join(process.projectDir, 'testOutput/output.json')
 
-    await processJob(command)
+    await expect(processJob(command)).toResolve()
 
     await expect(folderExists(folderPath)).resolves.toEqual(true)
     await expect(fileExists(filePath)).resolves.toEqual(true)
@@ -129,7 +129,7 @@ describe('sasjs job execute', () => {
 
     const filePathLog = path.join(process.projectDir, 'testLog.txt')
 
-    await processJob(command)
+    await expect(processJob(command)).toResolve()
 
     await expect(folderExists(folderPathOutput)).resolves.toEqual(true)
     await expect(fileExists(filePathOutput)).resolves.toEqual(true)
@@ -145,7 +145,8 @@ describe('sasjs job execute', () => {
     )
 
     const filePath = path.join(process.projectDir, 'job.log')
-    await processJob(command)
+
+    await expect(processJob(command)).toResolve()
 
     await expect(fileExists(filePath)).resolves.toEqual(true)
 
@@ -162,7 +163,7 @@ describe('sasjs job execute', () => {
 
       const filePath = path.join(process.projectDir, 'largeLogJob.log')
 
-      await processJob(command)
+      await expect(processJob(command)).toResolve()
 
       await expect(fileExists(filePath)).resolves.toEqual(true)
 
@@ -184,7 +185,7 @@ describe('sasjs job execute', () => {
 
     const filePath = path.join(process.projectDir, 'mycustom.log')
 
-    await processJob(command)
+    await expect(processJob(command)).toResolve()
 
     await expect(fileExists(filePath)).resolves.toEqual(true)
 
@@ -199,7 +200,7 @@ describe('sasjs job execute', () => {
     const folderPath = path.join(process.projectDir, 'my/folder')
     const filePath = path.join(process.projectDir, 'my/folder/mycustom.log')
 
-    await processJob(command)
+    await expect(processJob(command)).toResolve()
 
     await expect(folderExists(folderPath)).resolves.toEqual(true)
     await expect(fileExists(filePath)).resolves.toEqual(true)
@@ -219,7 +220,7 @@ describe('sasjs job execute', () => {
       'my/folder/testJob.status'
     )
 
-    await processJob(command)
+    await expect(processJob(command)).toResolve()
 
     await expect(folderExists(folderPath)).resolves.toEqual(true)
     await expect(fileExists(filePath)).resolves.toEqual(true)

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -1,28 +1,14 @@
-import path from 'path'
 import chalk from 'chalk'
 import cliTable from 'cli-table'
 import { lintProject, Diagnostic, Severity } from '@sasjs/lint'
-
-import { asyncForEach } from '../../utils/utils'
-import { getSubFoldersInFolder, getFilesInFolder } from '../../utils/file'
 
 interface LintResult {
   warnings: boolean
   errors: boolean
 }
 
-const excludeFolders = [
-  '.git',
-  '.github',
-  '.vscode',
-  'node_modules',
-  'sasjsbuild',
-  'sasjsresults'
-]
-
 /**
- * Looks for parent folder containing .sasjslint, if found that will be starting point else project directory
- * Linting all .sas files from starting point to sub-directories
+ * Linting all .sas files in project
  * @returns an object containing booleans `warnings` and `errors`
  */
 export async function processLint(): Promise<LintResult> {

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -1,8 +1,7 @@
 import path from 'path'
 import chalk from 'chalk'
 import cliTable from 'cli-table'
-import { lintFile, Diagnostic, Severity } from '@sasjs/lint'
-import { getProjectRoot as getDirectoryContainingLintConfig } from '@sasjs/lint/utils/getProjectRoot'
+import { lintProject, Diagnostic, Severity } from '@sasjs/lint'
 
 import { asyncForEach } from '../../utils/utils'
 import { getSubFoldersInFolder, getFilesInFolder } from '../../utils/file'
@@ -27,30 +26,11 @@ const excludeFolders = [
  * @returns an object containing booleans `warnings` and `errors`
  */
 export async function processLint(): Promise<LintResult> {
-  const lintConfigFolder =
-    (await getDirectoryContainingLintConfig()) ||
-    process.projectDir ||
-    process.currentDir
-
-  return await executeLint(lintConfigFolder)
-}
-
-/**
- * Linting all .sas files from provided folder
- * @param {string} folderPath- the path to folder as starting point
- * @returns an object containing booleans `warnings` and `errors`
- */
-async function executeLint(folderPath: string): Promise<LintResult> {
   const found = { warnings: false, errors: false }
-  const files = (await getFilesInFolder(folderPath)).filter((f: string) =>
-    f.endsWith('.sas')
-  )
+  const sasjsDiagnosticsMap: Map<string, Diagnostic[]> = await lintProject()
 
-  await asyncForEach(files, async (file) => {
-    const filePath = path.join(folderPath, file)
-    const sasjsDiagnostics = await lintFile(filePath)
-
-    if (sasjsDiagnostics.length) {
+  sasjsDiagnosticsMap.forEach(
+    (sasjsDiagnostics: Diagnostic[], filePath: string) => {
       found.warnings =
         found.warnings ||
         !!sasjsDiagnostics.find(
@@ -61,19 +41,11 @@ async function executeLint(folderPath: string): Promise<LintResult> {
         !!sasjsDiagnostics.find(
           (d: Diagnostic) => d.severity === Severity.Error
         )
-      displayDiagnostics(filePath, sasjsDiagnostics)
+      if (sasjsDiagnostics.length) {
+        displayDiagnostics(filePath, sasjsDiagnostics)
+      }
     }
-  })
-
-  const subFolders = (await getSubFoldersInFolder(folderPath)).filter(
-    (f: string) => !excludeFolders.includes(f)
   )
-
-  await asyncForEach(subFolders, async (subFolder) => {
-    const result = await executeLint(path.join(folderPath, subFolder))
-    found.warnings = found.warnings || result.warnings
-    found.errors = found.errors || result.errors
-  })
 
   return found
 }

--- a/src/commands/lint/index.ts
+++ b/src/commands/lint/index.ts
@@ -12,7 +12,7 @@ interface LintResult {
  * @returns an object containing booleans `warnings` and `errors`
  */
 export async function processLint(): Promise<LintResult> {
-  const found = { warnings: false, errors: false }
+  const found: LintResult = { warnings: false, errors: false }
   const sasjsDiagnosticsMap: Map<string, Diagnostic[]> = await lintProject()
 
   sasjsDiagnosticsMap.forEach(

--- a/src/commands/run/run.ts
+++ b/src/commands/run/run.ts
@@ -83,11 +83,7 @@ async function executeOnSasViya(
       let log = err.log
 
       if (!log)
-        throw new ErrorResponse(
-          'We were not able to fetch the log this time.',
-          err,
-          err
-        )
+        throw new ErrorResponse('We were not able to fetch the log this time.')
 
       const createdFilePath = await createOutputFile(log)
       process.logger?.error(`Log file has been created at ${createdFilePath} .`)

--- a/src/commands/run/run.ts
+++ b/src/commands/run/run.ts
@@ -83,7 +83,11 @@ async function executeOnSasViya(
       let log = err.log
 
       if (!log)
-        throw new ErrorResponse('We were not able to fetch the log this time.')
+        throw new ErrorResponse(
+          'We were not able to fetch the log this time.',
+          err,
+          err
+        )
 
       const createdFilePath = await createOutputFile(log)
       process.logger?.error(`Log file has been created at ${createdFilePath} .`)

--- a/src/commands/run/spec/run.spec.server.ts
+++ b/src/commands/run/spec/run.spec.server.ts
@@ -98,7 +98,7 @@ describe('sasjs run', () => {
     it(
       'should get the log on successfull execution having relative path but compile it first',
       async () => {
-        const logPart = `646  data;\n647    do x=1 to 100;\n648      output;\n649    end;\n650  run;`
+        const logPartRegex = /[0-9]*  data;\n[0-9]*    do x=1 to 100;\n[0-9]*      output;\n[0-9]*    end;\n[0-9]*  run;\n/
 
         const result: any = await runSasCode(
           new Command(
@@ -106,7 +106,7 @@ describe('sasjs run', () => {
           )
         )
 
-        expect(result.log.includes(logPart)).toBeTruthy()
+        expect(logPartRegex.test(result.log)).toBeTruthy()
       },
 
       60 * 1000
@@ -115,7 +115,7 @@ describe('sasjs run', () => {
     it(
       'should get the log on successfull execution having absolute path but compile it first',
       async () => {
-        const logPart = `646  data;\n647    do x=1 to 100;\n648      output;\n649    end;\n650  run;`
+        const logPartRegex = /[0-9]*  data;\n[0-9]*    do x=1 to 100;\n[0-9]*      output;\n[0-9]*    end;\n[0-9]*  run;\n/
 
         const result: any = await runSasCode(
           new Command(
@@ -123,7 +123,7 @@ describe('sasjs run', () => {
           )
         )
 
-        expect(result.log.includes(logPart)).toBeTruthy()
+        expect(logPartRegex.test(result.log)).toBeTruthy()
       },
 
       60 * 1000
@@ -270,7 +270,7 @@ describe('sasjs run', () => {
     it(
       'should get the log on successfull execution having relative path but compile it first',
       async () => {
-        const logPart = `\n458  data;\n459    do x=1 to 100;\n460      output;\n461    end;\n462  run;`
+        const logPartRegex = /[0-9]*  data;\n[0-9]*    do x=1 to 100;\n[0-9]*      output;\n[0-9]*    end;\n[0-9]*  run;\n/
 
         const result: any = await runSasCode(
           new Command(
@@ -278,7 +278,7 @@ describe('sasjs run', () => {
           )
         )
 
-        expect(result.log.includes(logPart)).toBeTruthy()
+        expect(logPartRegex.test(result.log)).toBeTruthy()
       },
 
       60 * 1000
@@ -287,7 +287,7 @@ describe('sasjs run', () => {
     it(
       'should get the log on successfull execution having absolute path but compile it first',
       async () => {
-        const logPart = `\n458  data;\n459    do x=1 to 100;\n460      output;\n461    end;\n462  run;`
+        const logPartRegex = /[0-9]*  data;\n[0-9]*    do x=1 to 100;\n[0-9]*      output;\n[0-9]*    end;\n[0-9]*  run;\n/
 
         const result: any = await runSasCode(
           new Command(
@@ -295,7 +295,7 @@ describe('sasjs run', () => {
           )
         )
 
-        expect(result.log.includes(logPart)).toBeTruthy()
+        expect(logPartRegex.test(result.log)).toBeTruthy()
       },
 
       60 * 1000


### PR DESCRIPTION
## Issue

Move CLI logic related to lint moved to utils/lint

## Implementation

- utils/lint version updated
- removed code from `lint/index.ts`, because logic is moved to `utils/lint`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
