### PR TITLE
feat: Switch <h4> SAS Programs </h4> to <h4> SAS Includes </h4>

### DIFF
--- a/src/commands/compile/internal/loadDependencies.ts
+++ b/src/commands/compile/internal/loadDependencies.ts
@@ -42,6 +42,20 @@ export async function loadDependencies(
     }
   }
 
+  if (fileContent.includes('<h4> SAS Programs </h4>')) {
+    const deprecationDate = new Date(2022, 4, 2)
+    const warningDate = new Date(2022, 10, 2)
+    const today = new Date()
+
+    const message = `Please use <h4> SAS Includes </h4> syntax to specify programs. Specifying programs with a <h4> SAS Programs </h4> syntax will not be supported starting from April 1, 2022.`
+    if (today < warningDate) process.logger?.info(message)
+    else if (today < deprecationDate) process.logger?.warn(message)
+    else
+      throw new Error(
+        'Using <h4> SAS Programs </h4> syntax is deprecated. Please use <h4> SAS Includes </h4> instead.'
+      )
+  }
+
   let init, initPath
   let term, termPath
   let serviceVars = ''

--- a/src/commands/compile/spec/loadDependencies.spec.ts
+++ b/src/commands/compile/spec/loadDependencies.spec.ts
@@ -90,6 +90,27 @@ const fakeJobInit = `/**
 
 %let mylib=WORK;`
 
+const fakeJobInit2 = `/**
+  @file
+  @brief This code is inserted into the beginning of each Viya Job.
+  @details Inserted during the \`sasjs compile\` step.  Add any code here that
+  should go at the beginning of every deployed job.
+
+  The path to this file should be listed in the \`jobInit\` property of the
+  sasjsconfig file.
+
+  <h4> SAS Includes </h4>
+  @li test.sas TEST
+
+  <h4> SAS Macros </h4>
+  @li examplemacro.sas
+
+**/
+
+%example(Job Init is executing!)
+
+%let mylib=WORK;`
+
 const fakeProgramLines = [
   'filename TEST temp;',
   'data _null_;',
@@ -211,6 +232,117 @@ describe('loadDependencies', () => {
       path.join(__dirname, './service.sas'),
       [],
       [],
+      'job'
+    )
+
+    expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
+
+    done()
+  })
+
+  test('it should load programs for a service with <h4> SAS Programs </h4>', async (done) => {
+    spyOn(internalModule, 'getServiceInit').and.returnValue({
+      content: `\n* ServiceInit start;\n${fakeJobInit}\n* ServiceInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getServiceTerm').and.returnValue({
+      content: `\n* ServiceTerm start;\n${fakeTerm}\n* ServiceTerm end;`,
+      filePath: ''
+    })
+
+    const dependencies = await loadDependencies(
+      target,
+      path.join(__dirname, './service.sas'),
+      ['../macros'],
+      ['../', '../services'],
+      'service'
+    )
+
+    expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
+
+    done()
+  })
+
+  test('it should load programs for a job <h4> SAS Programs </h4>', async (done) => {
+    spyOn(internalModule, 'getJobInit').and.returnValue({
+      content: `\n* JobInit start;\n${fakeJobInit}\n* JobInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getJobTerm').and.returnValue({
+      content: `\n* JobTerm start;\n${fakeTerm}\n* JobTerm end;`,
+      filePath: ''
+    })
+
+    const dependencies = await loadDependencies(
+      target,
+      path.join(__dirname, './service.sas'),
+      ['../macros'],
+      ['../', '../services'],
+      'job'
+    )
+
+    expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* JobTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
+
+    done()
+  })
+
+  test('it should load programs for a service with <h4> SAS Includes </h4>', async (done) => {
+    spyOn(internalModule, 'getServiceInit').and.returnValue({
+      content: `\n* ServiceInit start;\n${fakeJobInit2}\n* ServiceInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getServiceTerm').and.returnValue({
+      content: `\n* ServiceTerm start;\n${fakeTerm2}\n* ServiceTerm end;`,
+      filePath: ''
+    })
+
+    const dependencies = await loadDependencies(
+      target,
+      path.join(__dirname, './service.sas'),
+      ['../macros'],
+      ['../', '../services'],
+      'service'
+    )
+    expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
+    expect(/\* ServiceTerm end;/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_abort/.test(dependencies)).toEqual(true)
+    expect(/%macro mf_existds/.test(dependencies)).toEqual(true)
+
+    done()
+  })
+
+  test('it should load programs for a job <h4> SAS Includes </h4>', async (done) => {
+    spyOn(internalModule, 'getJobInit').and.returnValue({
+      content: `\n* JobInit start;\n${fakeJobInit2}\n* JobInit end;`,
+      filePath: ''
+    })
+    spyOn(internalModule, 'getJobTerm').and.returnValue({
+      content: `\n* JobTerm start;\n${fakeTerm2}\n* JobTerm end;`,
+      filePath: ''
+    })
+
+    const dependencies = await loadDependencies(
+      target,
+      path.join(__dirname, './service.sas'),
+      ['../macros'],
+      ['../', '../services'],
       'job'
     )
 

--- a/src/commands/shared/dependencies.ts
+++ b/src/commands/shared/dependencies.ts
@@ -224,7 +224,10 @@ function getProgramDependencyText(
 export function getProgramList(
   fileContent: string
 ): { fileName: string; fileRef: string }[] {
-  let programList = getList('<h4> SAS Programs </h4>', fileContent)
+  const includesHeader = fileContent.includes('<h4> SAS Includes </h4>')
+    ? '<h4> SAS Includes </h4>'
+    : '<h4> SAS Programs </h4>'
+  let programList = getList(includesHeader, fileContent)
   programList = programList.map((l) => {
     const [fileName, fileRef] = l.split(' ').filter((f: string) => !!f)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ export async function doc(command: Command) {
   return await generateDocs(targetName, outDirectory)
     .then((res) => {
       displaySuccess(
-        `Docs have been generated!\nThe docs are located in the ${res.outDirectory}' directory.`
+        `Docs have been generated!\nThe docs are located in the ${res.outDirectory}' directory.\nClick to open: ${res.outDirectory}/index.html`
       )
       return ReturnCode.Success
     })


### PR DESCRIPTION
## Issue

Closes #593
Closes #584 

## Intent

Switch `<h4> SAS Programs </h4>` to `<h4> SAS Includes </h4>`
and show link to index.html in console for `sasjs doc`

## Implementation

Updated `compile/internal/loadDependencies.ts`
- Added `info` till 6 six months
- Added `warning` after 6 months and till 1 year

Updated `shared/dependencies.ts`
- Added check to load `<h4> SAS Includes </h4>` along `<h4> SAS Programs </h4>`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
