### PR TITLE
fix(compile): not throwing for sasjs web while compile

### DIFF
--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -262,9 +262,9 @@ async function compileWeb(target: Target) {
       )
       .catch((err) => {
         process.logger?.error(
-          'An error has occurred when compiling web app services.'
+          'An error has occurred when compiling web app services.',
+          err.toString()
         )
-        throw err
       })
   }
 }


### PR DESCRIPTION
## Issue

closes #1094 

## Intent

`sasjs compile` should not throw if sasjs web process fails.

## Implementation

Removed throw err and also details of err (stack)

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
