### PR TITLE
fix(deploy): handle SAS9 execution error gracefully

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -259,7 +259,7 @@ async function deployToSas9(
         process.logger?.error('Deployment completed with errors.')
         const errorLogPath = path.join(
           logFilePath || process.cwd(),
-          `${path.basename(deployScript).replace('.sas', '')}.error.log`
+          `${path.basename(deployScript).replace('.sas', '')}.log`
         )
         await createFile(
           errorLogPath,

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -261,10 +261,7 @@ async function deployToSas9(
           logFilePath || process.cwd(),
           `${path.basename(deployScript).replace('.sas', '')}.log`
         )
-        await createFile(
-          errorLogPath,
-          err.result
-        )
+        await createFile(errorLogPath, err.result)
         process.logger?.info(`Error log is available at ${errorLogPath}`)
         throw new Error()
       } else {


### PR DESCRIPTION
## Issue

#1063 

## Intent

Handle job execution errors during SAS9 deployments.

## Implementation

Catch `JobExecutionError`s and save the log output to the usual log file path.
https://github.com/sasjs/adapter/pull/601 also fixes the adapter logic to return the correct error code so the 'missing SASjs runner' message is avoided.

A deploy that fails with stored process errors will now output this:
![image](https://user-images.githubusercontent.com/2980428/145729561-dfae5162-13d8-4a5e-9647-a5ddc7851af7.png)


## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
