### PR TITLE
feat(job-command): add exec subcommand alias

### DIFF
--- a/src/commands/job/jobCommand.ts
+++ b/src/commands/job/jobCommand.ts
@@ -8,7 +8,8 @@ import { prefixAppLoc } from '../../utils/prefixAppLoc'
 import { executeJobViya, executeJobSasjs } from './internal/execute'
 
 enum JobSubCommand {
-  Execute = 'execute'
+  Execute = 'execute',
+  Exec = 'exec'
 }
 
 const syntax = 'job <subCommand> <jobPath> [options]'
@@ -74,10 +75,15 @@ const executeParseOptions = {
 }
 
 export class JobCommand extends TargetCommand {
+  private jobSubCommands: any[]
+
   constructor(args: string[]) {
+    const jobSubCommands: string[] = (<any>Object).values(JobSubCommand)
     const subCommand = args[3]
-    const parseOptions =
-      subCommand === JobSubCommand.Execute ? executeParseOptions : {}
+    const parseOptions = jobSubCommands.includes(subCommand)
+      ? executeParseOptions
+      : {}
+
     super(args, {
       parseOptions,
       usage,
@@ -85,6 +91,8 @@ export class JobCommand extends TargetCommand {
       examples,
       syntax
     })
+
+    this.jobSubCommands = jobSubCommands
   }
 
   public async execute() {
@@ -111,7 +119,7 @@ export class JobCommand extends TargetCommand {
 
         if (!authConfig) return ReturnCode.InternalError
 
-        return this.parsed.subCommand === JobSubCommand.Execute
+        return this.jobSubCommands.includes(this.parsed.subCommand)
           ? await this.executeJobViya(target, sasjs, authConfig)
           : ReturnCode.InvalidCommand
 
@@ -124,7 +132,7 @@ export class JobCommand extends TargetCommand {
         if (typeof this.parsed.jobPath !== 'string')
           return ReturnCode.InvalidCommand
 
-        return this.parsed.subCommand === JobSubCommand.Execute
+        return this.jobSubCommands.includes(this.parsed.subCommand)
           ? await this.executeJobSasjs(sasjs, target)
           : ReturnCode.InvalidCommand
       default:

--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -251,13 +251,21 @@ const executeCommandWrapper = async (
   additionalParams: string[],
   checkTarget = true
 ) => {
-  const args = [...defaultArgs, ...additionalParams]
+  let subCommand = 'execute'
+  const args = [...defaultArgs, ...additionalParams].map((arg: string) => {
+    if (arg === 'execute') {
+      arg = Math.random() > 0.5 ? 'exec' : arg
+      subCommand = arg
+    }
+
+    return arg
+  })
 
   const command = new JobCommand(args)
   const returnCode = await command.execute()
 
   expect(command.name).toEqual('job')
-  expect(command.subCommand).toEqual('execute')
+  expect(command.subCommand).toEqual(subCommand)
 
   if (checkTarget) {
     const targetInfo = await command.getTargetInfo()


### PR DESCRIPTION
## Issue

Closes #878 

## Intent

- Add `exec` subcommand alias to `sasjs job execute` command.

## Implementation

- Updated `jobCommand.ts`.
- Updated `jobCommand.spec.ts`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/147332261-062c5972-5b9e-4920-97e0-e87efc79b4f3.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/147334258-84bfd4ae-6b8b-41a3-8cf0-6198e4809eff.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/147336684-0fbaf706-116d-444f-b0a0-407f9ab37e2d.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
