### PR TITLE
fix(sasjs-test): fix bug with compilation from sub folder

### DIFF
--- a/src/commands/compile/internal/compileTestFile.ts
+++ b/src/commands/compile/internal/compileTestFile.ts
@@ -22,8 +22,9 @@ import { getProgramFolders, getMacroFolders } from '../../../utils/config'
 import { getPreCodeForServicePack } from './compileServiceFile'
 import { getAbsolutePath } from '../../../utils/utils'
 
-const testsBuildFolder = () =>
-  path.join(process.currentDir, 'sasjsbuild', 'tests')
+const testsBuildFolder = () => {
+  return path.join(process.projectDir, 'sasjsbuild', 'tests')
+}
 
 const getFileName = (filePath: string) => path.parse(filePath).base
 

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -5,7 +5,9 @@ import {
   readFile,
   fileExists,
   deleteFolder,
-  generateTimestamp
+  generateTimestamp,
+  createFile,
+  folderExists
 } from '@sasjs/utils'
 import { BuildConfig } from '@sasjs/utils/types/config'
 import {
@@ -52,6 +54,34 @@ describe('sasjs compile', () => {
 
   afterAll(async () => {
     await removeTestApp(homedir, sharedAppName)
+  })
+
+  it('it should compile project from sub folder', async () => {
+    const serviceFolder = path.join(
+      process.projectDir,
+      'sasjs',
+      'services',
+      'admin'
+    )
+    const testFile = 'dostuff.test.sas'
+    const wrongSasjsBuildFolder = path.join(serviceFolder, 'sasjsbuild')
+    const correctSasjsBuildFolder = path.join(process.currentDir, 'sasjsbuild')
+    const correctBuildFile = path.join(
+      correctSasjsBuildFolder,
+      'tests',
+      'services',
+      'admin',
+      testFile
+    )
+
+    await createFile(path.join(serviceFolder, testFile), '')
+
+    process.currentDir = serviceFolder
+
+    await expect(compileModule.compile(target)).toResolve()
+    await expect(folderExists(wrongSasjsBuildFolder)).resolves.toEqual(false)
+    await expect(folderExists(correctSasjsBuildFolder)).resolves.toEqual(true)
+    await expect(fileExists(correctBuildFile)).resolves.toEqual(true)
   })
 
   it('should compile an uncompiled project', async () => {


### PR DESCRIPTION
## Issue

closes #879 

## Intent

Fix issue with `sasjs compile` command running from subfolder.

## Implementation

1. Changed `process.currentDir` to `process.projectDir` in `compileTestFile.ts`.
2. Add unit test covering such a scenario.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/143563183-9a641e3a-dc7e-4468-9d0e-246df2937127.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/143564103-6fedabe1-35ed-4a03-942c-5a9957cd1edb.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/143568067-abe36920-3c5a-4d25-8045-f17df08bb137.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
