### PR TITLE
fix: closes #644 (addition of global _program and printing syscc in a…

### DIFF
--- a/src/commands/compile/internal/compileServiceFile.ts
+++ b/src/commands/compile/internal/compileServiceFile.ts
@@ -63,8 +63,8 @@ async function getPreCodeForServicePack(serverType: ServerType) {
   }
   content +=
     '/* provide additional debug info */\n' +
-    '%global _program;' +
-    '%put &=syscc;' +
+    '%global _program;\n' +
+    '%put &=syscc;\n' +
     '%put user=%mf_getuser();\n' +
     '%put pgm=&_program;\n' +
     '%put timestamp=%sysfunc(datetime(),datetime19.);\n'

--- a/src/commands/compile/internal/compileServiceFile.ts
+++ b/src/commands/compile/internal/compileServiceFile.ts
@@ -63,6 +63,8 @@ async function getPreCodeForServicePack(serverType: ServerType) {
   }
   content +=
     '/* provide additional debug info */\n' +
+    '%global _program;' +
+    '%put &=syscc;' +
     '%put user=%mf_getuser();\n' +
     '%put pgm=&_program;\n' +
     '%put timestamp=%sysfunc(datetime(),datetime19.);\n'

--- a/src/commands/compile/spec/compileServiceFile.spec.ts
+++ b/src/commands/compile/spec/compileServiceFile.spec.ts
@@ -56,7 +56,7 @@ const fakeProgramLines = [
 ]
 
 const preCode =
-  '/* provide additional debug info */\n%put user=%mf_getuser();\n%put pgm=&_program;\n%put timestamp=%sysfunc(datetime(),datetime19.);\n'
+  '/* provide additional debug info */\n%global _program;\n%put &=syscc;\n%put user=%mf_getuser();\n%put pgm=&_program;\n%put timestamp=%sysfunc(datetime(),datetime19.);\n'
 
 describe('compileServiceFile', () => {
   let target: Target


### PR DESCRIPTION
…ll service invocations)

## Issue

#644 

## Intent

Prevents errors when running services in SAS Studio, and prints the value of syscc in all invocations (can indicate issues in autoexec)


