### PR TITLE
Output test url during running sasjs test command

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -101,7 +101,7 @@ module.exports = {
   // reporters: undefined,
 
   // Automatically reset mock state between every test
-  // resetMocks: false,
+  resetMocks: true,
 
   // Reset the module registry before running each individual test
   // resetModules: false,
@@ -110,7 +110,7 @@ module.exports = {
   // resolver: undefined,
 
   // Automatically restore mock state between every test
-  // restoreMocks: false,
+  restoreMocks: true,
 
   // The root directory that Jest should scan for tests and modules within
   // rootDir: undefined,

--- a/jest.server.config.js
+++ b/jest.server.config.js
@@ -101,7 +101,7 @@ module.exports = {
   // reporters: undefined,
 
   // Automatically reset mock state between every test
-  // resetMocks: false,
+  resetMocks: true,
 
   // Reset the module registry before running each individual test
   // resetModules: false,
@@ -110,7 +110,7 @@ module.exports = {
   // resolver: undefined,
 
   // Automatically restore mock state between every test
-  // restoreMocks: false,
+  restoreMocks: true,
 
   // The root directory that Jest should scan for tests and modules within
   // rootDir: undefined,

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -27,7 +27,6 @@ describe('CLI command parsing', () => {
   afterEach(async () => {
     await removeTestApp(__dirname, target.name)
     await removeFromGlobalConfig(target.name)
-    jest.clearAllMocks()
   })
 
   it('should call the correct function for the create command', async () => {

--- a/src/commands/add/spec/add-credential.spec.ts
+++ b/src/commands/add/spec/add-credential.spec.ts
@@ -33,7 +33,6 @@ describe('addCredential', () => {
     )
 
     await fileUtils.deleteFile(path.join('.', '.env.test-target'))
-    jest.clearAllMocks()
   })
 })
 

--- a/src/commands/add/spec/add-target.spec.ts
+++ b/src/commands/add/spec/add-target.spec.ts
@@ -39,9 +39,9 @@ describe('addTarget', () => {
       `/Public/app/cli-tests/${appName}`
     )
   })
+
   afterEach(async () => {
     await removeFromGlobalConfig(globalTestTarget.name)
-    jest.clearAllMocks()
   })
 
   it('should create a Viya target in the local sasjsconfig.json file', async () => {

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -48,7 +48,6 @@ describe('sasjs compile', () => {
 
   afterEach(async () => {
     await removeTestApp(__dirname, appName)
-    jest.clearAllMocks()
   })
 
   it('should compile an uncompiled project', async () => {
@@ -123,7 +122,6 @@ describe('sasjs compile single file', () => {
 
   afterEach(async () => {
     await removeTestApp(__dirname, appName)
-    jest.clearAllMocks()
   })
 
   describe('job', () => {

--- a/src/commands/compile/spec/copyFilesToBuildFolder.spec.ts
+++ b/src/commands/compile/spec/copyFilesToBuildFolder.spec.ts
@@ -15,7 +15,6 @@ describe('copyFilesToBuildFolder', () => {
 
   afterEach(async () => {
     await removeTestApp(__dirname, appName)
-    jest.clearAllMocks()
   })
 
   it('should copy files into the sasjsbuild folder', async () => {

--- a/src/commands/context/index.ts
+++ b/src/commands/context/index.ts
@@ -9,7 +9,7 @@ import { displayError } from '../../utils/displayResult'
 import { Command } from '../../utils/command'
 import SASjs from '@sasjs/adapter/node'
 
-export async function processContext(command: Command) {
+export async function processContext(command: Command, sasjs?: SASjs) {
   const subCommand = command.getSubCommand()
   const subCommands = {
     create: 'create',
@@ -67,12 +67,14 @@ export async function processContext(command: Command) {
     return contextName
   }
 
-  const sasjs = new SASjs({
-    serverUrl: target.serverUrl,
-    allowInsecureRequests: target.allowInsecureRequests,
-    appLoc: target.appLoc,
-    serverType: target.serverType
-  })
+  if (!sasjs) {
+    sasjs = new SASjs({
+      serverUrl: target.serverUrl,
+      allowInsecureRequests: target.allowInsecureRequests,
+      appLoc: target.appLoc,
+      serverType: target.serverType
+    })
+  }
 
   const accessToken = await getAccessToken(target).catch((err) => {
     displayError(err, 'Error obtaining access token.')

--- a/src/commands/folder/spec/delete.spec.server.ts
+++ b/src/commands/folder/spec/delete.spec.server.ts
@@ -11,6 +11,14 @@ import {
 
 jest.mock('../delete')
 
+const mockDeleteFolder = () => {
+  jest
+    .spyOn(deleteFolderModule, 'deleteFolder')
+    .mockImplementation((folderPath, adapter, _) =>
+      Promise.resolve(folderPath as any)
+    )
+}
+
 describe('sasjs folder delete', () => {
   const targetName = `cli-tests-folder-delete-${generateTimestamp()}`
   let target: Target
@@ -21,11 +29,6 @@ describe('sasjs folder delete', () => {
       `/Public/app/cli-tests/${targetName}`
     )
     await createTestMinimalApp(__dirname, targetName)
-    jest
-      .spyOn(deleteFolderModule, 'deleteFolder')
-      .mockImplementation((folderPath, adapter, _) =>
-        Promise.resolve(folderPath as any)
-      )
   })
 
   afterAll(async () => {
@@ -37,6 +40,8 @@ describe('sasjs folder delete', () => {
     const timestamp = generateTimestamp()
     const relativeFolderPath = `test-${timestamp}`
 
+    mockDeleteFolder()
+
     await expect(
       folder(
         new Command(['folder', 'delete', relativeFolderPath, '-t', targetName])
@@ -47,6 +52,8 @@ describe('sasjs folder delete', () => {
   it('should leave absolute file paths unaltered', async () => {
     const timestamp = generateTimestamp()
     const absoluteFolderPath = `${target.appLoc}/test-${timestamp}`
+
+    mockDeleteFolder()
 
     await expect(
       folder(

--- a/src/commands/job/spec/job.spec.server.ts
+++ b/src/commands/job/spec/job.spec.server.ts
@@ -14,7 +14,6 @@ import {
   LogLevel,
   generateTimestamp
 } from '@sasjs/utils'
-
 import {
   removeFromGlobalConfig,
   saveToGlobalConfig
@@ -25,6 +24,7 @@ import {
   mockProcessExit,
   removeTestApp
 } from '../../../utils/test'
+import { getConstants } from '../../../constants'
 
 describe('sasjs job execute', () => {
   let target: Target
@@ -53,10 +53,6 @@ describe('sasjs job execute', () => {
     )
     await removeTestApp(__dirname, target.name)
     await removeFromGlobalConfig(target.name)
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
   })
 
   it('should submit a job for execution', async () => {
@@ -381,7 +377,7 @@ const createGlobalTarget = async (serverType = ServerType.SasViya) => {
       ? process.env.VIYA_SERVER_URL
       : process.env.SAS9_SERVER_URL) as string,
     appLoc: `/Public/app/cli-tests/${targetName}`,
-    contextName: 'sasjs cli compute context',
+    contextName: (await getConstants()).contextName,
     serviceConfig: {
       serviceFolders: ['sasjs/testServices', 'sasjs/testJob', 'sasjs/services'],
       initProgram: 'sasjs/testServices/serviceinit.sas',

--- a/src/commands/testing/index.ts
+++ b/src/commands/testing/index.ts
@@ -150,6 +150,12 @@ export async function runTest(command: Command) {
         : 'SASStoredProcess'
     }/?_program=${sasJobLocation}&_debug=2477`
 
+    if (target.contextName) {
+      testUrl = `${testUrl}&_contextName=${encodeURI(target.contextName)}`
+    }
+
+    const printTestUrl = () => process.logger.info(`Test URL: ${testUrl}`)
+
     await sasjs
       .request(
         sasJobLocation,
@@ -203,6 +209,8 @@ export async function runTest(command: Command) {
 
         if (!res.result?.test_results) lineBreak = false
 
+        printTestUrl()
+
         if (res.log) await saveLog(outDirectory, test, res.log, lineBreak)
 
         if (res.result?.test_results) {
@@ -241,6 +249,8 @@ export async function runTest(command: Command) {
         }
       })
       .catch(async (err) => {
+        printTestUrl()
+
         if (err && err.errorCode === 404) {
           displaySasjsRunnerError(username)
         } else {

--- a/src/commands/testing/spec/testing.spec.server.ts
+++ b/src/commands/testing/spec/testing.spec.server.ts
@@ -27,7 +27,11 @@ import { getConstants } from '../../../constants'
 describe('sasjs test', () => {
   let target: Target
   const testUrl = (test: string) =>
-    `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${
+    `${target.serverUrl}/${
+      target.serverType === ServerType.SasViya
+        ? 'SASJobExecution'
+        : 'SASStoredProcess'
+    }/?_program=/Public/app/cli-tests/${
       target.name
     }/tests/${test}&_debug=2477&_contextName=${encodeURI(target.contextName)}`
   const testUrlLink = (test: string) => `"=HYPERLINK(""${testUrl(test)}"")"`

--- a/src/commands/testing/spec/testing.spec.server.ts
+++ b/src/commands/testing/spec/testing.spec.server.ts
@@ -26,6 +26,11 @@ import { getConstants } from '../../../constants'
 
 describe('sasjs test', () => {
   let target: Target
+  const testUrl = (test: string) =>
+    `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${
+      target.name
+    }/tests/${test}&_debug=2477&_contextName=${encodeURI(target.contextName)}`
+  const testUrlLink = (test: string) => `"=HYPERLINK(""${testUrl(test)}"")"`
 
   beforeAll(async () => {
     target = await createGlobalTarget()
@@ -57,7 +62,7 @@ describe('sasjs test', () => {
               test_loc: 'tests/testsetup.sas',
               sasjs_test_id: '',
               result: 'not provided',
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testsetup&_debug=2477`
+              test_url: testUrl('testsetup')
             }
           ]
         },
@@ -68,7 +73,7 @@ describe('sasjs test', () => {
               test_loc: 'tests/jobs/jobs/exampleprogram.test.sas',
               sasjs_test_id: '',
               result: 'not provided',
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/jobs/jobs/exampleprogram.test&_debug=2477`
+              test_url: testUrl('jobs/jobs/exampleprogram.test')
             }
           ]
         },
@@ -79,7 +84,7 @@ describe('sasjs test', () => {
               test_loc: 'tests/jobs/jobs/standalone.test.sas',
               sasjs_test_id: '',
               result: 'not provided',
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/jobs/jobs/standalone.test&_debug=2477`
+              test_url: testUrl('jobs/jobs/standalone.test')
             }
           ]
         },
@@ -95,7 +100,7 @@ describe('sasjs test', () => {
                   TEST_RESULT: 'PASS'
                 }
               ],
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/macros/examplemacro.test&_debug=2477`
+              test_url: testUrl('macros/examplemacro.test')
             }
           ]
         },
@@ -111,7 +116,7 @@ describe('sasjs test', () => {
                   TEST_RESULT: 'FAIL'
                 }
               ],
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/services/admin/dostuff.test.0&_debug=2477`
+              test_url: testUrl('services/admin/dostuff.test.0')
             },
             {
               test_loc: 'tests/services/admin/dostuff.test.1.sas',
@@ -122,7 +127,7 @@ describe('sasjs test', () => {
                   TEST_RESULT: 'PASS'
                 }
               ],
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/services/admin/dostuff.test.1&_debug=2477`
+              test_url: testUrl('services/admin/dostuff.test.1')
             }
           ]
         },
@@ -133,20 +138,34 @@ describe('sasjs test', () => {
               test_loc: 'tests/testteardown.sas',
               sasjs_test_id: '',
               result: 'not provided',
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testteardown&_debug=2477`
+              test_url: testUrl('testteardown')
             }
           ]
         }
       ]
     }
     const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
-testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testsetup&_debug=2477"")"
-exampleprogram,tests/jobs/jobs/exampleprogram.test.sas,sasjs_test_id,not provided,,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/jobs/jobs/exampleprogram.test&_debug=2477"")"
-standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,not provided,,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/jobs/jobs/standalone.test&_debug=2477"")"
-examplemacro,tests/macros/examplemacro.test.sas,sasjs_test_id,PASS,examplemacro test.1 description,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/macros/examplemacro.test&_debug=2477"")"
-dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,FAIL,dostuff 0 test description,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/services/admin/dostuff.test.0&_debug=2477"")"
-dostuff,tests/services/admin/dostuff.test.1.sas,sasjs_test_id,PASS,dostuff 1 test description,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/services/admin/dostuff.test.1&_debug=2477"")"
-testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testteardown&_debug=2477"")"
+testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,${testUrlLink(
+      'testsetup'
+    )}
+exampleprogram,tests/jobs/jobs/exampleprogram.test.sas,sasjs_test_id,not provided,,${testUrlLink(
+      'jobs/jobs/exampleprogram.test'
+    )}
+standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,not provided,,${testUrlLink(
+      'jobs/jobs/standalone.test'
+    )}
+examplemacro,tests/macros/examplemacro.test.sas,sasjs_test_id,PASS,examplemacro test.1 description,${testUrlLink(
+      'macros/examplemacro.test'
+    )}
+dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,FAIL,dostuff 0 test description,${testUrlLink(
+      'services/admin/dostuff.test.0'
+    )}
+dostuff,tests/services/admin/dostuff.test.1.sas,sasjs_test_id,PASS,dostuff 1 test description,${testUrlLink(
+      'services/admin/dostuff.test.1'
+    )}
+testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
+      'testteardown'
+    )}
 `
 
     const command = new Command(`test -t ${target.name}`)
@@ -247,7 +266,7 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,"=HYPERLINK(""ht
               test_loc: 'tests/testsetup.sas',
               sasjs_test_id: '',
               result: 'not provided',
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testsetup&_debug=2477`
+              test_url: testUrl('testsetup')
             }
           ]
         },
@@ -258,7 +277,7 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,"=HYPERLINK(""ht
               test_loc: 'tests/jobs/jobs/standalone.test.sas',
               sasjs_test_id: '',
               result: 'not provided',
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/jobs/jobs/standalone.test&_debug=2477`
+              test_url: testUrl('jobs/jobs/standalone.test')
             }
           ]
         },
@@ -274,7 +293,7 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,"=HYPERLINK(""ht
                   TEST_RESULT: 'FAIL'
                 }
               ],
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/services/admin/dostuff.test.0&_debug=2477`
+              test_url: testUrl('services/admin/dostuff.test.0')
             }
           ]
         },
@@ -285,17 +304,25 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,"=HYPERLINK(""ht
               test_loc: 'tests/testteardown.sas',
               sasjs_test_id: '',
               result: 'not provided',
-              test_url: `https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testteardown&_debug=2477`
+              test_url: testUrl('testteardown')
             }
           ]
         }
       ]
     }
     const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
-testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testsetup&_debug=2477"")"
-standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,not provided,,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/jobs/jobs/standalone.test&_debug=2477"")"
-dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,FAIL,dostuff 0 test description,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/services/admin/dostuff.test.0&_debug=2477"")"
-testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,"=HYPERLINK(""https://sas.analytium.co.uk/SASJobExecution/?_program=/Public/app/cli-tests/${target.name}/tests/testteardown&_debug=2477"")"
+testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,${testUrlLink(
+      'testsetup'
+    )}
+standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,not provided,,${testUrlLink(
+      'jobs/jobs/standalone.test'
+    )}
+dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,FAIL,dostuff 0 test description,${testUrlLink(
+      'services/admin/dostuff.test.0'
+    )}
+testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
+      'testteardown'
+    )}
 `
 
     const outputFolder = 'customOutPut'


### PR DESCRIPTION
## Intent

1. Mock context `creating`, `editing` and `deleting` during `context` test.
2. Fix clearing all mocks while running tests.
3. Add test URL while executing `sasjs test` command.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/123644352-f9bd6900-d82d-11eb-963c-363ab8174173.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/123645693-376ec180-d82f-11eb-8802-e09c249e17b2.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/123652816-4d7f8080-d835-11eb-9213-b35caa34f50c.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
