### PR TITLE
fix: logic causing failiur of request.spec.server

### DIFF
--- a/src/commands/request/request.ts
+++ b/src/commands/request/request.ts
@@ -108,8 +108,27 @@ export async function runSasJob(
       }
 
       let output = ''
-      if (res?.result) output = res.result
-      await writeOutput(outputPathParam, output, isLocal)
+
+      if (res?.result) {
+        res = res.result
+      } else if (res?.log) {
+        delete res.log
+      }
+
+      if (typeof res === 'string') {
+        try {
+          output = JSON.parse(res)
+        } catch (error) {
+          displayError('Error parsing response. JSON is expected.')
+        }
+      } else {
+        output = res
+      }
+
+      if (!!output) {
+        await writeOutput(outputPathParam, output, isLocal)
+      }
+
       await saveLogFile(sasjs, sasJobLocation, logFile, jobPath)
       result = true
     })

--- a/src/commands/request/request.ts
+++ b/src/commands/request/request.ts
@@ -110,12 +110,14 @@ export async function runSasJob(
       let output = ''
 
       if (res?.result) res = res.result
-      // in sasjs request debug is always on and reponse contains log too but it shouldn't be added to output file (*.json),
-      //because for log a separate *.log file is created
+    
+      // In sasjs request debug is always on, meaning the response object always contains the log
+      // This log goes to a seperate .log file, and should not be added to the output file (*.json)
+      // Therefore, we delete it now from the result object
       else if (res?.log) delete res.log
 
-      // sometimes res.result contains log of the request.
-      // so, making sure that the content that is going to be in output file (*.json) is in json form
+      // Sometimes res.result contains the log (eg when there is a SAS error)
+      // Here we make sure that the content in the output file (*.json) will be in json format
       if (typeof res === 'string') {
         try {
           output = JSON.parse(res)

--- a/src/commands/request/request.ts
+++ b/src/commands/request/request.ts
@@ -110,7 +110,6 @@ export async function runSasJob(
       let output = ''
 
       if (res?.result) res = res.result
-    
       // In sasjs request debug is always on, meaning the response object always contains the log
       // This log goes to a seperate .log file, and should not be added to the output file (*.json)
       // Therefore, we delete it now from the result object


### PR DESCRIPTION
## Issue

none

## Intent

* fix logic that caused the failure of request.spec.server

## Implementation

* if result attribute is present in the response, use that as a response
* if the resultant response is string, try to parse it into json
* if result is not present in response and log is there, remove log from response and use whole response for writing output file.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
