### PR TITLE
chore: reducing dependabot limit to 3 and restricting to production

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
We get a lot of dependabot alerts due to our core components requiring frequent upgrades.  The volume of these in our PR queue distracts from the more meaningful ones (ie, those adding features).  We can safely reduce these (security ones will still come through).  When upgrading one package, upgrade them all, would be a general rule to address the 'un-raised' dependabots in advance.

## Issue

None

## Intent

Tidy up the PR queue

## Implementation

Updated dependabot frequency

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
