### PR TITLE
fix: allowInsecureRequests supported for rest of the commands

### DIFF
--- a/src/commands/job/index.ts
+++ b/src/commands/job/index.ts
@@ -34,6 +34,7 @@ export async function processJob(command: Command) {
 
   const sasjs = new SASjs({
     serverUrl: target.serverUrl,
+    allowInsecureRequests: target.allowInsecureRequests,
     appLoc: target.appLoc,
     serverType: target.serverType,
     debug: true

--- a/src/commands/request/request.ts
+++ b/src/commands/request/request.ts
@@ -65,6 +65,7 @@ export async function runSasJob(command: Command) {
 
   const sasjs = new SASjs({
     serverUrl: target.serverUrl,
+    allowInsecureRequests: target.allowInsecureRequests,
     appLoc: target.appLoc,
     serverType: target.serverType
   })

--- a/src/commands/run/run.ts
+++ b/src/commands/run/run.ts
@@ -57,6 +57,7 @@ async function executeOnSasViya(
 
   const sasjs = new SASjs({
     serverUrl: target.serverUrl,
+    allowInsecureRequests: target.allowInsecureRequests,
     appLoc: target.appLoc,
     serverType: target.serverType,
     debug: true

--- a/src/commands/testing/index.ts
+++ b/src/commands/testing/index.ts
@@ -85,6 +85,7 @@ export async function runTest(command: Command) {
 
   const sasjs = new SASjs({
     serverUrl: target.serverUrl,
+    allowInsecureRequests: target.allowInsecureRequests,
     appLoc: target.appLoc,
     serverType: target.serverType,
     debug: true


### PR DESCRIPTION
## Issue

Closes #718 

## Intent

Added support of insecure connection for `sasjs job` and others if any unsupported

## Implementation

Added `allowInsecureRequests` attribute to `sasjs` instance for 
- `sasjs job`
- `sasjs request`
- `sasjs run`
- `sasjs test`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
