### PR TITLE
feat(compile): Add macro variables for jobs

### DIFF
--- a/src/commands/compile/spec/loadDependencies.spec.ts
+++ b/src/commands/compile/spec/loadDependencies.spec.ts
@@ -1,11 +1,18 @@
 import path from 'path'
-import { Target, generateTimestamp } from '@sasjs/utils'
+import {
+  Target,
+  generateTimestamp,
+  JobConfig,
+  ServiceConfig
+} from '@sasjs/utils'
 import * as internalModule from '../internal/config'
 import { removeFromGlobalConfig } from '../../../utils/config'
 import {
   createTestGlobalTarget,
   createTestMinimalApp,
-  removeTestApp
+  removeTestApp,
+  updateConfig,
+  updateTarget
 } from '../../../utils/test'
 import { loadDependencies } from '../internal/loadDependencies'
 
@@ -117,6 +124,44 @@ const fakeProgramLines = [
   'run;'
 ]
 
+const jobConfig = (root: boolean = true): JobConfig => ({
+  initProgram: '',
+  termProgram: '',
+  jobFolders: [],
+  macroVars: root
+    ? {
+        macrovar1: 'macro job value configuration 1',
+        macrovar2: 'macro job value configuration 2'
+      }
+    : {
+        macrovar2: 'macro job value target 2',
+        macrovar3: 'macro job value target 3'
+      }
+})
+
+const serviceConfig = (root: boolean = true): ServiceConfig => ({
+  initProgram: '',
+  termProgram: '',
+  serviceFolders: [],
+  macroVars: root
+    ? {
+        macrovar1: 'macro service value configuration 1',
+        macrovar2: 'macro service value configuration 2'
+      }
+    : {
+        macrovar2: 'macro service value target 2',
+        macrovar3: 'macro service value target 3'
+      }
+})
+
+const compiledVars = (type: 'Job' | 'Service') => `* ${type} Variables start;
+
+%let macrovar1=macro ${type.toLowerCase()} value configuration 1;
+%let macrovar2=macro ${type.toLowerCase()} value target 2;
+%let macrovar3=macro ${type.toLowerCase()} value target 3;
+
+*${type} Variables end;`
+
 describe('loadDependencies', () => {
   let target: Target
 
@@ -124,6 +169,16 @@ describe('loadDependencies', () => {
     const appName = `cli-tests-load-dependencies-${generateTimestamp()}`
     target = await createTestGlobalTarget(appName, '/Public/app')
     await createTestMinimalApp(__dirname, target.name)
+
+    await updateConfig({
+      jobConfig: jobConfig(),
+      serviceConfig: serviceConfig()
+    })
+    target = await updateTarget(
+      { jobConfig: jobConfig(false), serviceConfig: serviceConfig(false) },
+      target.name,
+      false
+    )
   })
 
   afterAll(async () => {
@@ -153,6 +208,7 @@ describe('loadDependencies', () => {
       'service'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Service'))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -183,6 +239,7 @@ describe('loadDependencies', () => {
       'job'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Job'))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -212,6 +269,8 @@ describe('loadDependencies', () => {
       [],
       'service'
     )
+
+    expect(dependencies).toStartWith(compiledVars('Service'))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -242,6 +301,7 @@ describe('loadDependencies', () => {
       'job'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Job'))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -272,6 +332,7 @@ describe('loadDependencies', () => {
       'service'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Service'))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -302,6 +363,7 @@ describe('loadDependencies', () => {
       'job'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Job'))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -331,6 +393,8 @@ describe('loadDependencies', () => {
       [path.join(__dirname, './'), path.join(__dirname, './services')],
       'service'
     )
+
+    expect(dependencies).toStartWith(compiledVars('Service'))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -361,6 +425,7 @@ describe('loadDependencies', () => {
       'job'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Job'))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -391,6 +456,7 @@ describe('loadDependencies', () => {
       'job'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Job'))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -427,6 +493,7 @@ describe('loadDependencies', () => {
       'job'
     )
 
+    expect(dependencies).toStartWith(compiledVars('Job'))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -461,6 +528,8 @@ describe('loadDependencies', () => {
       [path.join(__dirname, './'), path.join(__dirname, './services')],
       'service'
     )
+
+    expect(dependencies).toStartWith(compiledVars('Service'))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -496,6 +565,8 @@ describe('loadDependencies', () => {
       [path.join(__dirname, './'), path.join(__dirname, './services')],
       'service'
     )
+
+    expect(dependencies).toStartWith(compiledVars('Service'))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)

--- a/src/commands/deploy/spec/cbd.spec.server.ts
+++ b/src/commands/deploy/spec/cbd.spec.server.ts
@@ -69,7 +69,7 @@ describe('sasjs cbd with global config', () => {
      */
     const jobContent = await readFile(jobPath)
     expect(jobContent).not.toEqual('')
-    expect(/^\* Dependencies start;*/.test(jobContent)).toEqual(true)
+    expect(/^\* Job Variables start;*/.test(jobContent)).toEqual(true)
     expect(jobContent.includes(`* JobInit start;`)).toEqual(true)
     expect(jobContent.includes(`* JobTerm start;`)).toEqual(true)
     /**


### PR DESCRIPTION
## Issue

Closes #861 

## Intent

Should add macro variables while `sasjs compile` for `jobs`.

## Implementation

Added similar functionality to `jobs` for having job variables 

For example: 
>* Job Variables start;
>
>%let macrovar=macro value;
>%let macrovar2=macro value2;
>
>* Job Variables end;

Updated `getVars` function as well. 

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/126454571-0889f07f-1f5d-4d19-8b01-a53e973e80a1.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
