### PR TITLE
feat(test-command): add @sasjs/server support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.4.1",
+        "@sasjs/adapter": "3.5.0",
         "@sasjs/core": "3.10.0",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.36.0",
@@ -2222,31 +2222,32 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.4.1.tgz",
-      "integrity": "sha512-FbsvYDaoJAuH8FMidXhX3Kh4Eb8qIcxy5iiCxHgcSRWM89W29W21WfCqCw0F28yFr+V5vZkvphwXMKFdOGGxlw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.5.0.tgz",
+      "integrity": "sha512-GSp2gnpWnLOUJn8Yigjk7sKB7DPlWD3BJloCasNHe57CECZLkFB5vWdUSAB6r1rdEjZJSQ77y5v0DOcuL6uGvw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@sasjs/utils": "2.32.0",
-        "axios": "0.25.0",
-        "axios-cookiejar-support": "1.0.1",
+        "@sasjs/utils": "2.35.0",
+        "axios": "0.26.0",
+        "axios-cookiejar-support": "2.0.3",
         "form-data": "4.0.0",
         "https": "1.0.0",
         "tough-cookie": "4.0.0"
       }
     },
     "node_modules/@sasjs/adapter/node_modules/@sasjs/utils": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.32.0.tgz",
-      "integrity": "sha512-xnvdEuI4PhTtulcdDEIMK7IxVj9bOMU1JTnxRuSEKWcsclY9P9Fw3cnMOOEgXCDffrOPn3f54DP7Wb1GXd+f8g==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.35.0.tgz",
+      "integrity": "sha512-q9ZKV+TXqwiaj+0z5U7/00eBpp2QpjKfC9BKx7A6rQjBl10WtoWd5C9Em+RQULWVEdRbVS2XcnNsWelbKq/Zsw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@types/fs-extra": "^9.0.11",
+        "@types/fs-extra": "^9.0.13",
         "@types/prompts": "^2.0.13",
         "chalk": "^4.1.1",
         "cli-table": "^0.3.6",
         "consola": "^2.15.0",
         "csv-stringify": "^5.6.5",
+        "find": "0.3.0",
         "fs-extra": "^10.0.0",
         "jwt-decode": "^3.1.2",
         "prompts": "^2.4.1",
@@ -2845,7 +2846,8 @@
     "node_modules/@types/tough-cookie": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
