### PR TITLE
fix: removing checkNodeVersion.  Closes #1058

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   ],
   "scripts": {
     "checkNodeVersion": "node -e \"console.log('\u001b[36m', 'Checking your Node.js version...'); if (!process.versions || !process.versions.node) { console.log('\u001b[31m', 'Error determining Node.js version. Exiting...') } if (parseInt(process.versions.node) < 14) { console.log('\u001b[31m', '❌ You must be running at least Node.js 14 to install SASjs CLI.\\nYour current version is ' + process.versions.node + '.\\nPlease install a more recent version and try again.'); process.exit(1); } else { console.log('\u001b[32m', '✅ Node.js version check passed. Continuing...'); } console.log('\u001b[0m', '');\"",
-    "preinstall": "npm run checkNodeVersion -s",
     "prebuild": "npm run checkNodeVersion -s",
     "start": "nodemon --watch \"src/**/*\" --exec \"npm run build && npm run set:permissions\"",
     "set:permissions": "node -e \"require('fs').chmodSync('build/index.js', '755')\"",


### PR DESCRIPTION
## Issue

Relates to #1058 

## Intent

The goal is to prevent users from hitting errors when trying to install @sasjs/cli

## Implementation

Simply removed the `preinstall` script

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
