### PR TITLE
fix: updating core library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,9 +1554,9 @@
       "integrity": "sha512-L8lMsrn/+EL5MTTEuyfqTMAEJgZOjk4FKnKw99TFv0yP+u6qLr+7kgkhu9yWeq9/+hFadVTh2yAzC5NaBr6kIQ=="
     },
     "@sasjs/lint": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.5.0.tgz",
-      "integrity": "sha512-mNg+zJ6114J3/CrkmIK9JJF5PU3Orc2qg2RUuLy0+KrOGM33Pbxe4kkquaHZ/A9qJt5Klk3mCTh9M3zwAzTjrA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.6.1.tgz",
+      "integrity": "sha512-UegHiMTn3o3lujX8gnAfqbSI5q/DWiseDYYR5W0rnlaP4bTjza7aFDPZiBbhhHqPF6vnKKeWWWV9SZQXw474AQ==",
       "requires": {
         "@sasjs/utils": "^2.10.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,9 +1549,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.16.0.tgz",
-      "integrity": "sha512-zqBIW52KPNvR1TlzYPZ4KhKbFFQb3bpbxVUbBYs13K0lCVvP7cLETjgtXzLOdj3NqfVwtTykdPHD8RTH65GNow=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.17.0.tgz",
+      "integrity": "sha512-0apL+K/q3Ml/CjFGTABjn2qPRkqWYzIOnBcm/dZQ7H3lASKH6FpVJDORNurDUgD4kMTaJv1ezIOxFTc8FGI9BQ=="
     },
     "@sasjs/lint": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,9 +1549,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.17.0.tgz",
-      "integrity": "sha512-0apL+K/q3Ml/CjFGTABjn2qPRkqWYzIOnBcm/dZQ7H3lASKH6FpVJDORNurDUgD4kMTaJv1ezIOxFTc8FGI9BQ=="
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.17.1.tgz",
+      "integrity": "sha512-L8lMsrn/+EL5MTTEuyfqTMAEJgZOjk4FKnKw99TFv0yP+u6qLr+7kgkhu9yWeq9/+hFadVTh2yAzC5NaBr6kIQ=="
     },
     "@sasjs/lint": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1562,14 +1562,25 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.10.1.tgz",
-      "integrity": "sha512-T54jx6NEMLu2+R/ux4qcb3dDJ7nFrKkPCkmPXEfZxPQBkbq4C0kmaZv6dC63RDH68wYhoXR2S5fION5fFh91iw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.10.2.tgz",
+      "integrity": "sha512-N5nIsz7NUs1Yt0Am0QGs9UXDkN396ialCIfIRsNR9h4VtQRzvOwjXrsLnr3AUAAV9Z8h9CtadkC3W6MAzrQaOg==",
       "requires": {
-        "@types/prompts": "^2.0.9",
+        "@types/prompts": "^2.0.10",
         "consola": "^2.15.0",
-        "prompts": "^2.4.0",
+        "prompts": "^2.4.1",
         "valid-url": "^1.0.9"
+      },
+      "dependencies": {
+        "prompts": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+          "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+          "requires": {
+            "kleur": "^3.0.3",
+            "sisteransi": "^1.0.5"
+          }
+        }
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -1933,9 +1944,9 @@
       "dev": true
     },
     "@types/prompts": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
-      "integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.10.tgz",
+      "integrity": "sha512-W3PEl3l4vmxdgfY6LUG7ysh+mLJOTOFYmSpiLe6MCo1OdEm8b5s6ZJfuTQgEpYNwcMiiaRzJespPS5Py2tqLlQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -11092,6 +11103,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
       "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+      "dev": true,
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,9 +1549,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.13.2.tgz",
-      "integrity": "sha512-OiR0lG3sBJAVumgONlb52L6+t0HRYqF30LJKWqJNCrR62XnN0jXQLtPGGiiAi98AU7cUJTCWtV/+JBUe00kjyA=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-zqBIW52KPNvR1TlzYPZ4KhKbFFQb3bpbxVUbBYs13K0lCVvP7cLETjgtXzLOdj3NqfVwtTykdPHD8RTH65GNow=="
     },
     "@sasjs/lint": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "^2.2.13",
-    "@sasjs/core": "^2.17.0",
+    "@sasjs/core": "^2.17.1",
     "@sasjs/lint": "^1.4.1",
     "@sasjs/utils": "^2.8.0",
     "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "^2.2.13",
-    "@sasjs/core": "^2.16.0",
+    "@sasjs/core": "^2.17.0",
     "@sasjs/lint": "^1.4.1",
     "@sasjs/utils": "^2.8.0",
     "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "^2.2.13",
-    "@sasjs/core": "^2.13.2",
+    "@sasjs/core": "^2.16.0",
     "@sasjs/lint": "^1.2.0",
     "@sasjs/utils": "^2.8.0",
     "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@sasjs/adapter": "^2.2.13",
     "@sasjs/core": "^2.17.1",
     "@sasjs/lint": "^1.6.1",
-    "@sasjs/utils": "^2.8.0",
+    "@sasjs/utils": "^2.10.2",
     "btoa": "^1.2.1",
     "chalk": "^4.1.0",
     "cli-table": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@sasjs/adapter": "^2.2.13",
     "@sasjs/core": "^2.17.1",
-    "@sasjs/lint": "^1.4.1",
+    "@sasjs/lint": "^1.6.1",
     "@sasjs/utils": "^2.8.0",
     "btoa": "^1.2.1",
     "chalk": "^4.1.0",

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -113,7 +113,7 @@ async function getBuildInfo(target: Target) {
   )
   const dependenciesContent = await getDependencies(dependencyFilePaths)
   const buildVars = await getBuildVars(target)
-  return `%global appLoc;\n%let appLoc=%sysfunc(coalescec(&appLoc,${appLoc})); /* metadata or files service location of your app */\n%let sasjs_clickmeservice=clickme;\n%let syscc=0;\noptions ps=max noquotelenmax;\n${buildVars}\n${dependenciesContent}\n${buildConfig}\n`
+  return `%global appLoc;\n%let appLoc=%sysfunc(coalescec(&appLoc,${appLoc})); /* metadata or files service location of your app */\n%let sasjs_clickmeservice=clickme;\n%let syscc=0;\noptions ps=max nonotes nosgen nomprint nomlogic nosource2 nosource noquotelenmax;\n${buildVars}\n${dependenciesContent}\n${buildConfig}\n`
 }
 
 async function getCreateWebServiceScript(serverType: ServerType) {


### PR DESCRIPTION
## Issue

The previous version of @sasjs/core used a different git hooks library that left a message in the install console.  The new one leaves no unnecessary message.