### PR TITLE
fix: bumping adapter with log parsing fix for sasjs/server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.7.3",
+        "@sasjs/adapter": "3.7.4",
         "@sasjs/core": "4.9.2",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.36.0",
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.3.tgz",
-      "integrity": "sha512-FRswcMCrrec5G55E3Vkh9C/Oww03jOrjfDNsiR6wLTCHUN3aKChgRJ/BlosE6aS6cRORcnAGEfeXrC0nN2rZNA==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.4.tgz",
+      "integrity": "sha512-PwBkq0/lWiseD12wKPmpWim0Ls8RMK8MeWhxIK8SQ65EZLm4mQpnDFJ31wND7nL8svnwl/o+E3gQRyrzYmlNtw==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.35.0",
@@ -9686,9 +9686,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.3.tgz",
-      "integrity": "sha512-FRswcMCrrec5G55E3Vkh9C/Oww03jOrjfDNsiR6wLTCHUN3aKChgRJ/BlosE6aS6cRORcnAGEfeXrC0nN2rZNA==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.4.tgz",
+      "integrity": "sha512-PwBkq0/lWiseD12wKPmpWim0Ls8RMK8MeWhxIK8SQ65EZLm4mQpnDFJ31wND7nL8svnwl/o+E3gQRyrzYmlNtw==",
       "requires": {
         "@sasjs/utils": "2.35.0",
         "axios": "0.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.7.1",
-        "@sasjs/core": "^4.9.2",
+        "@sasjs/adapter": "3.7.2",
+        "@sasjs/core": "4.9.2",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.36.0",
         "chalk": "4.1.2",
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.1.tgz",
-      "integrity": "sha512-jFZgC6yqLRScbLQAfedbthqaLvuo2G0e5lUrAEWfJJDks2lbquQKIIVR0jKEmI31vovEY+IzvVtYJ0XzYMZ/FQ==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.2.tgz",
+      "integrity": "sha512-1qSsz9XcUSyOPdVpkSw/80ClC47jnDne4mO26IB5r6yq3ypFyGYcFqu220aeYK32dQtwFBD5t7YVpALfVthDOQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.35.0",
@@ -9686,9 +9686,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.1.tgz",
-      "integrity": "sha512-jFZgC6yqLRScbLQAfedbthqaLvuo2G0e5lUrAEWfJJDks2lbquQKIIVR0jKEmI31vovEY+IzvVtYJ0XzYMZ/FQ==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.2.tgz",
+      "integrity": "sha512-1qSsz9XcUSyOPdVpkSw/80ClC47jnDne4mO26IB5r6yq3ypFyGYcFqu220aeYK32dQtwFBD5t7YVpALfVthDOQ==",
       "requires": {
         "@sasjs/utils": "2.35.0",
         "axios": "0.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.7.0",
+        "@sasjs/adapter": "3.7.1",
         "@sasjs/core": "4.9.0",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.36.0",
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.0.tgz",
-      "integrity": "sha512-dIhwoGbdGpmE9v+vY5MyjFKMt72pt6qks6va7YRhkIUGrsF5A5Sy1wrfTIs47VoxrFRQP4lqScIZwrww9vTiaQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.1.tgz",
+      "integrity": "sha512-jFZgC6yqLRScbLQAfedbthqaLvuo2G0e5lUrAEWfJJDks2lbquQKIIVR0jKEmI31vovEY+IzvVtYJ0XzYMZ/FQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.35.0",
@@ -9686,9 +9686,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.0.tgz",
-      "integrity": "sha512-dIhwoGbdGpmE9v+vY5MyjFKMt72pt6qks6va7YRhkIUGrsF5A5Sy1wrfTIs47VoxrFRQP4lqScIZwrww9vTiaQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.1.tgz",
+      "integrity": "sha512-jFZgC6yqLRScbLQAfedbthqaLvuo2G0e5lUrAEWfJJDks2lbquQKIIVR0jKEmI31vovEY+IzvVtYJ0XzYMZ/FQ==",
       "requires": {
         "@sasjs/utils": "2.35.0",
         "axios": "0.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,10 @@
   "packages": {
     "": {
       "name": "@sasjs/cli",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.6.1",
+        "@sasjs/adapter": "3.7.0",
         "@sasjs/core": "4.9.0",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.36.0",
@@ -2052,9 +2053,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.6.1.tgz",
-      "integrity": "sha512-LyFqyyGze4laLF738ihWuV8agm+Ghlo1TfIrm4W3IghIeZmHptZzL4Lfp5PekguuJnWpAZf0uicIbxebX9mpiw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.0.tgz",
+      "integrity": "sha512-dIhwoGbdGpmE9v+vY5MyjFKMt72pt6qks6va7YRhkIUGrsF5A5Sy1wrfTIs47VoxrFRQP4lqScIZwrww9vTiaQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.35.0",
@@ -9685,9 +9686,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.6.1.tgz",
-      "integrity": "sha512-LyFqyyGze4laLF738ihWuV8agm+Ghlo1TfIrm4W3IghIeZmHptZzL4Lfp5PekguuJnWpAZf0uicIbxebX9mpiw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.7.0.tgz",
+      "integrity": "sha512-dIhwoGbdGpmE9v+vY5MyjFKMt72pt6qks6va7YRhkIUGrsF5A5Sy1wrfTIs47VoxrFRQP4lqScIZwrww9vTiaQ==",
       "requires": {
         "@sasjs/utils": "2.35.0",
         "axios": "0.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "3.7.1",
-        "@sasjs/core": "4.9.0",
+        "@sasjs/core": "^4.9.2",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.36.0",
         "chalk": "4.1.2",
@@ -2087,9 +2087,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.9.0.tgz",
-      "integrity": "sha512-zc1Ey0ylHt/eRZAfK0mVG3EqNyq//wLxbiguiK0R6FhVqwYFEkprs3IiLGZ5M9ttKs2rHRIjOe/ckklHm+6HNQ=="
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.9.2.tgz",
+      "integrity": "sha512-RviQFzYuR3zVR6x+ctcG01Apsw1yAciLZbKhlSccjglwJDb5QV87V8zSi2rH4Nm4B5ZC/Fb4KvO9fD3SN+rEgw=="
     },
     "node_modules/@sasjs/lint": {
       "version": "1.11.2",
@@ -9720,9 +9720,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.9.0.tgz",
-      "integrity": "sha512-zc1Ey0ylHt/eRZAfK0mVG3EqNyq//wLxbiguiK0R6FhVqwYFEkprs3IiLGZ5M9ttKs2rHRIjOe/ckklHm+6HNQ=="
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.9.2.tgz",
+      "integrity": "sha512-RviQFzYuR3zVR6x+ctcG01Apsw1yAciLZbKhlSccjglwJDb5QV87V8zSi2rH4Nm4B5ZC/Fb4KvO9fD3SN+rEgw=="
     },
     "@sasjs/lint": {
       "version": "1.11.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.6.1",
+    "@sasjs/adapter": "3.7.0",
     "@sasjs/core": "4.9.0",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.36.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "3.7.1",
-    "@sasjs/core": "4.9.0",
+    "@sasjs/core": "4.9.2",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.36.0",
     "chalk": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.7.0",
+    "@sasjs/adapter": "3.7.1",
     "@sasjs/core": "4.9.0",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.36.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "copy:files": "copyfiles -u 1 ./src/config.json ./build/ && npm run copy:doxy",
     "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/",
     "test": "npm run test:mocked && npm run test:server",
-    "test:server": "jest --runInBand --config=jest.server.config.js",
+    "test:server": "jest --silent --runInBand --config=jest.server.config.js",
     "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "copy:files": "copyfiles -u 1 ./src/config.json ./build/ && npm run copy:doxy",
     "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/",
     "test": "npm run test:mocked && npm run test:server",
-    "test:server": "jest --silent --runInBand --config=jest.server.config.js",
+    "test:server": "jest --runInBand --config=jest.server.config.js",
     "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.7.1",
+    "@sasjs/adapter": "3.7.2",
     "@sasjs/core": "4.9.2",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.36.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.7.3",
+    "@sasjs/adapter": "3.7.4",
     "@sasjs/core": "4.9.2",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.36.0",

--- a/src/commands/testing/test.ts
+++ b/src/commands/testing/test.ts
@@ -90,7 +90,7 @@ export async function runTest(
     serverType: target.serverType,
     debug: true,
     contextName: target.contextName,
-    useComputeApi: false
+    useComputeApi: target.serverType === ServerType.Sasjs ? undefined : false
   })
 
   let authConfig: AuthConfig, username: string, password: string
@@ -247,6 +247,7 @@ export async function runTest(
       }
     }
 
+    console.log('going to run ', sasJobLocation)
     await sasjs!
       .request(
         sasJobLocation,
@@ -260,6 +261,7 @@ export async function runTest(
       )
       .then(handleRes)
       .catch(async (err) => {
+        console.log('CATCH', sasJobLocation)
         if (err.error?.message === 'Error: invalid Json string') {
           await handleRes({})
           return

--- a/src/commands/testing/test.ts
+++ b/src/commands/testing/test.ts
@@ -247,7 +247,6 @@ export async function runTest(
       }
     }
 
-    console.log('going to run ', sasJobLocation)
     await sasjs!
       .request(
         sasJobLocation,
@@ -261,7 +260,6 @@ export async function runTest(
       )
       .then(handleRes)
       .catch(async (err) => {
-        console.log('CATCH', sasJobLocation)
         if (err.error?.message === 'Error: invalid Json string') {
           await handleRes({})
           return

--- a/src/commands/testing/test.ts
+++ b/src/commands/testing/test.ts
@@ -90,7 +90,7 @@ export async function runTest(
     serverType: target.serverType,
     debug: true,
     contextName: target.contextName,
-    useComputeApi: target.serverType === ServerType.Sasjs ? undefined : false
+    useComputeApi: false
   })
 
   let authConfig: AuthConfig, username: string, password: string


### PR DESCRIPTION
## Issue

https://github.com/sasjs/server/issues/68

## Intent

Enabling parsing of new log format on sasjs/server in the adapter

## Implementation

Log is captured line by line rather than as a single string

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/154983293-452c1256-9f66-478b-97de-9b7f13df276e.png)
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/154984875-d3f1b035-ec1a-47d6-82e6-cb2b51f1a2d7.png)
Server (without `request.spec.server` and `testing.spec.server`):
![image](https://user-images.githubusercontent.com/83717836/154995376-2be3b073-6c03-460c-a003-cf504d9634f9.png)
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
