### PR TITLE
fix: resolve tilde in sasjs config paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1766,9 +1766,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "2.35.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.3.tgz",
-      "integrity": "sha512-3o5PU6DkihpA+Aibt1lRy4USqJI0VFa+wNsKCD+bUD2DLZICU3JablZQxwAPH70VWJGXAUJtDFj0T/iRo5Devg=="
+      "version": "2.35.4",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.4.tgz",
+      "integrity": "sha512-Exr3+yRdvacKvbXQoi1RfGHi5NtZUkc7RwFNkemHTFXLYaIzPI8CGSCaQmKkwM1UteOJly2e2pw2YT6kHNY1NA=="
     },
     "@sasjs/lint": {
       "version": "1.11.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "2.8.9",
-    "@sasjs/core": "^2.35.4",
+    "@sasjs/core": "2.35.4",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.23.3",
     "@types/url-parse": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "2.8.9",
-    "@sasjs/core": "2.35.3",
+    "@sasjs/core": "^2.35.4",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.23.3",
     "@types/url-parse": "1.4.3",

--- a/src/commands/build/internal/config.ts
+++ b/src/commands/build/internal/config.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { Target } from '@sasjs/utils/types'
 import { getConstants } from '../../../constants'
 import { getConfiguration } from '../../../utils/config'
+import { getAbsolutePath } from '../../../utils/utils'
 import { readFile } from '@sasjs/utils'
 
 export const getBuildInit = async (target: Target) => {
@@ -9,9 +10,7 @@ export const getBuildInit = async (target: Target) => {
   let buildInitContent = ''
   if (target?.buildConfig?.initProgram) {
     buildInitContent = await readFile(
-      path.isAbsolute(target.buildConfig.initProgram)
-        ? target.buildConfig.initProgram
-        : path.join(buildSourceFolder, target.buildConfig.initProgram)
+      getAbsolutePath(target.buildConfig.initProgram, buildSourceFolder)
     )
   } else {
     const configuration = await getConfiguration(
@@ -19,9 +18,10 @@ export const getBuildInit = async (target: Target) => {
     )
     if (configuration?.buildConfig?.initProgram) {
       buildInitContent = await readFile(
-        path.isAbsolute(configuration.buildConfig.initProgram)
-          ? configuration.buildConfig.initProgram
-          : path.join(buildSourceFolder, configuration.buildConfig.initProgram)
+        getAbsolutePath(
+          configuration.buildConfig.initProgram,
+          buildSourceFolder
+        )
       )
     }
   }
@@ -36,9 +36,7 @@ export const getBuildTerm = async (target: Target) => {
   let buildTermContent = ''
   if (target?.buildConfig?.termProgram) {
     buildTermContent = await readFile(
-      path.isAbsolute(target.buildConfig.termProgram)
-        ? target.buildConfig.termProgram
-        : path.join(buildSourceFolder, target.buildConfig.termProgram)
+      getAbsolutePath(target.buildConfig.termProgram, buildSourceFolder)
     )
   } else {
     const configuration = await getConfiguration(
@@ -46,9 +44,10 @@ export const getBuildTerm = async (target: Target) => {
     )
     if (configuration?.buildConfig?.termProgram) {
       buildTermContent = await readFile(
-        path.isAbsolute(configuration.buildConfig.termProgram)
-          ? configuration.buildConfig.termProgram
-          : path.join(buildSourceFolder, configuration.buildConfig.termProgram)
+        getAbsolutePath(
+          configuration.buildConfig.termProgram,
+          buildSourceFolder
+        )
       )
     }
   }

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { getProgramFolders, getMacroFolders } from '../../utils/config'
+import { getAbsolutePath } from '../../utils/utils'
 import { fileExists, deleteFolder, createFolder, copy } from '@sasjs/utils'
 import { Target } from '@sasjs/utils/types'
 import { compileServiceFile } from './internal/compileServiceFile'
@@ -42,9 +43,7 @@ export async function compileSingleFile(
 
   source = source.split('/').join(path.sep)
 
-  const sourcePath = path.isAbsolute(source)
-    ? source
-    : path.join(process.currentDir!, source)
+  const sourcePath = getAbsolutePath(source, process.currentDir)
 
   if (!(await validateSourcePath(sourcePath))) {
     throw new Error(`Provide a path to source file (eg '${commandExample}')`)

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -70,7 +70,10 @@ export async function compileSingleFile(
   let outputPathParts = outputPath.split(path.sep)
   outputPathParts.pop(), outputPathParts.pop()
   const parentOutputFolder = outputPathParts.join(path.sep)
-  await deleteFolder(parentOutputFolder)
+
+  const pathExists = await fileExists(parentOutputFolder)
+  if (pathExists) await deleteFolder(parentOutputFolder)
+
   await createFolder(outputPath)
 
   const sourceFileName = sourcePath.split(path.sep).pop() as string

--- a/src/commands/compile/internal/compileTestFile.ts
+++ b/src/commands/compile/internal/compileTestFile.ts
@@ -21,6 +21,7 @@ import { sasFileRegExp } from '../../../utils/file'
 import chalk from 'chalk'
 import { getProgramFolders, getMacroFolders } from '../../../utils/config'
 import { getPreCodeForServicePack } from './compileServiceFile'
+import { getAbsolutePath } from '../../../utils/utils'
 
 const testsBuildFolder = () =>
   path.join(process.currentDir, 'sasjsbuild', 'tests')
@@ -36,9 +37,7 @@ export async function compileTestFile(
 ) {
   let dependencies = await loadDependencies(
     target,
-    path.isAbsolute(filePath)
-      ? filePath
-      : path.join(process.projectDir, filePath),
+    getAbsolutePath(filePath, process.projectDir),
     await getMacroFolders(target),
     await getProgramFolders(target),
     'test'

--- a/src/commands/compile/internal/config.ts
+++ b/src/commands/compile/internal/config.ts
@@ -3,6 +3,7 @@ import { readFile } from '@sasjs/utils'
 import path from 'path'
 import { getConstants } from '../../../constants'
 import { getLocalOrGlobalConfig } from '../../../utils/config'
+import { getAbsolutePath } from '../../../utils/utils'
 
 // TODO: REFACTOR
 
@@ -13,17 +14,19 @@ export const getServiceInit = async (
   let serviceInitContent = '',
     filePath = ''
   if (target?.serviceConfig?.initProgram) {
-    filePath = path.isAbsolute(target.serviceConfig.initProgram)
-      ? target.serviceConfig.initProgram
-      : path.join(buildSourceFolder, target.serviceConfig.initProgram)
+    filePath = getAbsolutePath(
+      target.serviceConfig.initProgram,
+      buildSourceFolder
+    )
     serviceInitContent = await readFile(filePath)
   } else {
     const { configuration } = await getLocalOrGlobalConfig()
 
     if (configuration?.serviceConfig?.initProgram) {
-      filePath = path.isAbsolute(configuration.serviceConfig.initProgram)
-        ? configuration.serviceConfig.initProgram
-        : path.join(buildSourceFolder, configuration.serviceConfig.initProgram)
+      filePath = getAbsolutePath(
+        configuration.serviceConfig.initProgram,
+        buildSourceFolder
+      )
       serviceInitContent = await readFile(filePath)
     }
   }
@@ -47,17 +50,19 @@ export const getServiceTerm = async (
     filePath = ''
   if (target?.serviceConfig?.termProgram) {
     filePath = path.join(buildSourceFolder, target.serviceConfig.termProgram)
-    filePath = path.isAbsolute(target.serviceConfig.termProgram)
-      ? target.serviceConfig.termProgram
-      : path.join(buildSourceFolder, target.serviceConfig.termProgram)
+    filePath = getAbsolutePath(
+      target.serviceConfig.termProgram,
+      buildSourceFolder
+    )
     serviceTermContent = await readFile(filePath)
   } else {
     const { configuration } = await getLocalOrGlobalConfig()
 
     if (configuration?.serviceConfig?.termProgram) {
-      filePath = path.isAbsolute(configuration.serviceConfig.termProgram)
-        ? configuration.serviceConfig.termProgram
-        : path.join(buildSourceFolder, configuration.serviceConfig.termProgram)
+      filePath = getAbsolutePath(
+        configuration.serviceConfig.termProgram,
+        buildSourceFolder
+      )
       serviceTermContent = await readFile(filePath)
     }
   }
@@ -81,17 +86,16 @@ export const getJobInit = async (
     filePath = ''
   if (target?.jobConfig?.initProgram) {
     filePath = path.join(buildSourceFolder, target.jobConfig.initProgram)
-    filePath = path.isAbsolute(target.jobConfig.initProgram)
-      ? target.jobConfig.initProgram
-      : path.join(buildSourceFolder, target.jobConfig.initProgram)
+    filePath = getAbsolutePath(target.jobConfig.initProgram, buildSourceFolder)
     jobInitContent = await readFile(filePath)
   } else {
     const { configuration } = await getLocalOrGlobalConfig()
 
     if (configuration?.jobConfig?.initProgram) {
-      filePath = path.isAbsolute(configuration.jobConfig.initProgram)
-        ? configuration.jobConfig.initProgram
-        : path.join(buildSourceFolder, configuration.jobConfig.initProgram)
+      filePath = getAbsolutePath(
+        configuration.jobConfig.initProgram,
+        buildSourceFolder
+      )
       jobInitContent = await readFile(filePath)
     }
   }
@@ -114,17 +118,16 @@ export const getJobTerm = async (
   let jobTermContent = '',
     filePath = ''
   if (target?.jobConfig?.termProgram) {
-    filePath = path.isAbsolute(target.jobConfig.termProgram)
-      ? target.jobConfig.termProgram
-      : path.join(buildSourceFolder, target.jobConfig.termProgram)
+    filePath = getAbsolutePath(target.jobConfig.termProgram, buildSourceFolder)
     jobTermContent = await readFile(filePath)
   } else {
     const { configuration } = await getLocalOrGlobalConfig()
 
     if (configuration?.jobConfig?.termProgram) {
-      filePath = path.isAbsolute(configuration.jobConfig.termProgram)
-        ? configuration.jobConfig.termProgram
-        : path.join(buildSourceFolder, configuration.jobConfig.termProgram)
+      filePath = getAbsolutePath(
+        configuration.jobConfig.termProgram,
+        buildSourceFolder
+      )
       jobTermContent = await readFile(filePath)
     }
   }
@@ -148,18 +151,17 @@ export const getTestInit = async (
     filePath = ''
 
   if (target?.testConfig?.initProgram) {
-    filePath = path.isAbsolute(target.testConfig.initProgram)
-      ? target.testConfig.initProgram
-      : path.join(buildSourceFolder, target.testConfig.initProgram)
+    filePath = getAbsolutePath(target.testConfig.initProgram, buildSourceFolder)
 
     testInitContent = await readFile(filePath)
   } else {
     const { configuration } = await getLocalOrGlobalConfig()
 
     if (configuration?.testConfig?.initProgram) {
-      filePath = path.isAbsolute(configuration.testConfig.initProgram)
-        ? configuration.testConfig.initProgram
-        : path.join(buildSourceFolder, configuration.testConfig.initProgram)
+      filePath = getAbsolutePath(
+        configuration.testConfig.initProgram,
+        buildSourceFolder
+      )
 
       testInitContent = await readFile(filePath)
     }
@@ -185,18 +187,17 @@ export const getTestTerm = async (
 
   if (target?.testConfig?.termProgram) {
     filePath = path.join(buildSourceFolder, target.testConfig.termProgram)
-    filePath = path.isAbsolute(target.testConfig.termProgram)
-      ? target.testConfig.termProgram
-      : path.join(buildSourceFolder, target.testConfig.termProgram)
+    filePath = getAbsolutePath(target.testConfig.termProgram, buildSourceFolder)
 
     testTermContent = await readFile(filePath)
   } else {
     const { configuration } = await getLocalOrGlobalConfig()
 
     if (configuration?.testConfig?.termProgram) {
-      filePath = path.isAbsolute(configuration.testConfig.termProgram)
-        ? configuration.testConfig.termProgram
-        : path.join(buildSourceFolder, configuration.testConfig.termProgram)
+      filePath = getAbsolutePath(
+        configuration.testConfig.termProgram,
+        buildSourceFolder
+      )
 
       testTermContent = await readFile(filePath)
     }

--- a/src/commands/compile/internal/getAllJobFolders.ts
+++ b/src/commands/compile/internal/getAllJobFolders.ts
@@ -1,7 +1,7 @@
-import path from 'path'
 import { Target } from '@sasjs/utils'
 import { getConstants } from '../../../constants'
 import { getLocalOrGlobalConfig } from '../../../utils/config'
+import { getAbsolutePath } from '../../../utils/utils'
 
 export async function getAllJobFolders(target: Target) {
   const { configuration } = await getLocalOrGlobalConfig()
@@ -16,9 +16,7 @@ export async function getAllJobFolders(target: Target) {
   allJobs = allJobs.filter((s) => !!s) as string[]
 
   const { buildSourceFolder } = await getConstants()
-  allJobs = allJobs.map((job) =>
-    path.isAbsolute(job) ? job : path.join(buildSourceFolder, job)
-  )
+  allJobs = allJobs.map((job) => getAbsolutePath(job, buildSourceFolder))
 
   return [...new Set(allJobs)]
 }

--- a/src/commands/compile/internal/getAllServiceFolders.ts
+++ b/src/commands/compile/internal/getAllServiceFolders.ts
@@ -1,7 +1,7 @@
-import path from 'path'
 import { Target } from '@sasjs/utils'
 import { getConstants } from '../../../constants'
 import { getLocalOrGlobalConfig } from '../../../utils/config'
+import { getAbsolutePath } from '../../../utils/utils'
 
 export async function getAllServiceFolders(target: Target) {
   const { configuration } = await getLocalOrGlobalConfig()
@@ -17,7 +17,7 @@ export async function getAllServiceFolders(target: Target) {
 
   const { buildSourceFolder } = await getConstants()
   allServices = allServices.map((service) =>
-    path.isAbsolute(service) ? service : path.join(buildSourceFolder, service)
+    getAbsolutePath(service, buildSourceFolder)
   )
 
   return [...new Set(allServices)]

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -31,7 +31,6 @@ describe('sasjs compile', () => {
   let sharedAppName: string
   let appName: string
   let target: Target
-  let parentOutputFolder: string
   const homedir = require('os').homedir()
 
   beforeAll(async () => {
@@ -80,11 +79,11 @@ describe('sasjs compile', () => {
     expect(compileModule.compileJobsServicesTests).toHaveBeenCalled()
   })
 
-  it('should compile project with having tilda in paths', async () => {
-    const tildaPathToApp = path.join(__dirname, appName).replace(homedir, '~')
+  it('should compile project with having tilde in paths', async () => {
+    const tildePathToApp = path.join(__dirname, appName).replace(homedir, '~')
 
-    await updateConfig(prefixConfigWithPath(tildaPathToApp), true)
-    await updateTarget(prefixTargetConfigWithPath(tildaPathToApp), 'viya', true)
+    await updateConfig(prefixConfigWithPath(tildePathToApp), true)
+    await updateTarget(prefixTargetConfigWithPath(tildePathToApp), 'viya', true)
 
     await expect(compileModule.compile(target)).toResolve()
     expect(compileModule.copyFilesToBuildFolder).toHaveBeenCalled()

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -2,7 +2,11 @@ import path from 'path'
 import os from 'os'
 import SASjs from '@sasjs/adapter/node'
 import { getLocalConfig, getAuthConfig } from '../../utils/config'
-import { displaySasjsRunnerError, executeShellScript } from '../../utils/utils'
+import {
+  displaySasjsRunnerError,
+  executeShellScript,
+  getAbsolutePath
+} from '../../utils/utils'
 import {
   readFile,
   readFileBinary,
@@ -50,9 +54,7 @@ export async function deploy(target: Target, isLocal: boolean) {
 
   const logFilePath = buildDestinationFolder
   await asyncForEach(deployScripts, async (deployScript) => {
-    const deployScriptPath = path.isAbsolute(deployScript)
-      ? deployScript
-      : path.join(process.projectDir, deployScript)
+    const deployScriptPath = getAbsolutePath(deployScript, process.projectDir)
 
     if (isSasFile(deployScript)) {
       process.logger?.info(

--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -19,6 +19,7 @@ import { createDotFiles } from './internal/createDotFiles'
 import { getDocConfig } from './internal/getDocConfig'
 
 import { LogLevel } from '@sasjs/utils/logger'
+import { getAbsolutePath } from '../../utils/utils'
 
 /**
  * Generates documentation(Doxygen)
@@ -97,9 +98,10 @@ export async function generateDocs(targetName: string, outDirectory: string) {
   }
 
   if (doxyContentFromConfig?.path)
-    doxyContent.path = path.isAbsolute(doxyContentFromConfig.path)
-      ? doxyContentFromConfig.path
-      : path.join(process.projectDir, doxyContentFromConfig.path)
+    doxyContent.path = getAbsolutePath(
+      doxyContentFromConfig.path,
+      process.projectDir
+    )
 
   const doxyParams = setVariableCmd({
     DOXY_HTML_OUTPUT: newOutDirectory,

--- a/src/commands/docs/generateDocs.ts
+++ b/src/commands/docs/generateDocs.ts
@@ -130,7 +130,8 @@ export async function generateDocs(targetName: string, outDirectory: string) {
   )
   if (process.env.LOG_LEVEL !== LogLevel.Debug) spinner.start()
 
-  await deleteFolder(newOutDirectory)
+  const pathExists = await fileExists(newOutDirectory)
+  if (pathExists) await deleteFolder(newOutDirectory)
   await createFolder(newOutDirectory)
 
   const { stderr, code } = shelljs.exec(

--- a/src/commands/docs/internal/getFoldersForDocs.ts
+++ b/src/commands/docs/internal/getFoldersForDocs.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 import { Target, Configuration } from '@sasjs/utils/types'
 import { getConstants } from '../../../constants'
+import { getAbsolutePath } from '../../../utils/utils'
 
 /**
  * Returns list of folders for documentation( macroCore / macros / SAS programs/ services / jobs )
@@ -36,23 +37,19 @@ async function extractFoldersForDocs(config: Target | Configuration) {
       : [path.join(process.projectDir, 'node_modules', '@sasjs', 'core')]
 
   const macroFolders = config?.macroFolders
-    ? config.macroFolders.map((f) =>
-        path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
-      )
+    ? config.macroFolders.map((f) => getAbsolutePath(f, buildSourceFolder))
     : []
   const programFolders = config?.programFolders
-    ? config.programFolders.map((f) =>
-        path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
-      )
+    ? config.programFolders.map((f) => getAbsolutePath(f, buildSourceFolder))
     : []
   const serviceFolders = config?.serviceConfig?.serviceFolders
     ? config.serviceConfig.serviceFolders.map((f) =>
-        path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
+        getAbsolutePath(f, buildSourceFolder)
       )
     : []
   const jobFolders = config?.jobConfig?.jobFolders
     ? config.jobConfig.jobFolders.map((f) =>
-        path.isAbsolute(f) ? f : path.join(buildSourceFolder, f)
+        getAbsolutePath(f, buildSourceFolder)
       )
     : []
 

--- a/src/commands/request/request.ts
+++ b/src/commands/request/request.ts
@@ -11,8 +11,9 @@ import {
 import { displayError, displaySuccess } from '../../utils/displayResult'
 import { Command } from '../../utils/command'
 import { ServerType } from '@sasjs/utils/types'
-import { displaySasjsRunnerError } from '../../utils/utils'
+import { displaySasjsRunnerError, getAbsolutePath } from '../../utils/utils'
 import { getConstants } from '../../constants'
+import { config } from 'dotenv'
 
 export async function runSasJob(command: Command) {
   const sasJobLocation = command.values.shift() as string
@@ -34,9 +35,7 @@ export async function runSasJob(command: Command) {
     }
 
     const dataFile = await readFile(
-      path.isAbsolute(dataFilePath)
-        ? dataFilePath
-        : path.join(process.projectDir, dataFilePath)
+      getAbsolutePath(dataFilePath, process.projectDir)
     )
 
     try {
@@ -52,9 +51,7 @@ export async function runSasJob(command: Command) {
     }
 
     const configFile = await readFile(
-      path.isAbsolute(configFilePath)
-        ? configFilePath
-        : path.join(process.projectDir, configFilePath)
+      getAbsolutePath(configFilePath, process.projectDir)
     )
 
     try {

--- a/src/commands/run/run.ts
+++ b/src/commands/run/run.ts
@@ -14,7 +14,7 @@ import { Command } from '../../utils/command'
 import { displayError } from '../../utils/displayResult'
 import { getConstants } from '../../constants'
 import { compileSingleFile } from '../'
-import { displaySasjsRunnerError } from '../../utils/utils'
+import { displaySasjsRunnerError, getAbsolutePath } from '../../utils/utils'
 
 /**
  * Runs SAS code from a given file on the specified target.
@@ -41,11 +41,7 @@ export async function runSasCode(command: Command) {
     ))
     process.logger?.success(`File Compiled and placed at: ${filePath} .`)
   }
-  const sasFile = await readFile(
-    path.isAbsolute(filePath)
-      ? filePath
-      : path.join(process.currentDir, filePath)
-  )
+  const sasFile = await readFile(getAbsolutePath(filePath, process.currentDir))
   const linesToExecute = sasFile.replace(/\r\n/g, '\n').split('\n')
   if (target.serverType === ServerType.SasViya) {
     return await executeOnSasViya(filePath, target, linesToExecute)

--- a/src/commands/servicepack/deploy.ts
+++ b/src/commands/servicepack/deploy.ts
@@ -5,6 +5,7 @@ import { displayError, displaySuccess } from '../../utils/displayResult'
 import { getAccessToken, findTargetInConfiguration } from '../../utils/config'
 import { ServerType, Target } from '@sasjs/utils/types'
 import { getConstants } from '../../constants'
+import { getAbsolutePath } from '../../utils/utils'
 
 export async function servicePackDeploy(
   jsonFilePath: string,
@@ -66,11 +67,7 @@ async function deployToSasViyaWithServicePack(
   let jsonContent
 
   if (jsonFilePath) {
-    jsonContent = await readFile(
-      path.isAbsolute(jsonFilePath)
-        ? jsonFilePath
-        : path.join(process.cwd(), jsonFilePath)
-    )
+    jsonContent = await readFile(getAbsolutePath(jsonFilePath, process.cwd()))
   } else {
     jsonContent = await readFile(finalFilePathJSON)
   }

--- a/src/commands/web/index.ts
+++ b/src/commands/web/index.ts
@@ -1,4 +1,4 @@
-import { chunk } from '../../utils/utils'
+import { chunk, getAbsolutePath } from '../../utils/utils'
 import {
   readFile,
   copy,
@@ -90,9 +90,7 @@ export async function createWebAppServices(target: Target) {
   )
   await createTargetDestinationFolder(destinationPath)
 
-  const webSourcePathFull = path.isAbsolute(webSourcePath)
-    ? webSourcePath
-    : path.join(process.projectDir, webSourcePath)
+  const webSourcePathFull = getAbsolutePath(webSourcePath, process.projectDir)
 
   if (!(await folderExists(webSourcePathFull)))
     process.logger?.warn(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { getInstalledPath } from 'get-installed-path'
 import { getLocalOrGlobalConfig } from './utils/config'
+import { getAbsolutePath } from './utils/utils'
 
 interface Constants {
   buildSourceFolder: string
@@ -54,9 +55,10 @@ export const getConstants = async (): Promise<Constants> => {
     'sasjs',
     'db'
   )
-  const buildDestinationFolder = path.isAbsolute(buildOutputFolder)
-    ? buildOutputFolder
-    : path.join(isLocal ? process.projectDir : homeDir, buildOutputFolder)
+  const buildDestinationFolder = getAbsolutePath(
+    buildOutputFolder,
+    isLocal ? process.projectDir : homeDir
+  )
   const buildDestinationServicesFolder = path.join(
     buildDestinationFolder,
     'services'
@@ -68,9 +70,10 @@ export const getConstants = async (): Promise<Constants> => {
   const macroCorePath = isLocal
     ? path.join(buildSourceFolder, 'node_modules', '@sasjs/core')
     : await getMacroCoreGlobalPath()
-  const buildDestinationResultsFolder = path.isAbsolute(buildResultsFolder)
-    ? buildResultsFolder
-    : path.join(isLocal ? process.projectDir : homeDir, buildResultsFolder)
+  const buildDestinationResultsFolder = getAbsolutePath(
+    buildResultsFolder,
+    isLocal ? process.projectDir : homeDir
+  )
   const buildDestinationResultsLogsFolder = path.join(
     buildDestinationResultsFolder,
     'logs'

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,6 +21,7 @@ import {
 import path from 'path'
 import dotenv from 'dotenv'
 import { TargetScope } from '../types/targetScope'
+import { getAbsolutePath } from './utils'
 
 const ERROR_MESSAGE = (targetName: string = '') => {
   return {
@@ -431,9 +432,7 @@ export async function getProgramFolders(target: Target) {
 
   const { buildSourceFolder } = await getConstants()
   programFolders = programFolders.map((programFolder) =>
-    path.isAbsolute(programFolder)
-      ? programFolder
-      : path.join(buildSourceFolder, programFolder)
+    getAbsolutePath(programFolder, buildSourceFolder)
   )
 
   return [...new Set(programFolders)]
@@ -459,9 +458,7 @@ export async function getMacroFolders(target?: Target) {
 
   const { buildSourceFolder } = await getConstants()
   macroFolders = macroFolders.map((macroFolder) =>
-    path.isAbsolute(macroFolder)
-      ? macroFolder
-      : path.join(buildSourceFolder, macroFolder)
+    getAbsolutePath(macroFolder, buildSourceFolder)
   )
 
   return [...new Set(macroFolders)]

--- a/src/utils/spec/utils.spec.ts
+++ b/src/utils/spec/utils.spec.ts
@@ -3,7 +3,8 @@ import {
   millisecondsToDdHhMmSs,
   inExistingProject,
   diff,
-  setupGitIgnore
+  setupGitIgnore,
+  getAbsolutePath
 } from '../utils'
 import { createFile, deleteFile, fileExists, readFile } from '@sasjs/utils'
 import path from 'path'
@@ -156,6 +157,37 @@ describe('utils', () => {
       expect(gitIgnoreContent.match(regExp)!.length).toEqual(1)
 
       await deleteFile(gitFilePath)
+    })
+  })
+
+  describe('getAbsolutePath', () => {
+    const homedir = require('os').homedir()
+    it('should convert relative path to absolute', () => {
+      const relativePath = './my-path/xyz'
+      const pathRelativeTo = '/home/abc'
+
+      const expectedAbsolutePath = '/home/abc/my-path/xyz'
+
+      expect(getAbsolutePath(relativePath, pathRelativeTo)).toEqual(
+        expectedAbsolutePath
+      )
+    })
+
+    it('should convert tilde from absolute path', () => {
+      const relativePath = '~/my-path/xyz'
+
+      const expectedAbsolutePath = '~/my-path/xyz'.replace('~', homedir)
+
+      expect(getAbsolutePath(relativePath, '')).toEqual(expectedAbsolutePath)
+    })
+
+    it('should return same path if path is absolute', () => {
+      const absolutePath = '/my-path/xyz'
+      const pathRelativeTo = '/home/abc'
+
+      expect(getAbsolutePath(absolutePath, pathRelativeTo)).toEqual(
+        absolutePath
+      )
     })
   })
 })

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,6 @@
 import shelljs from 'shelljs'
 import path from 'path'
+import os from 'os'
 import ora from 'ora'
 import {
   fileExists,
@@ -393,3 +394,8 @@ parmcards4;
     `Please deploy the SASjs runner by running the code below and try again:\n${sasjsRunnerCode}`
   )
 }
+
+export const getAbsolutePath = (providedPath: string, relativePath: string) =>
+  path.isAbsolute(providedPath) || /^~/.exec(providedPath)
+    ? providedPath.replace(/^~/, os.homedir())
+    : path.join(relativePath, providedPath)


### PR DESCRIPTION
## Issue

Closes #794 

## Intent

resolve paths with `~` in sasjsConfig.

## Implementation

Added `getAbsolutePath` to `utils/utils.ts`, and extracted logic from `commands/*`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/125422079-dd32333a-b76c-4435-b86f-273c7f12d01a.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/125423892-4d58298d-8a61-4e79-9f53-8610eddf9315.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/125933595-65150f53-b2e8-442b-9daf-59f63eb506d3.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
