### PR TITLE
fix: remove preinstall and prebuild scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,11 @@
     "build/**/*"
   ],
   "scripts": {
-    "preinstall": "node checkNodeVersion",
-    "prebuild": "node checkNodeVersion",
     "start": "nodemon --watch \"src/**/*\" --exec \"npm run build && npm run set:permissions\"",
     "set:permissions": "node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "build": "rimraf build && tsc -p . && npm run copy:files",
     "copy:files": "copyfiles -u 1 ./src/config.json ./build/ && npm run copy:doxy",
-    "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/ && npm run copy:checkNodeVersion",
-    "copy:checkNodeVersion": "copyfiles ./checkNodeVersion.js ./build/",
+    "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/",
     "test": "npm run test:mocked && npm run test:server",
     "test:server": "jest --silent --runInBand --config=jest.server.config.js",
     "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",


### PR DESCRIPTION
## Issue

Link any related issue(s) in this section.

## Intent

preinstall script is causing problem as checkNodeVersion script is not being included in package therefore, remove this script for now.

## Implementation

What code changes have been made to achieve the intent.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