+      "dev": true
     },
     "node_modules/@types/url-parse": {
       "version": "1.4.4",
@@ -3271,28 +3273,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/axios-cookiejar-support": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-2.0.3.tgz",
+      "integrity": "sha512-tvMB+0JhxXLjjvePsXzqXhBI4DMlW4ImR4pKKNl+xclwF0IviNV+CkuhubQCCFjPzOXv7PIzOq3z7WFiF9pMpw==",
       "dependencies": {
-        "is-redirect": "^1.0.0",
-        "pify": "^5.0.0"
+        "http-cookie-agent": "^1.0.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=12.19.0 <13.0.0 || >=14.5.0"
       },
       "peerDependencies": {
-        "@types/tough-cookie": ">=2.3.3",
-        "axios": ">=0.16.2",
-        "tough-cookie": ">=2.3.3"
+        "axios": ">=0.20.0",
+        "tough-cookie": ">=4.0.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5136,9 +5136,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "funding": [
         {
           "type": "individual",
@@ -5689,6 +5689,20 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "node_modules/http-cookie-agent": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.4.tgz",
+      "integrity": "sha512-2gSYSE3m38/QMKPPbbS/6lEIm8OTbGA5sY3aBLtr/BUTNOFNeL4WqkdNQM6WmIBT7AWKC20aYfU3uq+cgR+Byg==",
+      "dependencies": {
+        "agent-base": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=12.19.0 <13.0.0 || >=14.5.0"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -6204,14 +6218,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-    },
-    "node_modules/is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -11605,17 +11611,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -15584,29 +15579,30 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.4.1.tgz",
-      "integrity": "sha512-FbsvYDaoJAuH8FMidXhX3Kh4Eb8qIcxy5iiCxHgcSRWM89W29W21WfCqCw0F28yFr+V5vZkvphwXMKFdOGGxlw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.5.0.tgz",
+      "integrity": "sha512-GSp2gnpWnLOUJn8Yigjk7sKB7DPlWD3BJloCasNHe57CECZLkFB5vWdUSAB6r1rdEjZJSQ77y5v0DOcuL6uGvw==",
       "requires": {
-        "@sasjs/utils": "2.32.0",
-        "axios": "0.25.0",
-        "axios-cookiejar-support": "1.0.1",
+        "@sasjs/utils": "2.35.0",
+        "axios": "0.26.0",
+        "axios-cookiejar-support": "2.0.3",
         "form-data": "4.0.0",
         "https": "1.0.0",
         "tough-cookie": "4.0.0"
       },
       "dependencies": {
         "@sasjs/utils": {
-          "version": "2.32.0",
-          "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.32.0.tgz",
-          "integrity": "sha512-xnvdEuI4PhTtulcdDEIMK7IxVj9bOMU1JTnxRuSEKWcsclY9P9Fw3cnMOOEgXCDffrOPn3f54DP7Wb1GXd+f8g==",
+          "version": "2.35.0",
+          "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.35.0.tgz",
+          "integrity": "sha512-q9ZKV+TXqwiaj+0z5U7/00eBpp2QpjKfC9BKx7A6rQjBl10WtoWd5C9Em+RQULWVEdRbVS2XcnNsWelbKq/Zsw==",
           "requires": {
-            "@types/fs-extra": "^9.0.11",
+            "@types/fs-extra": "^9.0.13",
             "@types/prompts": "^2.0.13",
             "chalk": "^4.1.1",
             "cli-table": "^0.3.6",
             "consola": "^2.15.0",
             "csv-stringify": "^5.6.5",
+            "find": "0.3.0",
             "fs-extra": "^10.0.0",
             "jwt-decode": "^3.1.2",
             "prompts": "^2.4.1",
@@ -16144,7 +16140,8 @@
     "@types/tough-cookie": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
+      "dev": true
     },
     "@types/url-parse": {
       "version": "1.4.4",
@@ -16513,20 +16510,19 @@
       "dev": true
     },
     "axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "requires": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.8"
       }
     },
     "axios-cookiejar-support": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-2.0.3.tgz",
+      "integrity": "sha512-tvMB+0JhxXLjjvePsXzqXhBI4DMlW4ImR4pKKNl+xclwF0IviNV+CkuhubQCCFjPzOXv7PIzOq3z7WFiF9pMpw==",
       "requires": {
-        "is-redirect": "^1.0.0",
-        "pify": "^5.0.0"
+        "http-cookie-agent": "^1.0.2"
       }
     },
     "babel-jest": {
@@ -17916,9 +17912,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "foreach": {
       "version": "2.0.5",
@@ -18320,6 +18316,14 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "http-cookie-agent": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.4.tgz",
+      "integrity": "sha512-2gSYSE3m38/QMKPPbbS/6lEIm8OTbGA5sY3aBLtr/BUTNOFNeL4WqkdNQM6WmIBT7AWKC20aYfU3uq+cgR+Byg==",
+      "requires": {
+        "agent-base": "^6.0.2"
+      }
+    },
     "http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -18669,11 +18673,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -22653,11 +22652,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
-    },
-    "pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
     },
     "pirates": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.4.1",
+    "@sasjs/adapter": "3.5.0",
     "@sasjs/core": "3.10.0",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.36.0",

--- a/src/commands/testing/spec/testing.spec.server.ts
+++ b/src/commands/testing/spec/testing.spec.server.ts
@@ -21,241 +21,10 @@ import {
 import { contextName } from '../../../utils'
 import dotenv from 'dotenv'
 import { build, deploy } from '../..'
+import SASjs from '@sasjs/adapter/node'
 
 describe('sasjs test', () => {
-  const target: Target = generateTarget()
-  const testUrl = (test: string) =>
-    `${target.serverUrl}/${
-      target.serverType === ServerType.SasViya
-        ? 'SASJobExecution'
-        : 'SASStoredProcess'
-    }/?_program=/Public/app/cli-tests/${
-      target.name
-    }/tests/${test}&_debug=2477&_contextName=${encodeURIComponent(
-      target.contextName
-    )}`
-  const testUrlLink = (test: string) => `"=HYPERLINK(""${testUrl(test)}"")"`
-
-  beforeAll(async () => {
-    await createTestApp(__dirname, target.name)
-    await copyTestFiles(target.name)
-    await build(target)
-    await deploy(target, false)
-
-    process.logger = new Logger(LogLevel.Off)
-  })
-
-  afterAll(async () => {
-    await removeTestServerFolder(`/Public/app/cli-tests/${target.name}`, target)
-    await removeTestApp(__dirname, target.name)
-  })
-
-  it('should execute tests and create result CSV, XML and JSON files using default source and output locations', async () => {
-    const expectedResultsJson = {
-      sasjs_test_meta: [
-        {
-          test_target: 'testsetup',
-          results: [
-            {
-              test_loc: 'tests/testsetup.sas',
-              sasjs_test_id: '',
-              result: 'not provided',
-              test_url: testUrl('testsetup')
-            }
-          ]
-        },
-        {
-          test_target: 'exampleprogram',
-          results: [
-            {
-              test_loc: 'tests/jobs/jobs/exampleprogram.test.sas',
-              sasjs_test_id: '',
-              result: 'not provided',
-              test_url: testUrl('jobs/jobs/exampleprogram.test')
-            }
-          ]
-        },
-        {
-          test_target: 'standalone',
-          results: [
-            {
-              test_loc: 'tests/jobs/jobs/standalone.test.sas',
-              sasjs_test_id: '',
-              result: 'not provided',
-              test_url: testUrl('jobs/jobs/standalone.test')
-            }
-          ]
-        },
-        {
-          test_target: 'examplemacro',
-          results: [
-            {
-              test_loc: 'tests/macros/examplemacro.test.sas',
-              sasjs_test_id: '',
-              result: [
-                {
-                  TEST_DESCRIPTION: 'examplemacro test.1 description',
-                  TEST_RESULT: 'PASS'
-                }
-              ],
-              test_url: testUrl('macros/examplemacro.test')
-            }
-          ]
-        },
-        {
-          test_target: 'dostuff',
-          results: [
-            {
-              test_loc: 'tests/services/admin/dostuff.test.0.sas',
-              sasjs_test_id: '',
-              result: [
-                {
-                  TEST_DESCRIPTION: 'dostuff 0 test description',
-                  TEST_RESULT: 'FAIL'
-                }
-              ],
-              test_url: testUrl('services/admin/dostuff.test.0')
-            },
-            {
-              test_loc: 'tests/services/admin/dostuff.test.1.sas',
-              sasjs_test_id: '',
-              result: [
-                {
-                  TEST_DESCRIPTION: 'dostuff 1 test description',
-                  TEST_RESULT: 'PASS'
-                }
-              ],
-              test_url: testUrl('services/admin/dostuff.test.1')
-            }
-          ]
-        },
-        {
-          test_target: 'testteardown',
-          results: [
-            {
-              test_loc: 'tests/testteardown.sas',
-              sasjs_test_id: '',
-              result: 'not provided',
-              test_url: testUrl('testteardown')
-            }
-          ]
-        }
-      ]
-    }
-    const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
-testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,${testUrlLink(
-      'testsetup'
-    )}
-exampleprogram,tests/jobs/jobs/exampleprogram.test.sas,sasjs_test_id,not provided,,${testUrlLink(
-      'jobs/jobs/exampleprogram.test'
-    )}
-standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,not provided,,${testUrlLink(
-      'jobs/jobs/standalone.test'
-    )}
-examplemacro,tests/macros/examplemacro.test.sas,sasjs_test_id,PASS,examplemacro test.1 description,${testUrlLink(
-      'macros/examplemacro.test'
-    )}
-dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,FAIL,dostuff 0 test description,${testUrlLink(
-      'services/admin/dostuff.test.0'
-    )}
-dostuff,tests/services/admin/dostuff.test.1.sas,sasjs_test_id,PASS,dostuff 1 test description,${testUrlLink(
-      'services/admin/dostuff.test.1'
-    )}
-testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
-      'testteardown'
-    )}
-`
-
-    await runTest(target)
-
-    const resultsFolderPath = path.join(__dirname, target.name, 'sasjsresults')
-    const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
-
-    await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
-    await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
-
-    const resultsJson = await readFile(resultsJsonPath)
-
-    const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
-
-    await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
-
-    let parsedResults = JSON.parse(resultsJson)
-
-    parsedResults.sasjs_test_meta = parsedResults.sasjs_test_meta.flatMap(
-      (res: TestDescription) => ({
-        ...res,
-        results: res.results.map((r: TestResult) => ({
-          ...r,
-          sasjs_test_id: ''
-        }))
-      })
-    )
-
-    expect(parsedResults).toEqual(expectedResultsJson)
-
-    let resultsCsv = await readFile(resultsCsvPath)
-    resultsCsv = resultsCsv.replace(
-      /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/g,
-      'sasjs_test_id'
-    )
-
-    expect(resultsCsv).toEqual(expectedResultsCsv)
-
-    const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
-
-    await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
-
-    let resultsXml = await readFile(resultsXmlPath)
-
-    const expectedResultsXml = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<testsuites id="" name=\"SASjs Test Meta\" tests=\"7\" failures=\"5\">
-  <testsuite id=\"testsetup\" name=\"testsetup\" tests=\"1\" failures=\"1\">
-    <testcase id="">
-      <failure>Status was not provided</failure>
-    </testcase>
-  </testsuite>
-  <testsuite id=\"exampleprogram\" name=\"exampleprogram\" tests=\"1\" failures=\"1\">
-    <testcase id="">
-      <failure>Status was not provided</failure>
-    </testcase>
-  </testsuite>
-  <testsuite id=\"standalone\" name=\"standalone\" tests=\"1\" failures=\"1\">
-    <testcase id="">
-      <failure>Status was not provided</failure>
-    </testcase>
-  </testsuite>
-  <testsuite id=\"examplemacro\" name=\"examplemacro\" tests=\"1\" failures=\"0\">
-    <testcase id=\"\">
-    </testcase>
-  </testsuite>
-  <testsuite id=\"dostuff\" name=\"dostuff\" tests=\"2\" failures=\"1\">
-    <testcase id="">
-      <failure>Description: dostuff 0 test description</failure>
-    </testcase>
-    <testcase id="">
-    </testcase>
-  </testsuite>
-  <testsuite id=\"testteardown\" name=\"testteardown\" tests=\"1\" failures=\"1\">
-    <testcase id="">
-      <failure>Status was not provided</failure>
-    </testcase>
-  </testsuite>
-</testsuites>`
-
-    resultsXml = resultsXml.replace(
-      /testsuites id="[^ ]*"/gm,
-      `testsuites id=""`
-    )
-    resultsXml = resultsXml.replace(/testcase id="[^ ]*"/gm, `testcase id=""`)
-
-    expect(resultsXml).toEqual(expectedResultsXml)
-
-    const coverageLcovPath = path.join(resultsFolderPath, 'coverage.lcov')
-
-    await expect(fileExists(coverageLcovPath)).resolves.toEqual(true)
-
-    const expectedCoverageLcov = `TN:testsetup.sas
+  const expectedCoverageLcov = `TN:testsetup.sas
 SF:standalone
 FNF:1
 FNH:1
@@ -328,152 +97,392 @@ BRF:1
 BRH:1
 end_of_record`
 
-    const coverageLcov = await readFile(coverageLcovPath)
+  describe('SASVIYA', () => {
+    const target: Target = generateTarget()
+    const testUrl = (test: string) =>
+      `${target.serverUrl}/${
+        target.serverType === ServerType.SasViya
+          ? 'SASJobExecution'
+          : 'SASStoredProcess'
+      }/?_program=/Public/app/cli-tests/${
+        target.name
+      }/tests/${test}&_debug=2477&_contextName=${encodeURIComponent(
+        target.contextName
+      )}`
+    const testUrlLink = (test: string) => `"=HYPERLINK(""${testUrl(test)}"")"`
 
-    expect(coverageLcov).toEqual(expectedCoverageLcov)
-  })
+    beforeAll(async () => {
+      await createTestApp(__dirname, target.name)
+      await copyTestFiles(target.name)
+      await build(target)
+      await deploy(target, false)
 
-  it('should execute filtered tests and create result CSV, XML and JSON files using custom source and output locations', async () => {
-    const expectedResultsJson = {
-      sasjs_test_meta: [
-        {
-          test_target: 'testsetup',
-          results: [
-            {
-              test_loc: 'tests/testsetup.sas',
-              sasjs_test_id: '',
-              result: 'not provided',
-              test_url: testUrl('testsetup')
-            }
-          ]
-        },
-        {
-          test_target: 'standalone',
-          results: [
-            {
-              test_loc: 'tests/jobs/jobs/standalone.test.sas',
-              sasjs_test_id: '',
-              result: 'not provided',
-              test_url: testUrl('jobs/jobs/standalone.test')
-            }
-          ]
-        },
-        {
-          test_target: 'dostuff',
-          results: [
-            {
-              test_loc: 'tests/services/admin/dostuff.test.0.sas',
-              sasjs_test_id: '',
-              result: [
-                {
-                  TEST_DESCRIPTION: 'dostuff 0 test description',
-                  TEST_RESULT: 'FAIL'
-                }
-              ],
-              test_url: testUrl('services/admin/dostuff.test.0')
-            }
-          ]
-        },
-        {
-          test_target: 'testteardown',
-          results: [
-            {
-              test_loc: 'tests/testteardown.sas',
-              sasjs_test_id: '',
-              result: 'not provided',
-              test_url: testUrl('testteardown')
-            }
-          ]
-        }
-      ]
-    }
-    const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
+      process.logger = new Logger(LogLevel.Off)
+    })
+
+    afterAll(async () => {
+      await removeTestServerFolder(
+        `/Public/app/cli-tests/${target.name}`,
+        target
+      )
+      await removeTestApp(__dirname, target.name)
+    })
+
+    it('should execute tests and create result CSV, XML and JSON files using default source and output locations', async () => {
+      const expectedResultsJson = {
+        sasjs_test_meta: [
+          {
+            test_target: 'testsetup',
+            results: [
+              {
+                test_loc: 'tests/testsetup.sas',
+                sasjs_test_id: '',
+                result: 'not provided',
+                test_url: testUrl('testsetup')
+              }
+            ]
+          },
+          {
+            test_target: 'exampleprogram',
+            results: [
+              {
+                test_loc: 'tests/jobs/jobs/exampleprogram.test.sas',
+                sasjs_test_id: '',
+                result: 'not provided',
+                test_url: testUrl('jobs/jobs/exampleprogram.test')
+              }
+            ]
+          },
+          {
+            test_target: 'standalone',
+            results: [
+              {
+                test_loc: 'tests/jobs/jobs/standalone.test.sas',
+                sasjs_test_id: '',
+                result: 'not provided',
+                test_url: testUrl('jobs/jobs/standalone.test')
+              }
+            ]
+          },
+          {
+            test_target: 'examplemacro',
+            results: [
+              {
+                test_loc: 'tests/macros/examplemacro.test.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'examplemacro test.1 description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('macros/examplemacro.test')
+              }
+            ]
+          },
+          {
+            test_target: 'dostuff',
+            results: [
+              {
+                test_loc: 'tests/services/admin/dostuff.test.0.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'dostuff 0 test description',
+                    TEST_RESULT: 'FAIL'
+                  }
+                ],
+                test_url: testUrl('services/admin/dostuff.test.0')
+              },
+              {
+                test_loc: 'tests/services/admin/dostuff.test.1.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'dostuff 1 test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('services/admin/dostuff.test.1')
+              }
+            ]
+          },
+          {
+            test_target: 'testteardown',
+            results: [
+              {
+                test_loc: 'tests/testteardown.sas',
+                sasjs_test_id: '',
+                result: 'not provided',
+                test_url: testUrl('testteardown')
+              }
+            ]
+          }
+        ]
+      }
+      const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
 testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,${testUrlLink(
-      'testsetup'
-    )}
+        'testsetup'
+      )}
+exampleprogram,tests/jobs/jobs/exampleprogram.test.sas,sasjs_test_id,not provided,,${testUrlLink(
+        'jobs/jobs/exampleprogram.test'
+      )}
 standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,not provided,,${testUrlLink(
-      'jobs/jobs/standalone.test'
-    )}
+        'jobs/jobs/standalone.test'
+      )}
+examplemacro,tests/macros/examplemacro.test.sas,sasjs_test_id,PASS,examplemacro test.1 description,${testUrlLink(
+        'macros/examplemacro.test'
+      )}
 dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,FAIL,dostuff 0 test description,${testUrlLink(
-      'services/admin/dostuff.test.0'
-    )}
+        'services/admin/dostuff.test.0'
+      )}
+dostuff,tests/services/admin/dostuff.test.1.sas,sasjs_test_id,PASS,dostuff 1 test description,${testUrlLink(
+        'services/admin/dostuff.test.1'
+      )}
 testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
-      'testteardown'
-    )}
+        'testteardown'
+      )}
 `
 
-    const outputFolder = 'customOutPut'
-    const movedTestFlow = 'movedTestFlow.json'
+      await runTest(target)
 
-    await copy(
-      path.join(__dirname, target.name, 'sasjsbuild', 'testFlow.json'),
-      path.join(__dirname, target.name, movedTestFlow)
-    )
+      const resultsFolderPath = path.join(
+        __dirname,
+        target.name,
+        'sasjsresults'
+      )
+      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
 
-    await runTest(
-      target,
-      ['jobs/standalone', 'shouldFail', 'services/admin/dostuff.test.0'],
-      outputFolder,
-      movedTestFlow
-    )
+      await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
+      await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
 
-    const resultsFolderPath = path.join(__dirname, target.name, outputFolder)
-    const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
+      const resultsJson = await readFile(resultsJsonPath)
 
-    await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
-    await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
+      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
 
-    const resultsJson = await readFile(resultsJsonPath)
+      await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
 
-    const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
+      let parsedResults = JSON.parse(resultsJson)
 
-    await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
+      parsedResults.sasjs_test_meta = parsedResults.sasjs_test_meta.flatMap(
+        (res: TestDescription) => ({
+          ...res,
+          results: res.results.map((r: TestResult) => ({
+            ...r,
+            sasjs_test_id: ''
+          }))
+        })
+      )
 
-    let parsedResults = JSON.parse(resultsJson)
+      expect(parsedResults).toEqual(expectedResultsJson)
 
-    parsedResults.sasjs_test_meta = parsedResults.sasjs_test_meta.flatMap(
-      (res: TestDescription) => ({
-        ...res,
-        results: res.results.map((r: TestResult) => ({
-          ...r,
-          sasjs_test_id: ''
-        }))
-      })
-    )
+      let resultsCsv = await readFile(resultsCsvPath)
+      resultsCsv = resultsCsv.replace(
+        /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/g,
+        'sasjs_test_id'
+      )
 
-    expect(parsedResults).toEqual(expectedResultsJson)
+      expect(resultsCsv).toEqual(expectedResultsCsv)
 
-    let resultsCsv = await readFile(resultsCsvPath)
-    resultsCsv = resultsCsv.replace(
-      /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/g,
-      'sasjs_test_id'
-    )
+      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
 
-    expect(resultsCsv).toEqual(expectedResultsCsv)
+      await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
 
-    const logFolder = path.join(resultsFolderPath, 'logs')
+      let resultsXml = await readFile(resultsXmlPath)
 
-    const logPath = path.join(logFolder, 'macros_shouldFail.test.log')
+      const expectedResultsXml = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites id="" name=\"SASjs Test Meta\" tests=\"7\" failures=\"5\">
+  <testsuite id=\"testsetup\" name=\"testsetup\" tests=\"1\" failures=\"1\">
+    <testcase id="">
+      <failure>Status was not provided</failure>
+    </testcase>
+  </testsuite>
+  <testsuite id=\"exampleprogram\" name=\"exampleprogram\" tests=\"1\" failures=\"1\">
+    <testcase id="">
+      <failure>Status was not provided</failure>
+    </testcase>
+  </testsuite>
+  <testsuite id=\"standalone\" name=\"standalone\" tests=\"1\" failures=\"1\">
+    <testcase id="">
+      <failure>Status was not provided</failure>
+    </testcase>
+  </testsuite>
+  <testsuite id=\"examplemacro\" name=\"examplemacro\" tests=\"1\" failures=\"0\">
+    <testcase id=\"\">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"dostuff\" name=\"dostuff\" tests=\"2\" failures=\"1\">
+    <testcase id="">
+      <failure>Description: dostuff 0 test description</failure>
+    </testcase>
+    <testcase id="">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"testteardown\" name=\"testteardown\" tests=\"1\" failures=\"1\">
+    <testcase id="">
+      <failure>Status was not provided</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`
 
-    await expect(listFilesInFolder(logFolder)).resolves.toEqual([
-      'jobs_jobs_standalone.test.log',
-      'macros_shouldFail.test.log',
-      'services_admin_dostuff.test.0.log',
-      'testsetup.log',
-      'testteardown.log'
-    ])
+      resultsXml = resultsXml.replace(
+        /testsuites id="[^ ]*"/gm,
+        `testsuites id=""`
+      )
+      resultsXml = resultsXml.replace(/testcase id="[^ ]*"/gm, `testcase id=""`)
 
-    const log = await readFile(logPath)
+      expect(resultsXml).toEqual(expectedResultsXml)
 
-    expect(log.length).toBeGreaterThan(0)
+      const coverageLcovPath = path.join(resultsFolderPath, 'coverage.lcov')
 
-    const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
+      await expect(fileExists(coverageLcovPath)).resolves.toEqual(true)
 
-    await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
+      const coverageLcov = await readFile(coverageLcovPath)
 
-    let resultsXml = await readFile(resultsXmlPath)
+      expect(coverageLcov).toEqual(expectedCoverageLcov)
+    })
 
-    const expectedResultsXml = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    it('should execute filtered tests and create result CSV, XML and JSON files using custom source and output locations', async () => {
+      const expectedResultsJson = {
+        sasjs_test_meta: [
+          {
+            test_target: 'testsetup',
+            results: [
+              {
+                test_loc: 'tests/testsetup.sas',
+                sasjs_test_id: '',
+                result: 'not provided',
+                test_url: testUrl('testsetup')
+              }
+            ]
+          },
+          {
+            test_target: 'standalone',
+            results: [
+              {
+                test_loc: 'tests/jobs/jobs/standalone.test.sas',
+                sasjs_test_id: '',
+                result: 'not provided',
+                test_url: testUrl('jobs/jobs/standalone.test')
+              }
+            ]
+          },
+          {
+            test_target: 'dostuff',
+            results: [
+              {
+                test_loc: 'tests/services/admin/dostuff.test.0.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'dostuff 0 test description',
+                    TEST_RESULT: 'FAIL'
+                  }
+                ],
+                test_url: testUrl('services/admin/dostuff.test.0')
+              }
+            ]
+          },
+          {
+            test_target: 'testteardown',
+            results: [
+              {
+                test_loc: 'tests/testteardown.sas',
+                sasjs_test_id: '',
+                result: 'not provided',
+                test_url: testUrl('testteardown')
+              }
+            ]
+          }
+        ]
+      }
+      const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
+testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,${testUrlLink(
+        'testsetup'
+      )}
+standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,not provided,,${testUrlLink(
+        'jobs/jobs/standalone.test'
+      )}
+dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,FAIL,dostuff 0 test description,${testUrlLink(
+        'services/admin/dostuff.test.0'
+      )}
+testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
+        'testteardown'
+      )}
+`
+
+      const outputFolder = 'customOutPut'
+      const movedTestFlow = 'movedTestFlow.json'
+
+      await copy(
+        path.join(__dirname, target.name, 'sasjsbuild', 'testFlow.json'),
+        path.join(__dirname, target.name, movedTestFlow)
+      )
+
+      await runTest(
+        target,
+        ['jobs/standalone', 'shouldFail', 'services/admin/dostuff.test.0'],
+        outputFolder,
+        movedTestFlow
+      )
+
+      const resultsFolderPath = path.join(__dirname, target.name, outputFolder)
+      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
+
+      await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
+      await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
+
+      const resultsJson = await readFile(resultsJsonPath)
+
+      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
+
+      await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
+
+      let parsedResults = JSON.parse(resultsJson)
+
+      parsedResults.sasjs_test_meta = parsedResults.sasjs_test_meta.flatMap(
+        (res: TestDescription) => ({
+          ...res,
+          results: res.results.map((r: TestResult) => ({
+            ...r,
+            sasjs_test_id: ''
+          }))
+        })
+      )
+
+      expect(parsedResults).toEqual(expectedResultsJson)
+
+      let resultsCsv = await readFile(resultsCsvPath)
+      resultsCsv = resultsCsv.replace(
+        /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/g,
+        'sasjs_test_id'
+      )
+
+      expect(resultsCsv).toEqual(expectedResultsCsv)
+
+      const logFolder = path.join(resultsFolderPath, 'logs')
+
+      const logPath = path.join(logFolder, 'macros_shouldFail.test.log')
+
+      await expect(listFilesInFolder(logFolder)).resolves.toEqual([
+        'jobs_jobs_standalone.test.log',
+        'macros_shouldFail.test.log',
+        'services_admin_dostuff.test.0.log',
+        'testsetup.log',
+        'testteardown.log'
+      ])
+
+      const log = await readFile(logPath)
+
+      expect(log.length).toBeGreaterThan(0)
+
+      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
+
+      await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
+
+      let resultsXml = await readFile(resultsXmlPath)
+
+      const expectedResultsXml = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <testsuites id=\"\" name=\"SASjs Test Meta\" tests=\"4\" failures=\"4\">
   <testsuite id=\"testsetup\" name=\"testsetup\" tests=\"1\" failures=\"1\">
     <testcase id=\"\">
@@ -497,13 +506,313 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
   </testsuite>
 </testsuites>`
 
-    resultsXml = resultsXml.replace(
-      /testsuites id="[^ ]*"/gm,
-      `testsuites id=""`
-    )
-    resultsXml = resultsXml.replace(/testcase id="[^ ]*"/gm, `testcase id=""`)
+      resultsXml = resultsXml.replace(
+        /testsuites id="[^ ]*"/gm,
+        `testsuites id=""`
+      )
+      resultsXml = resultsXml.replace(/testcase id="[^ ]*"/gm, `testcase id=""`)
 
-    expect(resultsXml).toEqual(expectedResultsXml)
+      expect(resultsXml).toEqual(expectedResultsXml)
+    })
+  })
+
+  describe('SASJS', () => {
+    const sasjs = new (<jest.Mock<SASjs>>SASjs)()
+    const target: Target = generateTarget(ServerType.Sasjs)
+    const testUrl = (test: string) =>
+      `${target.serverUrl}/${
+        target.serverType === ServerType.SasViya
+          ? 'SASJobExecution'
+          : 'SASStoredProcess'
+      }/?_program=/Public/app/cli-tests/${
+        target.name
+      }/tests/${test}&_debug=2477&_contextName=${encodeURIComponent(
+        target.contextName
+      )}`
+    const testUrlLink = (test: string) => `"=HYPERLINK(""${testUrl(test)}"")"`
+
+    beforeAll(async () => {
+      await createTestApp(__dirname, target.name)
+      await copyTestFiles(target.name)
+      await build(target)
+
+      process.logger = new Logger(LogLevel.Off)
+    })
+
+    afterAll(async () => {
+      await removeTestApp(__dirname, target.name)
+    })
+
+    it('should execute tests and create result CSV, XML and JSON files using default source and output locations', async () => {
+      const expectedResultsJson = {
+        sasjs_test_meta: [
+          {
+            test_target: 'testsetup',
+            results: [
+              {
+                test_loc: 'tests/testsetup.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('testsetup')
+              }
+            ]
+          },
+          {
+            test_target: 'exampleprogram',
+            results: [
+              {
+                test_loc: 'tests/jobs/jobs/exampleprogram.test.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('jobs/jobs/exampleprogram.test')
+              }
+            ]
+          },
+          {
+            test_target: 'standalone',
+            results: [
+              {
+                test_loc: 'tests/jobs/jobs/standalone.test.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('jobs/jobs/standalone.test')
+              }
+            ]
+          },
+          {
+            test_target: 'examplemacro',
+            results: [
+              {
+                test_loc: 'tests/macros/examplemacro.test.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('macros/examplemacro.test')
+              }
+            ]
+          },
+          {
+            test_target: 'shouldFail',
+            results: [
+              {
+                test_loc: 'tests/macros/shouldFail.test.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('macros/shouldFail.test')
+              }
+            ]
+          },
+          {
+            test_target: 'dostuff',
+            results: [
+              {
+                test_loc: 'tests/services/admin/dostuff.test.0.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('services/admin/dostuff.test.0')
+              },
+              {
+                test_loc: 'tests/services/admin/dostuff.test.1.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('services/admin/dostuff.test.1')
+              }
+            ]
+          },
+          {
+            test_target: 'testteardown',
+            results: [
+              {
+                test_loc: 'tests/testteardown.sas',
+                sasjs_test_id: '',
+                result: [
+                  {
+                    TEST_DESCRIPTION: 'random test description',
+                    TEST_RESULT: 'PASS'
+                  }
+                ],
+                test_url: testUrl('testteardown')
+              }
+            ]
+          }
+        ]
+      }
+      const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
+testsetup,tests/testsetup.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'testsetup'
+      )}
+exampleprogram,tests/jobs/jobs/exampleprogram.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'jobs/jobs/exampleprogram.test'
+      )}
+standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'jobs/jobs/standalone.test'
+      )}
+examplemacro,tests/macros/examplemacro.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'macros/examplemacro.test'
+      )}
+shouldFail,tests/macros/shouldFail.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'macros/shouldFail.test'
+      )}
+dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'services/admin/dostuff.test.0'
+      )}
+dostuff,tests/services/admin/dostuff.test.1.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'services/admin/dostuff.test.1'
+      )}
+testteardown,tests/testteardown.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+        'testteardown'
+      )}
+`
+
+      jest.spyOn(sasjs, 'executeJobSASjs').mockImplementation(() =>
+        Promise.resolve({
+          status: 'success',
+          _webout:
+            '{"test_results":\r\n' +
+            '[\r\n' +
+            '{"TEST_DESCRIPTION":"random test description" ,"TEST_RESULT":"PASS" }\r\n' +
+            ']}',
+          log:
+            '1                                          The SAS System             11:42 Friday, February 11, 2022\r\n' +
+            '\r\n' +
+            'NOTE: Copyright (c) 2016 by SAS Institute Inc., Cary, NC, USA. \r\n' +
+            'NOTE: SAS (r) Proprietary Software 9.4 (TS1M6) \r\n' +
+            '      Licensed to ANALYTIUM LTD- PARTNER LICENCE DATA MANAGER CLIENT, Site 70221619.\r\n' +
+            'NOTE: This session is executing on the X64_10PRO  platform.\r\n',
+          message: 'success'
+        })
+      )
+
+      await runTest(target, undefined, undefined, undefined, sasjs)
+
+      const resultsFolderPath = path.join(
+        __dirname,
+        target.name,
+        'sasjsresults'
+      )
+      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
+
+      await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
+      await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
+
+      const resultsJson = await readFile(resultsJsonPath)
+
+      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
+
+      await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
+
+      let parsedResults = JSON.parse(resultsJson)
+
+      parsedResults.sasjs_test_meta = parsedResults.sasjs_test_meta.flatMap(
+        (res: TestDescription) => ({
+          ...res,
+          results: res.results.map((r: TestResult) => ({
+            ...r,
+            sasjs_test_id: ''
+          }))
+        })
+      )
+
+      expect(parsedResults).toEqual(expectedResultsJson)
+
+      let resultsCsv = await readFile(resultsCsvPath)
+      resultsCsv = resultsCsv.replace(
+        /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/g,
+        'sasjs_test_id'
+      )
+
+      expect(resultsCsv).toEqual(expectedResultsCsv)
+
+      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
+
+      await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
+
+      let resultsXml = await readFile(resultsXmlPath)
+
+      const expectedResultsXml = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites id="" name=\"SASjs Test Meta\" tests=\"8\" failures=\"0\">
+  <testsuite id=\"testsetup\" name=\"testsetup\" tests=\"1\" failures=\"0\">
+    <testcase id="">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"exampleprogram\" name=\"exampleprogram\" tests=\"1\" failures=\"0\">
+    <testcase id="">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"standalone\" name=\"standalone\" tests=\"1\" failures=\"0\">
+    <testcase id="">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"examplemacro\" name=\"examplemacro\" tests=\"1\" failures=\"0\">
+    <testcase id=\"\">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"shouldFail\" name=\"shouldFail\" tests=\"1\" failures=\"0\">
+    <testcase id=\"\">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"dostuff\" name=\"dostuff\" tests=\"2\" failures=\"0\">
+    <testcase id="">
+    </testcase>
+    <testcase id="">
+    </testcase>
+  </testsuite>
+  <testsuite id=\"testteardown\" name=\"testteardown\" tests=\"1\" failures=\"0\">
+    <testcase id="">
+    </testcase>
+  </testsuite>
+</testsuites>`
+
+      resultsXml = resultsXml.replace(
+        /testsuites id="[^ ]*"/gm,
+        `testsuites id=""`
+      )
+      resultsXml = resultsXml.replace(/testcase id="[^ ]*"/gm, `testcase id=""`)
+
+      expect(resultsXml).toEqual(expectedResultsXml)
+
+      const coverageLcovPath = path.join(resultsFolderPath, 'coverage.lcov')
+
+      await expect(fileExists(coverageLcovPath)).resolves.toEqual(true)
+
+      const coverageLcov = await readFile(coverageLcovPath)
+
+      expect(coverageLcov).toEqual(expectedCoverageLcov)
+    })
   })
 })
 
@@ -512,12 +821,15 @@ function generateTarget(serverType = ServerType.SasViya): Target {
 
   const timestamp = generateTimestamp()
   const targetName = `cli-tests-test-command-${timestamp}`
+
   return new Target({
     name: targetName,
     serverType,
     serverUrl: (serverType === ServerType.SasViya
       ? process.env.VIYA_SERVER_URL
-      : process.env.SAS9_SERVER_URL) as string,
+      : serverType === ServerType.Sas9
+      ? process.env.SAS9_SERVER_URL
+      : process.env.SASJS_SERVER_URL) as string,
     appLoc: `/Public/app/cli-tests/${targetName}`,
     contextName,
     macroFolders: ['sasjs/macros'],

--- a/src/commands/testing/spec/testing.spec.server.ts
+++ b/src/commands/testing/spec/testing.spec.server.ts
@@ -100,11 +100,7 @@ end_of_record`
   describe('SASVIYA', () => {
     const target: Target = generateTarget()
     const testUrl = (test: string) =>
-      `${target.serverUrl}/${
-        target.serverType === ServerType.SasViya
-          ? 'SASJobExecution'
-          : 'SASStoredProcess'
-      }/?_program=/Public/app/cli-tests/${
+      `${target.serverUrl}/SASJobExecution/?_program=/Public/app/cli-tests/${
         target.name
       }/tests/${test}&_debug=2477&_contextName=${encodeURIComponent(
         target.contextName
@@ -544,6 +540,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
     })
 
     it('should execute tests and create result CSV, XML and JSON files using default source and output locations', async () => {
+      const testDescription = 'random test description'
+      const testResult = 'PASS'
       const expectedResultsJson = {
         sasjs_test_meta: [
           {
@@ -554,8 +552,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('testsetup')
@@ -570,8 +568,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('jobs/jobs/exampleprogram.test')
@@ -586,8 +584,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('jobs/jobs/standalone.test')
@@ -602,8 +600,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('macros/examplemacro.test')
@@ -618,8 +616,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('macros/shouldFail.test')
@@ -634,8 +632,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('services/admin/dostuff.test.0')
@@ -645,8 +643,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('services/admin/dostuff.test.1')
@@ -661,8 +659,8 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
                 sasjs_test_id: '',
                 result: [
                   {
-                    TEST_DESCRIPTION: 'random test description',
-                    TEST_RESULT: 'PASS'
+                    TEST_DESCRIPTION: testDescription,
+                    TEST_RESULT: testResult
                   }
                 ],
                 test_url: testUrl('testteardown')
@@ -672,28 +670,28 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
         ]
       }
       const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
-testsetup,tests/testsetup.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+testsetup,tests/testsetup.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'testsetup'
       )}
-exampleprogram,tests/jobs/jobs/exampleprogram.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+exampleprogram,tests/jobs/jobs/exampleprogram.test.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'jobs/jobs/exampleprogram.test'
       )}
-standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+standalone,tests/jobs/jobs/standalone.test.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'jobs/jobs/standalone.test'
       )}
-examplemacro,tests/macros/examplemacro.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+examplemacro,tests/macros/examplemacro.test.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'macros/examplemacro.test'
       )}
-shouldFail,tests/macros/shouldFail.test.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+shouldFail,tests/macros/shouldFail.test.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'macros/shouldFail.test'
       )}
-dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+dostuff,tests/services/admin/dostuff.test.0.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'services/admin/dostuff.test.0'
       )}
-dostuff,tests/services/admin/dostuff.test.1.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+dostuff,tests/services/admin/dostuff.test.1.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'services/admin/dostuff.test.1'
       )}
-testteardown,tests/testteardown.sas,sasjs_test_id,PASS,random test description,${testUrlLink(
+testteardown,tests/testteardown.sas,sasjs_test_id,${testResult},${testDescription},${testUrlLink(
         'testteardown'
       )}
 `
@@ -704,14 +702,12 @@ testteardown,tests/testteardown.sas,sasjs_test_id,PASS,random test description,$
           _webout:
             '{"test_results":\r\n' +
             '[\r\n' +
-            '{"TEST_DESCRIPTION":"random test description" ,"TEST_RESULT":"PASS" }\r\n' +
+            `{"TEST_DESCRIPTION":"${testDescription}" ,"TEST_RESULT":"${testResult}" }\r\n` +
             ']}',
           log:
             '1                                          The SAS System             11:42 Friday, February 11, 2022\r\n' +
             '\r\n' +
             'NOTE: Copyright (c) 2016 by SAS Institute Inc., Cary, NC, USA. \r\n' +
-            'NOTE: SAS (r) Proprietary Software 9.4 (TS1M6) \r\n' +
-            '      Licensed to ANALYTIUM LTD- PARTNER LICENCE DATA MANAGER CLIENT, Site 70221619.\r\n' +
             'NOTE: This session is executing on the X64_10PRO  platform.\r\n',
           message: 'success'
         })

--- a/src/commands/testing/spec/testing.spec.server.ts
+++ b/src/commands/testing/spec/testing.spec.server.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { runTest } from '../test'
+import { runTest, getTestUrl } from '../test'
 import { TestDescription, TestResult } from '../../../types'
 import {
   Logger,
@@ -515,16 +515,14 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
   describe('SASJS', () => {
     const sasjs = new (<jest.Mock<SASjs>>SASjs)()
     const target: Target = generateTarget(ServerType.Sasjs)
+
+    let t = `/Public/app/cli-tests/${target.name}/tests/${test}`
+
     const testUrl = (test: string) =>
-      `${target.serverUrl}/${
-        target.serverType === ServerType.SasViya
-          ? 'SASJobExecution'
-          : 'SASStoredProcess'
-      }/?_program=/Public/app/cli-tests/${
-        target.name
-      }/tests/${test}&_debug=2477&_contextName=${encodeURIComponent(
-        target.contextName
-      )}`
+      `${getTestUrl(
+        target,
+        `/Public/app/cli-tests/${target.name}/tests/${test}`
+      )}&_contextName=${encodeURIComponent(target.contextName)}`
     const testUrlLink = (test: string) => `"=HYPERLINK(""${testUrl(test)}"")"`
 
     beforeAll(async () => {

--- a/src/commands/testing/test.ts
+++ b/src/commands/testing/test.ts
@@ -151,13 +151,7 @@ export async function runTest(
       .replace(/(.test)?(.\d+)?(.sas)?$/i, '')
     const testId = uuidv4()
 
-    let testUrl = `${target.serverUrl}/${
-      target.serverType === ServerType.SasViya
-        ? 'SASJobExecution'
-        : target.serverType === ServerType.Sas9
-        ? 'SASStoredProcess'
-        : 'SASjsApi/stp/execute'
-    }/?_program=${sasJobLocation}&_debug=2477`
+    let testUrl = getTestUrl(target, sasJobLocation)
 
     if (target.contextName) {
       testUrl = `${testUrl}&_contextName=${encodeURIComponent(
@@ -392,3 +386,12 @@ export async function runTest(
   ${coverageReportPath}`
   )
 }
+
+export const getTestUrl = (target: Target, jobLocation: string) =>
+  `${target.serverUrl}/${
+    target.serverType === ServerType.SasViya
+      ? 'SASJobExecution'
+      : target.serverType === ServerType.Sas9
+      ? 'SASStoredProcess'
+      : 'SASjsApi/stp/execute'
+  }/?_program=${jobLocation}&_debug=2477`

--- a/src/commands/testing/test.ts
+++ b/src/commands/testing/test.ts
@@ -154,7 +154,9 @@ export async function runTest(
     let testUrl = `${target.serverUrl}/${
       target.serverType === ServerType.SasViya
         ? 'SASJobExecution'
-        : 'SASStoredProcess'
+        : target.serverType === ServerType.Sas9
+        ? 'SASStoredProcess'
+        : 'SASjsApi/stp/execute'
     }/?_program=${sasJobLocation}&_debug=2477`
 
     if (target.contextName) {


### PR DESCRIPTION
## Issue

Closes #1108 

## Intent

- Add `@sasjs/server` support to `sasjs test` command

## Implementation

- Added logic to support `SASJS` `ServerType`.
- Added unit test to cover the new functionality.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/154053960-c7edaa71-ea88-42a1-bba6-643106fe6043.png)
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/154055143-b0d26ebf-19a7-4539-bda5-c7f5346c297a.png)
Server (without `request.spec.server`):
![image](https://user-images.githubusercontent.com/83717836/154058450-5882a4ad-ace2-4454-bef4-3853dbdc6158.png)
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
