### PR TITLE
fix: fixed executeShellScript utility and saveLog function

### DIFF
--- a/src/commands/request/spec/request.spec.server.ts
+++ b/src/commands/request/spec/request.spec.server.ts
@@ -54,6 +54,9 @@ const expectedDataObj = {
   ]
 }
 
+const getOutputJson = async () =>
+  JSON.parse(await readFile(path.join(process.projectDir, 'output.json')))
+
 describe('sasjs request without compute API', () => {
   const appName = 'cli-tests-request-' + generateTimestamp()
   const target: Target = generateTestTarget(
@@ -113,11 +116,9 @@ describe('sasjs request without compute API', () => {
         authConfig
       )
     ).toResolve()
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
 
-    expect(output.table1).toEqual(expectedDataArr.table1)
-    expect(output.table2).toEqual(expectedDataArr.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataArr.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataArr.table2)
   })
 
   it(`should execute service 'sendObj' with absolute path`, async () => {
@@ -131,11 +132,9 @@ describe('sasjs request without compute API', () => {
         authConfig
       )
     ).toResolve()
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
 
-    expect(output.table1).toEqual(expectedDataObj.table1)
-    expect(output.table2).toEqual(expectedDataObj.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataObj.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataObj.table2)
   })
 
   it(`should execute service 'sendArr' with relative path`, async () => {
@@ -150,11 +149,8 @@ describe('sasjs request without compute API', () => {
       )
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataArr.table1)
-    expect(output.table2).toEqual(expectedDataArr.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataArr.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataArr.table2)
   })
 
   it(`should execute service 'sendObj' with relative path`, async () => {
@@ -169,11 +165,8 @@ describe('sasjs request without compute API', () => {
       )
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataObj.table1)
-    expect(output.table2).toEqual(expectedDataObj.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataObj.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataObj.table2)
   })
 
   it(`should execute service 'sendArr' with absolute path with output path`, async () => {
@@ -190,7 +183,10 @@ describe('sasjs request without compute API', () => {
         './myoutput.json'
       )
     ).toResolve()
-    const rawData = await readFile(`${process.projectDir}/myoutput.json`)
+
+    const rawData = await readFile(
+      path.join(process.projectDir, 'myoutput.json')
+    )
     const output = JSON.parse(rawData)
 
     expect(output.table1).toEqual(expectedDataArr.table1)
@@ -198,14 +194,17 @@ describe('sasjs request without compute API', () => {
   })
 
   it(`should execute service 'err' with absolute path with log path`, async () => {
-    const jobPath = prefixAppLoc(target.appLoc, process.currentDir as string)
-    const log = getLogFilePath('./mylog.txt', jobPath || '')
+    const jobPath = prefixAppLoc(
+      target.appLoc,
+      'services/runRequest/err'
+    ) as string
+    const log = getLogFilePath('./mylog.txt', jobPath || '') as string
 
     await expect(
       runSasJob(
         target,
         false,
-        `/Public/app/cli-tests/${target.name}/services/runRequest/err`,
+        jobPath,
         dataPathRel,
         undefined,
         authConfig,
@@ -213,22 +212,27 @@ describe('sasjs request without compute API', () => {
         jobPath
       )
     ).toResolve()
-    const rawLogDataStats = statSync(`${process.projectDir}/mylog.txt`)
-    const rawDataStats = statSync(`${process.projectDir}/output.json`)
+
+    const rawLogDataStats = statSync(log)
+    const rawDataStats = statSync(path.join(process.projectDir, 'output.json'))
 
     expect(rawLogDataStats.size).toBeGreaterThan(10)
     expect(rawDataStats.size).toBeGreaterThan(10)
   })
 
   it(`should execute service 'err' with absolute path with default log path`, async () => {
-    const jobPath = prefixAppLoc(target.appLoc, process.currentDir as string)
-    const log = getLogFilePath('', jobPath || '')
+    const jobPath = prefixAppLoc(
+      target.appLoc,
+      'services/runRequest/err'
+    ) as string
+
+    const log = getLogFilePath('', jobPath || '') as string
 
     await expect(
       runSasJob(
         target,
         false,
-        `/Public/app/cli-tests/${target.name}/services/runRequest/err`,
+        jobPath,
         dataPathRel,
         undefined,
         authConfig,
@@ -236,8 +240,9 @@ describe('sasjs request without compute API', () => {
         jobPath
       )
     ).toResolve()
-    const rawLogDataStats = statSync(`${process.projectDir}/${target.name}.log`)
-    const rawDataStats = statSync(`${process.projectDir}/output.json`)
+
+    const rawLogDataStats = statSync(log)
+    const rawDataStats = statSync(path.join(process.projectDir, 'output.json'))
 
     expect(rawLogDataStats.size).toBeGreaterThan(10)
     expect(rawDataStats.size).toBeGreaterThan(10)
@@ -299,11 +304,9 @@ describe('sasjs request with SAS9', () => {
         dataPathRel
       )
     ).toResolve()
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
 
-    expect(output.table1).toEqual(expectedDataArr.table1)
-    expect(output.table2).toEqual(expectedDataArr.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataArr.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataArr.table2)
   })
 
   it(`should execute service 'sendObj' with absolute path`, async () => {
@@ -315,11 +318,9 @@ describe('sasjs request with SAS9', () => {
         dataPathRel
       )
     ).toResolve()
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
 
-    expect(output.table1).toEqual(expectedDataObj.table1)
-    expect(output.table2).toEqual(expectedDataObj.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataObj.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataObj.table2)
   })
 
   it(`should execute service 'sendArr' with relative path`, async () => {
@@ -327,11 +328,8 @@ describe('sasjs request with SAS9', () => {
       runSasJob(target, false, 'services/runRequest/sendArr', dataPathRel)
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataArr.table1)
-    expect(output.table2).toEqual(expectedDataArr.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataArr.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataArr.table2)
   })
 
   it(`should execute service 'sendObj' with relative path`, async () => {
@@ -339,11 +337,8 @@ describe('sasjs request with SAS9', () => {
       runSasJob(target, false, 'services/runRequest/sendObj', dataPathRel)
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataObj.table1)
-    expect(output.table2).toEqual(expectedDataObj.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataObj.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataObj.table2)
   })
 
   it(`should execute service 'sendArr' with absolute path with output path`, async () => {
@@ -360,7 +355,10 @@ describe('sasjs request with SAS9', () => {
         './myoutput.json'
       )
     ).toResolve()
-    const rawData = await readFile(`${process.projectDir}/myoutput.json`)
+
+    const rawData = await readFile(
+      path.join(process.projectDir, 'myoutput.json')
+    )
     const output = JSON.parse(rawData)
 
     expect(output.table1).toEqual(expectedDataArr.table1)
@@ -368,14 +366,17 @@ describe('sasjs request with SAS9', () => {
   })
 
   it(`should execute service 'err' with absolute path with log path`, async () => {
-    const jobPath = prefixAppLoc(target.appLoc, process.currentDir as string)
-    const log = getLogFilePath('./mylog.txt', jobPath || '')
+    const jobPath = prefixAppLoc(
+      target.appLoc,
+      'services/runRequest/err'
+    ) as string
+    const log = getLogFilePath('./mylog.txt', jobPath || '') as string
 
     await expect(
       runSasJob(
         target,
         false,
-        `/Public/app/cli-tests/${target.name}/services/runRequest/err`,
+        jobPath,
         dataPathRel,
         undefined,
         undefined,
@@ -383,22 +384,26 @@ describe('sasjs request with SAS9', () => {
         jobPath
       )
     ).toResolve()
-    const rawLogDataStats = statSync(`${process.projectDir}/mylog.txt`)
-    const rawDataStats = statSync(`${process.projectDir}/output.json`)
+
+    const rawLogDataStats = statSync(log)
+    const rawDataStats = statSync(path.join(process.projectDir, 'output.json'))
 
     expect(rawLogDataStats.size).toBeGreaterThan(10)
     expect(rawDataStats.size).toBeGreaterThan(10)
   })
 
   it(`should execute service 'err' with absolute path with default log path`, async () => {
-    const jobPath = prefixAppLoc(target.appLoc, process.currentDir as string)
-    const log = getLogFilePath('', jobPath || '')
+    const jobPath = prefixAppLoc(
+      target.appLoc,
+      'services/runRequest/err'
+    ) as string
+    const log = getLogFilePath('', jobPath || '') as string
 
     await expect(
       runSasJob(
         target,
         false,
-        `/Public/app/cli-tests/${target.name}/services/runRequest/err`,
+        jobPath,
         dataPathRel,
         undefined,
         undefined,
@@ -406,8 +411,8 @@ describe('sasjs request with SAS9', () => {
         jobPath
       )
     ).toResolve()
-    const rawLogDataStats = statSync(`${process.projectDir}/${target.name}.log`)
-    const rawDataStats = statSync(`${process.projectDir}/output.json`)
+    const rawLogDataStats = statSync(log)
+    const rawDataStats = statSync(path.join(process.projectDir, 'output.json'))
 
     expect(rawLogDataStats.size).toBeGreaterThan(10)
     expect(rawDataStats.size).toBeGreaterThan(10)
@@ -478,11 +483,8 @@ describe(`sasjs request with compute API`, () => {
       )
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataArr.table1)
-    expect(output.table2).toEqual(expectedDataArr.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataArr.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataArr.table2)
   })
 
   it(`should execute service 'sendObj' with absolute path`, async () => {
@@ -497,11 +499,8 @@ describe(`sasjs request with compute API`, () => {
       )
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataObj.table1)
-    expect(output.table2).toEqual(expectedDataObj.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataObj.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataObj.table2)
   })
 
   it(`should execute service 'sendArr' with relative path`, async () => {
@@ -516,11 +515,8 @@ describe(`sasjs request with compute API`, () => {
       )
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataArr.table1)
-    expect(output.table2).toEqual(expectedDataArr.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataArr.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataArr.table2)
   })
 
   it(`should execute service 'sendObj' with relative path`, async () => {
@@ -535,10 +531,7 @@ describe(`sasjs request with compute API`, () => {
       )
     ).toResolve()
 
-    const rawData = await readFile(`${process.projectDir}/output.json`)
-    const output = JSON.parse(rawData)
-
-    expect(output.table1).toEqual(expectedDataObj.table1)
-    expect(output.table2).toEqual(expectedDataObj.table2)
+    expect((await getOutputJson()).table1).toEqual(expectedDataObj.table1)
+    expect((await getOutputJson()).table2).toEqual(expectedDataObj.table2)
   })
 })

--- a/src/commands/testing/internal/saveOutput.ts
+++ b/src/commands/testing/internal/saveOutput.ts
@@ -29,7 +29,7 @@ export const saveLog = async (
   const logPath = path.join(
     outDirectory,
     'logs',
-    test.replace(sasFileRegExp, '').split(path.sep).slice(1).join('_') + '.log'
+    test.replace(sasFileRegExp, '').split('/').slice(1).join('_') + '.log'
   )
 
   await createFile(logPath, log)

--- a/src/utils/getLogFilePath.ts
+++ b/src/utils/getLogFilePath.ts
@@ -1,16 +1,17 @@
 import path from 'path'
 
 export const getLogFilePath = (logArg: unknown, jobPath: string) => {
-  if (logArg === undefined || !jobPath || jobPath === '') {
-    return undefined
-  }
+  if (logArg === undefined || !jobPath || jobPath === '') return undefined
 
   if (logArg) {
     const currentDirPath = path.isAbsolute(logArg as string)
       ? ''
       : process.projectDir
+
     return path.join(currentDirPath, logArg as string)
   }
-  const logFileName = `${jobPath.split('/').slice(-1).pop()}.log`
+
+  const logFileName = `${jobPath.split(path.sep).slice(-1).pop()}.log`
+
   return path.join(process.projectDir, logFileName)
 }

--- a/src/utils/getLogFilePath.ts
+++ b/src/utils/getLogFilePath.ts
@@ -11,7 +11,7 @@ export const getLogFilePath = (logArg: unknown, jobPath: string) => {
     return path.join(currentDirPath, logArg as string)
   }
 
-  const logFileName = `${jobPath.split(path.sep).slice(-1).pop()}.log`
+  const logFileName = `${jobPath.split('/').slice(-1).pop()}.log`
 
   return path.join(process.projectDir, logFileName)
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -270,8 +270,9 @@ export async function executeShellScript(
   logFilePath: string
 ) {
   return new Promise(async (resolve, reject) => {
-    const shellCommand = isWindows() ? `${filePath}` : `bash ${filePath}`
+    const shellCommand = isWindows() ? `sh ${filePath}` : `bash ${filePath}`
     const result = shelljs.exec(shellCommand, { silent: true })
+
     if (result.code) {
       process.logger?.error(`Error: ${result.stderr}`)
       reject(result.code)


### PR DESCRIPTION
## Intent

- Fix `executeShellScript` utility for Windows.
- Fix `saveLog` function for Windows.

## Implementation

- Add `sh` prefix `executeShellScript` utility for Windows.
- Replace `path.sep` with `/`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/151316426-67bed3d2-525a-4f80-a0a0-3f0a64571bc7.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/151183746-c5089646-7c31-4557-8de7-9883f4633866.png)
Server:
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
