### PR TITLE
fix: adding focus to child iframe when running streaming app

### DIFF
--- a/src/commands/web/adjustIframeScript.ts
+++ b/src/commands/web/adjustIframeScript.ts
@@ -14,6 +14,7 @@ export const adjustIframeScript = `
       window.frameElement.setAttribute("marginheight","0")
       window.frameElement.setAttribute("marginwidth","0")
       window.frameElement.setAttribute("scrolling","auto")
+      window.focus()
     }
     </script>
 `


### PR DESCRIPTION
## Issue

When running streaming apps on Viya, the iframe is not in focus

## Intent

This fix puts the focus on the iframe

## Implementation

Added `window.focus()`

## Testing

```bash
git clone https://github.com/sasjs/rockroller
cd rockroller
sasjs add cred -t viya
sasjs cbd
```
click the link, and it should be possible to immediately play the game without having to click the screen first

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
