### PR TITLE
fix: paths removed from service-pack and having base64 strings

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.17.5]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.17.5]
 
     steps:
       - uses: actions/checkout@v2

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { Target, ServerType } from '@sasjs/utils/types'
+import { Target, ServerType, StreamConfig } from '@sasjs/utils/types'
 import {
   readFile,
   base64EncodeFile,
@@ -20,8 +20,8 @@ import { compile } from '../compile/compile'
 import { getBuildInit, getBuildTerm } from './internal/config'
 import { getLaunchPageCode } from './internal/getLaunchPageCode'
 import { getDependencyPaths } from '../shared/dependencies'
-import { StreamConfig } from '@sasjs/utils/types/config'
 import { isTestFile } from '../compile/internal/compileTestFile'
+import { ServicePack, ServicePackMember } from '../../types'
 
 export async function build(target: Target) {
   await compile(target)
@@ -182,12 +182,15 @@ function getWebServiceScriptInvocation(
  * Jobs are deployed within a jobs folder within the appLoc.
  * @param {ServerType} serverType
  */
-async function getFolderContent(serverType: ServerType) {
+async function getFolderContent(serverType: ServerType): Promise<{
+  folderContent: string
+  folderContentJSON: ServicePack
+}> {
   const { buildDestinationFolder } = process.sasjsConstants
   const buildSubFolders = await listSubFoldersInFolder(buildDestinationFolder)
 
   let folderContent = ''
-  let folderContentJSON: any = { members: [] }
+  let folderContentJSON: ServicePack = { members: [] }
   await asyncForEach(buildSubFolders, async (subFolder) => {
     const { content, contentJSON } = await getContentFor(
       path.join(buildDestinationFolder, subFolder),
@@ -218,7 +221,7 @@ async function getContentFor(
   folderPath: string,
   serverType: ServerType,
   testPath: string | undefined = undefined
-) {
+): Promise<{ content: string; contentJSON: ServicePackMember }> {
   const folderName = path.basename(folderPath)
   if (!testPath && folderName === 'tests') {
     testPath = ''
@@ -237,7 +240,7 @@ async function getContentFor(
           .join('/')
   };\n`
 
-  const contentJSON: any = {
+  const contentJSON: ServicePackMember = {
     name: folderName,
     type: 'folder',
     members: []
@@ -258,19 +261,25 @@ async function getContentFor(
       )
       content += `\n${transformedContent}\n`
 
-      contentJSON?.members.push({
+      contentJSON!.members!.push({
         name: file.replace(/.sas$/, ''),
         type: 'service',
         code: removeComments(fileContent)
       })
     } else {
-      const transformedContent = await getFileText(file, filePath, serverType)
+      const fileContentEncoded = await base64EncodeFile(filePath)
+
+      const transformedContent = getFileText(
+        file,
+        fileContentEncoded,
+        serverType
+      )
       content += `\n${transformedContent}\n`
 
-      contentJSON?.members.push({
+      contentJSON!.members!.push({
         name: file.replace(/.sas$/, ''),
         type: 'file',
-        path: filePath
+        code: fileContentEncoded
       })
     }
   })
@@ -290,7 +299,7 @@ async function getContentFor(
           : undefined
       )
 
-    contentJSON?.members.push(childContentJSON)
+    contentJSON!.members!.push(childContentJSON)
     content += childContent
   })
 
@@ -326,15 +335,15 @@ filename sascode clear;
 `
 }
 
-async function getFileText(
+function getFileText(
   fileName: string,
-  filePath: string,
+  fileContent: string,
   serverType: ServerType
 ) {
   const fileExtension = path.extname(fileName).substring(1).toUpperCase()
 
-  const { content, encoded, maxLineLength } = await getWebFileContent(
-    filePath,
+  const { content, maxLineLength } = getWebFileContent(
+    fileContent,
     fileExtension
   )
 
@@ -344,59 +353,33 @@ data _null_;
 file filecode;
 ${content}\n
 run;
-${getWebServiceScriptInvocation(serverType, undefined, false, encoded)}
+${getWebServiceScriptInvocation(serverType, undefined, false, true)}
 filename filecode clear;
 `
 }
 
-async function getWebFileContent(filePath: string, type: string) {
-  let lines,
-    encoded = false
+function getWebFileContent(filecontent: string, type: string) {
+  let parsedContent = ''
 
-  const typesToEncode: string[] = [
-    'ICO',
-    'PNG',
-    'JPG',
-    'JPEG',
-    'MP3',
-    'OGG',
-    'WAV'
-  ]
-
-  if (typesToEncode.includes(type)) {
-    encoded = true
-    lines = [await base64EncodeFile(filePath)]
+  const chunkedLines = chunk(filecontent)
+  if (chunkedLines.length === 1) {
+    parsedContent = ` put '${chunkedLines[0].split("'").join("''")}';\n`
   } else {
-    lines = (await readFile(filePath))
-      .replace(/\r\n/g, '\n')
-      .split('\n')
-      .filter((l) => !!l)
+    let combinedLines = ''
+    chunkedLines.forEach((chunkedLine, index) => {
+      let text = ` put '${chunkedLine.split("'").join("''")}'`
+      if (index !== chunkedLines.length - 1) {
+        text += '@;\n'
+      } else {
+        text += ';\n'
+      }
+      combinedLines += text
+    })
+    parsedContent += combinedLines
   }
+  const maxLineLength = Math.max(32767, filecontent.length)
 
-  let parsedContent = '',
-    maxLineLength = 32767
-
-  lines.forEach((line) => {
-    const chunkedLines = chunk(line)
-    if (chunkedLines.length === 1) {
-      parsedContent += ` put '${chunkedLines[0].split("'").join("''")}';\n`
-    } else {
-      let combinedLines = ''
-      chunkedLines.forEach((chunkedLine, index) => {
-        let text = ` put '${chunkedLine.split("'").join("''")}'`
-        if (index !== chunkedLines.length - 1) {
-          text += '@;\n'
-        } else {
-          text += ';\n'
-        }
-        combinedLines += text
-      })
-      parsedContent += combinedLines
-    }
-    maxLineLength = maxLineLength < line.length ? line.length : maxLineLength
-  })
-
-  return { content: parsedContent, encoded, maxLineLength }
+  return { content: parsedContent, maxLineLength }
 }
 
 function getLines(text: string): string[] {

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -261,7 +261,7 @@ async function getContentFor(
       )
       content += `\n${transformedContent}\n`
 
-      contentJSON!.members!.push({
+      contentJSON.members!.push({
         name: file.replace(/.sas$/, ''),
         type: 'service',
         code: removeComments(fileContent)
@@ -276,7 +276,7 @@ async function getContentFor(
       )
       content += `\n${transformedContent}\n`
 
-      contentJSON!.members!.push({
+      contentJSON.members!.push({
         name: file.replace(/.sas$/, ''),
         type: 'file',
         code: fileContentEncoded
@@ -299,7 +299,7 @@ async function getContentFor(
           : undefined
       )
 
-    contentJSON!.members!.push(childContentJSON)
+    contentJSON.members!.push(childContentJSON)
     content += childContent
   })
 

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -368,11 +368,9 @@ function getWebFileContent(filecontent: string, type: string) {
     let combinedLines = ''
     chunkedLines.forEach((chunkedLine, index) => {
       let text = ` put '${chunkedLine.split("'").join("''")}'`
-      if (index !== chunkedLines.length - 1) {
-        text += '@;\n'
-      } else {
-        text += ';\n'
-      }
+      if (index !== chunkedLines.length - 1) text += '@;\n'
+      else text += ';\n'
+
       combinedLines += text
     })
     parsedContent += combinedLines

--- a/src/commands/create/spec/create.spec.ts
+++ b/src/commands/create/spec/create.spec.ts
@@ -16,7 +16,7 @@ describe('sasjs create', () => {
   })
 
   afterEach(async () => {
-    await deleteFolder(path.join(__dirname, 'test-app-create-*'))
+    // await deleteFolder(path.join(__dirname, 'test-app-create-*'))
   })
 
   it('should set up a default app in the current folder', async () => {

--- a/src/commands/create/spec/create.spec.ts
+++ b/src/commands/create/spec/create.spec.ts
@@ -16,7 +16,7 @@ describe('sasjs create', () => {
   })
 
   afterEach(async () => {
-    // await deleteFolder(path.join(__dirname, 'test-app-create-*'))
+    await deleteFolder(path.join(__dirname, 'test-app-create-*'))
   })
 
   it('should set up a default app in the current folder', async () => {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -19,7 +19,7 @@ import {
 } from '@sasjs/utils'
 import { isSasFile, isShellScript } from '../../utils/file'
 import { getDeployScripts } from './internal/getDeployScripts'
-import { deployToSasViyaWithServicePack } from './internal/deployToSasViyaWithServicePack'
+import { deployToSasViyaWithServicePack } from '../shared/deployToSasViyaWithServicePack'
 import { ServicePack } from '../../types'
 
 export async function deploy(target: Target, isLocal: boolean) {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -41,6 +41,7 @@ export async function deploy(target: Target, isLocal: boolean) {
     const jsonObject: ServicePack = await deployToSasViyaWithServicePack(
       finalFilePathJSON,
       target,
+      isLocal,
       true
     )
 

--- a/src/commands/deploy/internal/deployToSasViyaWithServicePack.ts
+++ b/src/commands/deploy/internal/deployToSasViyaWithServicePack.ts
@@ -1,0 +1,54 @@
+import SASjs from '@sasjs/adapter/node'
+import { readFile, Target } from '@sasjs/utils'
+import { ServicePack, ServicePackMember } from '../../../types'
+import { decode } from 'js-base64'
+import { getAccessToken } from '../../../utils'
+
+export async function deployToSasViyaWithServicePack(
+  jsonFilePath: string,
+  target: Target,
+  isForced: boolean = false
+): Promise<ServicePack> {
+  const jsonContent = await readFile(jsonFilePath)
+
+  let jsonObject: ServicePack
+
+  try {
+    jsonObject = JSON.parse(jsonContent)
+  } catch (err) {
+    throw new Error('Provided data file must be valid json.')
+  }
+
+  populateCodeInServicePack(jsonObject)
+
+  const sasjs = new SASjs({
+    allowInsecureRequests: target.allowInsecureRequests,
+    appLoc: target.appLoc,
+    serverType: target.serverType,
+    serverUrl: target.serverUrl,
+    useComputeApi: true
+  })
+  const access_token = await getAccessToken(target)
+
+  if (!access_token) {
+    throw new Error(
+      `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
+    )
+  }
+
+  await sasjs.deployServicePack(
+    jsonObject,
+    undefined,
+    undefined,
+    access_token,
+    isForced
+  )
+
+  return jsonObject
+}
+
+const populateCodeInServicePack = (json: ServicePack | ServicePackMember) =>
+  json?.members?.forEach((member: ServicePackMember) => {
+    if (member.type === 'file') member.code = decode(member.code!)
+    if (member.type === 'folder') populateCodeInServicePack(member)
+  })

--- a/src/commands/deploy/spec/cbd.spec.server.ts
+++ b/src/commands/deploy/spec/cbd.spec.server.ts
@@ -14,7 +14,6 @@ import {
   saveToGlobalConfig
 } from '../../../utils/config'
 import * as configUtils from '../../../utils/config'
-import * as displayResultModule from '../../../utils/displayResult'
 import * as getDeployScriptsModule from '../internal/getDeployScripts'
 import {
   createTestApp,
@@ -153,7 +152,7 @@ describe('sasjs cbd with local config', () => {
   })
 
   it(`should error when an access token is not provided`, async () => {
-    jest.spyOn(configUtils, 'getAuthConfig').mockImplementation(() => {
+    jest.spyOn(configUtils, 'getAccessToken').mockImplementation(() => {
       return Promise.reject('Token error')
     })
 

--- a/src/commands/servicepack/deploy.ts
+++ b/src/commands/servicepack/deploy.ts
@@ -6,6 +6,7 @@ import { deployToSasViyaWithServicePack } from '../shared/deployToSasViyaWithSer
 
 export async function servicePackDeploy(
   target: Target,
+  isLocal: boolean,
   jsonFilePath: string,
   isForced = false
 ) {
@@ -25,7 +26,7 @@ export async function servicePackDeploy(
   }
 
   let success
-  await deployToSasViyaWithServicePack(jsonFilePath, target, isForced)
+  await deployToSasViyaWithServicePack(jsonFilePath, target, isLocal, isForced)
     .then((_) => {
       displaySuccess('Servicepack successfully deployed!')
 

--- a/src/commands/servicepack/deploy.ts
+++ b/src/commands/servicepack/deploy.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { displayError, displaySuccess } from '../../utils/displayResult'
 import { Target } from '@sasjs/utils'
 import { getAbsolutePath } from '../../utils/utils'
-import { deployToSasViyaWithServicePack } from '../deploy/internal/deployToSasViyaWithServicePack'
+import { deployToSasViyaWithServicePack } from '../shared/deployToSasViyaWithServicePack'
 
 export async function servicePackDeploy(
   target: Target,

--- a/src/commands/servicepack/deploy.ts
+++ b/src/commands/servicepack/deploy.ts
@@ -1,10 +1,8 @@
 import path from 'path'
-import SASjs from '@sasjs/adapter/node'
-import { readFile } from '@sasjs/utils'
 import { displayError, displaySuccess } from '../../utils/displayResult'
-import { getAccessToken, findTargetInConfiguration } from '../../utils/config'
-import { ServerType, Target } from '@sasjs/utils/types'
+import { Target } from '@sasjs/utils'
 import { getAbsolutePath } from '../../utils/utils'
+import { deployToSasViyaWithServicePack } from '../deploy/internal/deployToSasViyaWithServicePack'
 
 export async function servicePackDeploy(
   target: Target,
@@ -15,18 +13,18 @@ export async function servicePackDeploy(
     throw new Error('Provided data file must be valid json.')
   }
 
-  if (target.serverType !== ServerType.SasViya) {
-    throw new Error(
-      `Unable to deploy service pack to target ${target.name}. This command is only supported for server type ${ServerType.SasViya}.`
-    )
-  }
-
   process.logger?.info(
     `Deploying service pack to ${target.serverUrl} at location ${target.appLoc} .`
   )
 
-  let success
+  if (jsonFilePath) {
+    jsonFilePath = getAbsolutePath(jsonFilePath, process.cwd())
+  } else {
+    const { buildDestinationFolder } = process.sasjsConstants
+    jsonFilePath = path.join(buildDestinationFolder, `${target.name}.json`)
+  }
 
+  let success
   await deployToSasViyaWithServicePack(jsonFilePath, target, isForced)
     .then((_) => {
       displaySuccess('Servicepack successfully deployed!')
@@ -40,56 +38,4 @@ export async function servicePackDeploy(
     })
 
   return success
-}
-
-async function deployToSasViyaWithServicePack(
-  jsonFilePath: string,
-  buildTarget: Target,
-  isForced: boolean
-) {
-  const sasjs = new SASjs({
-    serverUrl: buildTarget.serverUrl,
-    allowInsecureRequests: buildTarget.allowInsecureRequests,
-    appLoc: buildTarget.appLoc,
-    serverType: buildTarget.serverType,
-    useComputeApi: true
-  })
-  const { buildDestinationFolder } = process.sasjsConstants
-
-  const finalFilePathJSON = path.join(
-    buildDestinationFolder,
-    `${buildTarget.name}.json`
-  )
-
-  let jsonContent
-
-  if (jsonFilePath) {
-    jsonContent = await readFile(getAbsolutePath(jsonFilePath, process.cwd()))
-  } else {
-    jsonContent = await readFile(finalFilePathJSON)
-  }
-
-  let jsonObject
-
-  try {
-    jsonObject = JSON.parse(jsonContent)
-  } catch (err) {
-    throw new Error('Provided data file must be valid json.')
-  }
-
-  const access_token = await getAccessToken(buildTarget)
-
-  if (!access_token) {
-    throw new Error(
-      `Deployment failed. Request is not authenticated.\nPlease add the following variables to your .env file:\nCLIENT, SECRET, ACCESS_TOKEN, REFRESH_TOKEN`
-    )
-  }
-
-  return await sasjs.deployServicePack(
-    jsonObject,
-    undefined,
-    undefined,
-    access_token,
-    isForced
-  )
 }

--- a/src/commands/servicepack/servicePackCommand.ts
+++ b/src/commands/servicepack/servicePackCommand.ts
@@ -1,3 +1,4 @@
+import { ServerType } from '@sasjs/utils'
 import { CommandExample, ReturnCode } from '../../types/command'
 import { TargetCommand } from '../../types/command/targetCommand'
 import { displayError } from '../../utils'
@@ -48,6 +49,12 @@ export class ServicePackCommand extends TargetCommand {
 
   public async execute() {
     const { target } = await this.getTargetInfo()
+    if (target.serverType !== ServerType.SasViya) {
+      process.logger?.error(
+        `Unable to deploy service pack to target ${target.name}. This command is only supported for server type ${ServerType.SasViya}.`
+      )
+      return ReturnCode.InternalError
+    }
 
     const { source, force } = this.parsed
 

--- a/src/commands/servicepack/servicePackCommand.ts
+++ b/src/commands/servicepack/servicePackCommand.ts
@@ -48,7 +48,7 @@ export class ServicePackCommand extends TargetCommand {
   }
 
   public async execute() {
-    const { target } = await this.getTargetInfo()
+    const { target, isLocal } = await this.getTargetInfo()
     if (target.serverType !== ServerType.SasViya) {
       process.logger?.error(
         `Unable to deploy service pack to target ${target.name}. This command is only supported for server type ${ServerType.SasViya}.`
@@ -58,7 +58,12 @@ export class ServicePackCommand extends TargetCommand {
 
     const { source, force } = this.parsed
 
-    return await servicePackDeploy(target, source as string, force as boolean)
+    return await servicePackDeploy(
+      target,
+      isLocal,
+      source as string,
+      force as boolean
+    )
       .then(() => {
         return ReturnCode.Success
       })

--- a/src/commands/servicepack/spec/servicepack.spec.server.ts
+++ b/src/commands/servicepack/spec/servicepack.spec.server.ts
@@ -47,6 +47,7 @@ describe('sasjs servicepack', () => {
         await expect(
           servicePackDeploy(
             target,
+            false,
             'src/commands/servicepack/spec/testServicepack.json',
             true
           )
@@ -61,6 +62,7 @@ describe('sasjs servicepack', () => {
         await expect(
           servicePackDeploy(
             target,
+            false,
             'src/commands/servicepack/spec/testServicepack.json'
           )
         ).resolves.toEqual(false)

--- a/src/commands/servicepack/spec/servicepackCommand.spec.ts
+++ b/src/commands/servicepack/spec/servicepackCommand.spec.ts
@@ -27,6 +27,7 @@ describe('ServicePackCommand', () => {
 
     expect(deployModule.servicePackDeploy).toHaveBeenCalledWith(
       target,
+      true,
       source,
       false
     )
@@ -43,6 +44,7 @@ describe('ServicePackCommand', () => {
 
     expect(deployModule.servicePackDeploy).toHaveBeenCalledWith(
       target,
+      true,
       source,
       true
     )
@@ -53,6 +55,7 @@ describe('ServicePackCommand', () => {
 
     expect(deployModule.servicePackDeploy).toHaveBeenCalledWith(
       target,
+      true,
       source,
       true
     )
@@ -102,7 +105,7 @@ const executeCommandWrapper = async (additionalParams: string[]) => {
   expect(command.name).toEqual('servicepack')
   expect(command.subCommand).toEqual('deploy')
   expect(targetInfo.target).toEqual(target)
-  expect(targetInfo.isLocal).toBeTrue()
+  expect(targetInfo.isLocal).toEqual(true)
 
   return returnCode
 }

--- a/src/commands/shared/deployToSasViyaWithServicePack.ts
+++ b/src/commands/shared/deployToSasViyaWithServicePack.ts
@@ -1,8 +1,8 @@
 import SASjs from '@sasjs/adapter/node'
 import { readFile, Target } from '@sasjs/utils'
-import { ServicePack, ServicePackMember } from '../../../types'
+import { ServicePack, ServicePackMember } from '../../types'
 import { decode } from 'js-base64'
-import { getAccessToken } from '../../../utils'
+import { getAccessToken } from '../../utils'
 
 export async function deployToSasViyaWithServicePack(
   jsonFilePath: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,3 +14,4 @@ export {
   TestResultDescription
 } from './testing'
 export { Flow, FlowWave, FlowWaveJob } from './flow'
+export { ServicePack, ServicePackMember } from './servicePack'

--- a/src/types/servicePack.ts
+++ b/src/types/servicePack.ts
@@ -1,0 +1,10 @@
+export interface ServicePack {
+  members: ServicePackMember[]
+}
+
+export interface ServicePackMember {
+  name: string
+  type: 'folder' | 'service' | 'file'
+  code?: string
+  members?: ServicePackMember[]
+}


### PR DESCRIPTION
## Issue

Adapter issue: https://github.com/sasjs/adapter/issues/492

## Intent

Remove paths from servicePack.json and have base64 encoded string. It should be portable and self-contained.

## Implementation

Types added for:
- `ServicePack`
- `ServicePackMember`

Updated :
- `build.ts` for saving base64 encoded string to servicepack and 
- `deploy.ts` for decoding base64 and send to adapter as code string.

++

- `sasjs deploy` and `sasjs servicepack` were having duplicate code for `deployToSasViyaWithServicePack`, is DRY now.
- `deployToSasViyaWithServicePack` is placed in shared folder.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/130965012-ee075594-f47a-4d04-b970-c1f2c755cf9d.png)
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/130966315-915776ba-1ed7-489f-aa8f-6414fb7d44ff.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/130971754-4d80598e-d856-4bf0-acc1-9c6d7c53db5b.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
