### PR TITLE
fix: funding.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [sasjs]


### PR DESCRIPTION
This is a bump as the previous one did not get picked up in the auto-release!

The actual new feature here is the deprecation of lua in the streaming apps capability, so that it will work on Viya 4.  See:  https://github.com/sasjs/cli/pull/1139
