### PR TITLE
Fix test macro compilation

### DIFF
--- a/src/commands/compile/internal/compileServiceFile.ts
+++ b/src/commands/compile/internal/compileServiceFile.ts
@@ -4,6 +4,7 @@ import { Target, ServerType } from '@sasjs/utils/types'
 import { ServerTypeError } from '@sasjs/utils/error'
 import { loadDependencies } from './loadDependencies'
 import { getServerType } from './getServerType'
+import { isTestFile } from './compileTestFile'
 
 export async function compileServiceFile(
   target: Target,
@@ -16,7 +17,8 @@ export async function compileServiceFile(
     target,
     filePath,
     macroFolders,
-    programFolders
+    programFolders,
+    isTestFile(filePath) ? 'test' : undefined
   )
 
   const serverType = await getServerType(target)

--- a/src/commands/compile/internal/spec/compileTestFile.spec.ts
+++ b/src/commands/compile/internal/spec/compileTestFile.spec.ts
@@ -37,7 +37,8 @@ describe('compileTestFile', () => {
     ...temp.toJson(),
     jobConfig: {
       jobFolders: [path.join('sasjs', 'jobs')]
-    }
+    },
+    macroFolders: ['sasjs/macros']
   })
   let sasjsPath: string
   let testBody: string
@@ -124,6 +125,7 @@ describe('compileTestFile', () => {
       await testContent(path.join('jobs', 'jobs', 'testJob.test.sas'))
       await testContent(path.join('testsetup.sas'))
       await testContent(path.join('testteardown.sas'))
+      await testContent(path.join('macros', 'testMacro.test.sas'))
     })
   })
 
@@ -180,6 +182,7 @@ describe('compileTestFile', () => {
       const expectedTestFlow = {
         tests: [
           ['tests', 'jobs', 'jobs', 'testJob.test.sas'].join('/'),
+          ['tests', 'macros', 'testMacro.test.sas'].join('/'),
           ['tests', 'services', 'services', 'admin', 'random.test.sas'].join(
             '/'
           ),
@@ -234,6 +237,11 @@ describe('compileTestFile', () => {
           'standalone'
         ],
         [
+          ['tests', 'macros', 'testMacro.test.sas'].join('/'),
+          'test',
+          'standalone'
+        ],
+        [
           ['tests', 'services', 'services', 'admin', 'random.test.sas'].join(
             '/'
           ),
@@ -256,10 +264,10 @@ describe('compileTestFile', () => {
 
       await compile(target)
 
-      expect(process.logger.info).toHaveBeenCalledTimes(14)
-      expect(process.logger.info).toHaveBeenNthCalledWith(12, `Test coverage:`)
+      expect(process.logger.info).toHaveBeenCalledTimes(15)
+      expect(process.logger.info).toHaveBeenNthCalledWith(13, `Test coverage:`)
       expect(process.logger.info).toHaveBeenNthCalledWith(
-        13,
+        14,
         `Services coverage: 0/4 (${chalk.greenBright('0%')})`
       )
       expect(process.logger.info).toHaveBeenLastCalledWith(
@@ -297,6 +305,10 @@ const copyTestFiles = async (appName: string) => {
   await copy(
     path.join(__dirname, 'testFiles', 'jobs'),
     path.join(__dirname, appName, 'sasjs', 'jobs')
+  )
+  await copy(
+    path.join(__dirname, 'testFiles', 'macros'),
+    path.join(__dirname, appName, 'sasjs', 'macros')
   )
 }
 

--- a/src/commands/compile/internal/spec/testFiles/macros/testMacro.test.sas
+++ b/src/commands/compile/internal/spec/testFiles/macros/testMacro.test.sas
@@ -1,0 +1,16 @@
+/**
+  @file
+  @sastype_test
+  @brief testing macro
+
+  <h4> SAS Macros </h4>
+  @li mp_assert.sas
+**/
+
+%put this is a test;
+
+%assert(msg=My Test for macro,result=FAIL)
+
+%webout(OPEN)
+%webout(OBJ,test_results)
+%webout(CLOSE)


### PR DESCRIPTION
## Issue

Closes #1047 

## Intent

Add `macroVars` to test macro files.

## Implementation

Add check if a file is a test when loading dependencies in `compileServiceFile` function.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/143439603-084789ff-69dc-462e-b3dd-f8743cd75b82.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/143441822-4552e3f1-5f0b-4447-a128-97b5aaeec736.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/143446752-fe0bbafb-85ef-4c73-a5ee-6927efb977b5.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
