### PR TITLE
test(docs): updated spec checks for docs

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Install Doxygen
-        run: choco install doxygen.install --version 1.9.1
+        run: choco install doxygen.install
 
       - name: Add doxygen to path
         run: echo "C:\Program Files\doxygen\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -425,9 +425,8 @@ export const verifyDocs = async (
 
   const indexHTMLContent = await readFile(indexHTML)
 
-  expect(indexHTMLContent).toEqual(
-    expect.stringContaining('<h1><a class="anchor" id="autotoc_md1"></a>')
-  )
+  expect(indexHTMLContent).toEqual(expect.stringMatching(/Contributing/))
+  expect(indexHTMLContent).toEqual(expect.stringMatching(/Environment Setup/))
 }
 
 export const verifyDotFiles = async (docsFolder: string) => {


### PR DESCRIPTION
## Issue

Closes #945 

## Intent

Fix specs using latest(1.9.2) version of doxygen.

## Implementation

It turns out that just specs were failing. Doxygen 1.9.2 works fine and supported with CLI.
Updated specs for `index.html` file 
Updated version restriction from github workflow

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
