### PR TITLE
fix: using _folder param so the correct folder can be opened automati…

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -24,7 +24,7 @@ export async function deploy(target: Target, isLocal: boolean) {
     await deployToSasViyaWithServicePack(target, isLocal)
     process.logger?.success('Build pack has been successfully deployed.')
     process.logger?.success(
-      `${target.serverUrl}/SASJobExecution?_path=${target.appLoc}`
+      `${target.serverUrl}/SASJobExecution/?_folder=${target.appLoc}`
     )
   }
 


### PR DESCRIPTION
…cally at the SASJobExecution endpoint

## Issue

The current _path variable was a placeholder as we weren't aware there was a viya equivalent to this SAS 9 parameter

## Intent

Allows the SASJobExecution application to automatically open the correct folder when clicked

## Implementation

Changed one url param

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
