### PR TITLE
When serverUrl is missing in target, prompt the user to provide

### DIFF
--- a/src/commands/add/addCredential.ts
+++ b/src/commands/add/addCredential.ts
@@ -39,6 +39,11 @@ export const addCredential = async (
   if (!target.serverUrl) {
     const serverUrl = await getAndValidateServerUrl(target)
     target = new Target({ ...target.toJson(false), serverUrl })
+    if (isLocal) {
+      await saveToLocalConfig(target, false, false)
+    } else {
+      await saveToGlobalConfig(target, false, false)
+    }
   }
 
   const { client, secret } = await getCredentialsInput(target.name)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -137,6 +137,9 @@ async function getLocalTarget(targetName: string): Promise<Target> {
         `Target ${targetName} was found in your local sasjsconfig.json file.`
       )
       targetJson.appLoc = sanitizeAppLoc(targetJson.appLoc)
+      if (!targetJson.hasOwnProperty('serverUrl')) {
+        targetJson.serverUrl = ''
+      }
       targetJson.serverUrl = urlOrigin(targetJson.serverUrl)
       targetJson.allowInsecureRequests = getPrecedenceOfInsecureRequests(
         localConfig,
@@ -168,6 +171,9 @@ async function getLocalFallbackTarget(): Promise<Target> {
         `No target was specified. Falling back to default target '${fallBackTargetJson.name}' from your local sasjsconfig.json file.`
       )
       fallBackTargetJson.appLoc = sanitizeAppLoc(fallBackTargetJson.appLoc)
+      if (!fallBackTargetJson.hasOwnProperty('serverUrl')) {
+        fallBackTargetJson.serverUrl = ''
+      }
       fallBackTargetJson.serverUrl = urlOrigin(fallBackTargetJson.serverUrl)
       fallBackTargetJson.allowInsecureRequests =
         getPrecedenceOfInsecureRequests(localConfig, fallBackTargetJson)
@@ -189,6 +195,9 @@ async function getGlobalTarget(targetName: string): Promise<Target> {
         `Target ${targetName} was found in your global .sasjsrc file.`
       )
       targetJson.appLoc = sanitizeAppLoc(targetJson.appLoc)
+      if (!targetJson.hasOwnProperty('serverUrl')) {
+        targetJson.serverUrl = ''
+      }
       targetJson.serverUrl = urlOrigin(targetJson.serverUrl)
       targetJson.allowInsecureRequests = getPrecedenceOfInsecureRequests(
         globalConfig,
@@ -217,6 +226,9 @@ async function getGlobalFallbackTarget(): Promise<Target> {
       `No target was specified. Falling back to default target '${fallBackTargetJson.name}' from your global .sasjsrc file.`
     )
     fallBackTargetJson.appLoc = sanitizeAppLoc(fallBackTargetJson.appLoc)
+    if (!fallBackTargetJson.hasOwnProperty('serverUrl')) {
+      fallBackTargetJson.serverUrl = ''
+    }
     fallBackTargetJson.serverUrl = urlOrigin(fallBackTargetJson.serverUrl)
     fallBackTargetJson.allowInsecureRequests = getPrecedenceOfInsecureRequests(
       globalConfig,


### PR DESCRIPTION
## Issue

#712 .

## Intent

When serverUrl is missing in target in config file, instead of giving error prompt user for server url.

## Implementation

When serverUrl is missing in target in config, update the config file.  

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
