### PR TITLE
fix(sas9-support): consider build output filename when deployServicePack is true

### DIFF
--- a/src/commands/deploy/internal/getDeployScripts.ts
+++ b/src/commands/deploy/internal/getDeployScripts.ts
@@ -22,9 +22,11 @@ export async function getDeployScripts(target: Target) {
     !!target.deployConfig?.deployServicePack &&
     target.serverType === ServerType.Sas9
   ) {
+    const buildOutputFileName =
+      target.buildConfig?.buildOutputFileName || `${target.name}.sas`
     const deployScriptPath = path.join(
       buildDestinationFolder,
-      `${target.name}.sas`
+      buildOutputFileName
     )
     allDeployScripts = [...allDeployScripts, deployScriptPath]
   }

--- a/src/commands/deploy/spec/getDeployScripts.spec.ts
+++ b/src/commands/deploy/spec/getDeployScripts.spec.ts
@@ -1,0 +1,50 @@
+import path from 'path'
+import { generateTimestamp, ServerType, Target } from '@sasjs/utils'
+import { removeFromGlobalConfig } from '../../../utils/config'
+import {
+  createTestApp,
+  createTestGlobalTarget,
+  removeTestApp
+} from '../../../utils/test'
+import { getDeployScripts } from '../internal/getDeployScripts'
+import { getConstants } from '../../../constants'
+
+describe('getDeployScripts', () => {
+  let target: Target
+
+  beforeEach(async () => {
+    const appName = `cli-tests-${generateTimestamp()}`
+    await createTestApp(__dirname, appName)
+    target = await createTestGlobalTarget(
+      appName,
+      `/Public/app/cli-tests/${appName}`,
+      undefined,
+      ServerType.Sas9
+    )
+  })
+
+  afterEach(async () => {
+    await removeTestApp(__dirname, target.name)
+    await removeFromGlobalConfig(target.name)
+  })
+
+  it('should include the build output file for SAS9 when deployServicePack is true', async () => {
+    target.buildConfig!.buildOutputFileName = 'output-test.sas'
+    const deployScripts = await getDeployScripts(target)
+    const { buildDestinationFolder } = await getConstants()
+
+    expect(deployScripts).toIncludeAllMembers([
+      path.join(buildDestinationFolder, 'output-test.sas')
+    ])
+  })
+
+  it('should should fallback to target name for the build output file name for SAS9', async () => {
+    target.buildConfig!.buildOutputFileName = ''
+    const deployScripts = await getDeployScripts(target)
+    const { buildDestinationFolder } = await getConstants()
+
+    expect(deployScripts).toIncludeAllMembers([
+      path.join(buildDestinationFolder, `${target.name}.sas`)
+    ])
+  })
+})

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -104,6 +104,9 @@ export const generateTestTarget = (
       testSetUp: '',
       testTearDown: ''
     },
+    buildConfig: {
+      buildOutputFileName: 'test.sas'
+    },
     deployConfig: {
       deployServicePack: true
     }

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -105,7 +105,7 @@ export const generateTestTarget = (
       testTearDown: ''
     },
     buildConfig: {
-      buildOutputFileName: 'test.sas'
+      buildOutputFileName: `${targetName}.sas`
     },
     deployConfig: {
       deployServicePack: true


### PR DESCRIPTION
## Issue

Fixes https://github.com/sasjs/cli/issues/771

## Intent

Use the `buildOutputFileName` when determining the set of deploy scripts to run for a SAS9 deploy.

## Implementation

* Take the `buildOutputFileName` from the target buildConfig, and if unavailable fallback to `{target.name}.sas`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/122539181-fbb64980-d02f-11eb-9b0e-a10362b7a996.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/122540743-995e4880-d031-11eb-9d87-86bed7ec31c8.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/122561555-adfb0a80-d04a-11eb-9686-6c38457d2ced.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
