### PR TITLE
docs: suggestion to use npm rm -g @sasjs/cli for unlinking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ npm link
 npm start
 ```
 
-The `npm start` script watches for changes in the source files and automatically rebuilds them.  Once done, you can use `npm unlink` from the repository to unlink it.
+The `npm start` script watches for changes in the source files and automatically rebuilds them.  Once done, you can use `npm unlink` from the repository to unlink it.  If this doesn't work, you can try: `npm rm -g @sasjs/cli`.
 
 ## Development Notes
 


### PR DESCRIPTION
## Issue

Spent 20 mins today figuring out how to unlink

## Intent

Make the unlink process faster

## Implementation

Updating CONTRIBUTING.md with the suggestion to use `npm rm -g @sasjs/cli` if `npm unlink sasjs` doesn't work

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
