### PR TITLE
fix: sasjs/adapter version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.3.0",
+        "@sasjs/adapter": "3.3.1",
         "@sasjs/core": "^3.8.0",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.34.1",
@@ -2311,9 +2311,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.3.0.tgz",
-      "integrity": "sha512-EDsKDIAH+bHTC5oX97S9OBki87td2aSYB4DsRoY6gjHNZLxXBmlJwG7x5vxrQWM893uPABEos6RGwkTSTLgo7A==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.3.1.tgz",
+      "integrity": "sha512-rmdOG+sjmwGipq1AHczwEXNUlzRFV5efj89neVVJWQMZR6JBC1O6Dr9HjEyJHPKcnQ6z3vzH9rRA2PGi5lgMhA==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "^2.32.0",
@@ -15665,9 +15665,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.3.0.tgz",
-      "integrity": "sha512-EDsKDIAH+bHTC5oX97S9OBki87td2aSYB4DsRoY6gjHNZLxXBmlJwG7x5vxrQWM893uPABEos6RGwkTSTLgo7A==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.3.1.tgz",
+      "integrity": "sha512-rmdOG+sjmwGipq1AHczwEXNUlzRFV5efj89neVVJWQMZR6JBC1O6Dr9HjEyJHPKcnQ6z3vzH9rRA2PGi5lgMhA==",
       "requires": {
         "@sasjs/utils": "^2.32.0",
         "axios": "^0.21.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.3.0",
+    "@sasjs/adapter": "3.3.1",
     "@sasjs/core": "^3.8.0",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.34.1",


### PR DESCRIPTION
## Issue

No issue to link.

## Intent

`sasjs/adapter` version bump `3.3.0` to `3.3.1`

## Implementation

There are no code changes.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
