### PR TITLE
chore: remove it.only from test cases to avoid test skipping

### DIFF
--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -196,12 +196,12 @@ describe('JobCommand', () => {
     })
   })
 
-  describe.only('for server type sas9', () => {
+  describe('for server type sas9', () => {
     beforeEach(() => {
       setupMocksForSAS9()
     })
 
-    it.only('should return the error code when user credentials are not found', async () => {
+    it('should return the error code when user credentials are not found', async () => {
       const username = process.env.SAS_USERNAME
       const password = process.env.SAS_PASSWORD
       process.env.SAS_USERNAME = ''


### PR DESCRIPTION
## Issue

Link any related issue(s) in this section.

## Intent

Forgot to remove `it.only` from previous PR.

## Implementation

What code changes have been made to achieve the intent.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/155992927-c9b55e34-9b3e-4cf2-8ea6-d5f811daac31.png)
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/155989108-e55eed19-99fe-427d-a8d8-b1e83aa130e0.png)
Server:
![image](https://user-images.githubusercontent.com/83717836/155992860-a9da01ae-aa12-443e-82f1-ae56579d5840.png)
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
