### PR TITLE
feat(create): enable git clone with submodels

### DIFF
--- a/src/commands/create/create.ts
+++ b/src/commands/create/create.ts
@@ -39,10 +39,9 @@ export async function create(parentFolderName: string, appType: string) {
   if (!appType) {
     await setupNpmProject(parentFolderName)
   }
+
   await setupGitIgnore(parentFolderName)
-
   await setupDoxygen(parentFolderName)
-
   await createReadme(parentFolderName)
 
   const lintConfigPath = path.join(
@@ -50,6 +49,8 @@ export async function create(parentFolderName: string, appType: string) {
     parentFolderName,
     '.sasjslint'
   )
-  if (!(await fileExists(lintConfigPath)))
+
+  if (!(await fileExists(lintConfigPath))) {
     await createLintConfigFile(parentFolderName)
+  }
 }

--- a/src/commands/create/spec/angularAppFiles.ts
+++ b/src/commands/create/spec/angularAppFiles.ts
@@ -125,6 +125,11 @@ export const angularAppFiles: Folder = {
           subFolders: []
         }
       ]
+    },
+    {
+      folderName: 'docs',
+      files: [{ fileName: 'index.html' }],
+      subFolders: []
     }
   ]
 }

--- a/src/commands/create/spec/create.spec.ts
+++ b/src/commands/create/spec/create.spec.ts
@@ -1,6 +1,10 @@
 import dotenv from 'dotenv'
 import path from 'path'
-import { verifyFolder, verifyPackageJsonContent } from '../../../utils/test'
+import {
+  verifyFolder,
+  verifyPackageJsonContent,
+  verifyGitNotPresent
+} from '../../../utils/test'
 import { createFolder, deleteFolder, generateTimestamp } from '@sasjs/utils'
 import { getFolders } from '../../../utils/config'
 import { minimalAppFiles } from './minimalAppFiles'
@@ -73,6 +77,7 @@ describe('sasjs create', () => {
     await expect(create('.', 'react')).toResolve()
 
     await verifyCreateWeb('.', 'react')
+    await verifyGitNotPresent(process.projectDir)
   })
 
   it(`should set up a react app in a given folder`, async () => {
@@ -87,6 +92,7 @@ describe('sasjs create', () => {
     await expect(create('test-react-app', 'react')).toResolve()
 
     await verifyCreateWeb('test-react-app', 'react')
+    await verifyGitNotPresent(process.projectDir)
   })
 
   it(`should set up a minimal app in a given folder`, async () => {
@@ -115,6 +121,7 @@ describe('sasjs create', () => {
     await expect(create('test-angular-app', 'angular')).toResolve()
 
     await verifyCreateWeb('test-angular-app', 'angular')
+    await verifyGitNotPresent(process.projectDir)
   })
 
   it(`should fail with an unknown app type 'xyz'`, async () => {
@@ -149,6 +156,7 @@ const verifyCreateWeb = async (appName: string, appType: string) => {
 
 const verifyCreate = async (parentFolderName: string, appType: string) => {
   let fileStructure
+
   if (appType === 'sasonly') {
     fileStructure = {
       folderName: parentFolderName,
@@ -169,6 +177,7 @@ const verifyCreate = async (parentFolderName: string, appType: string) => {
       files: [{ fileName: 'README.md' }]
     }
   }
+
   await verifyFolder(fileStructure)
   await verifyPackageJsonContent(parentFolderName)
 }

--- a/src/commands/create/spec/reactAppFiles.ts
+++ b/src/commands/create/spec/reactAppFiles.ts
@@ -76,6 +76,17 @@ export const reactAppFiles: Folder = {
           subFolders: []
         }
       ]
+    },
+    {
+      folderName: 'public',
+      files: [],
+      subFolders: [
+        {
+          folderName: 'docs',
+          files: [{ fileName: 'index.html' }],
+          subFolders: []
+        }
+      ]
     }
   ]
 }

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -6,7 +6,9 @@ import {
   fileExists,
   folderExists,
   readFile,
-  asyncForEach
+  asyncForEach,
+  listFilesAndSubFoldersInFolder,
+  pathSepEscaped
 } from '@sasjs/utils'
 import { deleteFolder as deleteServerFolder } from '../commands/folder/delete'
 import {
@@ -515,4 +517,17 @@ const verifyCompile = async (
     const re = new RegExp(`%macro ${macro}`)
     expect(re.test(compiledContent)).toEqual(true)
   })
+}
+
+export const verifyGitNotPresent = async (folder: string) => {
+  const gitFolderOrModules = (
+    await listFilesAndSubFoldersInFolder(folder, true)
+  ).filter(
+    (sub: string) =>
+      /\.git$/.test(sub) ||
+      new RegExp(`\.git${pathSepEscaped}`).test(sub) ||
+      /\.gitmodules/.test(sub)
+  )
+
+  expect(gitFolderOrModules.length).toEqual(0)
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -94,6 +94,7 @@ function createApp(
     .exec(`git version`, { silent: true })
     .stdout.match(/(?<!git version)\d+\.\d+\.\d+/) || '')[0].replace(/\./g, '')
 
+  // NOTE: git version 2.13 and greater are using '--recurse-submodules' instead of '--recurse'
   shelljs.exec(
     `cd "${folderPath}" && git clone --recurse${
       parseInt(gitVersion) > 2130 ? '-submodules' : ''

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -88,20 +88,16 @@ function createApp(
   const spinner = ora(`Creating SASjs project in ${folderPath}.`)
   spinner.start()
 
-  // FIXME
-  // const gitBranch = repoUrl.includes('template_sasonly') ? 'master' : 'main'
+  const gitBranch = repoUrl.includes('template_sasonly') ? 'master' : 'main'
 
-  // shelljs.exec(
-  //   `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b ${gitBranch} ${repoUrl} .`,
-  //   { silent: true }
-  // )
-
-  console.log(
-    `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b cli-issue-1167 ${repoUrl} .`
-  )
+  const gitVersion: string = (shelljs
+    .exec(`git version`, { silent: true })
+    .stdout.match(/(?<!git version)\d+\.\d+\.\d+/) || '')[0].replace(/\./g, '')
 
   shelljs.exec(
-    `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b cli-issue-1167 ${repoUrl} .`,
+    `cd "${folderPath}" && git clone --recurse${
+      parseInt(gitVersion) > 2130 ? '-submodules' : ''
+    } --depth 1 -b ${gitBranch} ${repoUrl} .`,
     { silent: true }
   )
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -95,7 +95,15 @@ function createApp(
     { silent: true }
   )
 
-  shelljs.rm('-rf', path.join(folderPath, '.git'))
+  deleteGitFolder(folderPath)
+
+  shelljs.rm('-f', [path.join(folderPath, '.gitmodules')])
+
+  if (repoUrl.includes('react-seed-app')) {
+    deleteGitFolder(path.join(folderPath, 'public', 'docs'))
+  } else if (repoUrl.includes('angular-seed-app')) {
+    deleteGitFolder(path.join(folderPath, 'docs'))
+  }
 
   spinner.stop()
 
@@ -110,6 +118,9 @@ function createApp(
     spinner.stop()
   }
 }
+
+const deleteGitFolder = (folderPath: string) =>
+  shelljs.rm('-rf', path.join(folderPath, '.git'))
 
 export async function setupNpmProject(folderName: string): Promise<void> {
   const folderPath = path.join(process.projectDir, folderName)
@@ -171,14 +182,6 @@ export async function setupGitIgnore(folderName: string): Promise<void> {
     )
 
     process.logger?.success('.gitignore file has been created.')
-  }
-
-  const folderPath = path.join(process.projectDir, folderName)
-  const gitDirectoryExists = await folderExists(path.join(folderPath, '.git'))
-  if (!gitDirectoryExists) {
-    shelljs.exec(`cd ${folderName} && git init`, {
-      silent: true
-    })
   }
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -91,19 +91,22 @@ function createApp(
   const gitBranch = repoUrl.includes('template_sasonly') ? 'master' : 'main'
 
   shelljs.exec(
-    `cd "${folderPath}" && git clone --depth 1 -b ${gitBranch} ${repoUrl} .`,
+    `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b ${gitBranch} ${repoUrl} .`,
     { silent: true }
   )
 
   shelljs.rm('-rf', path.join(folderPath, '.git'))
 
   spinner.stop()
+
   if (installDependencies) {
     spinner.text = 'Installing dependencies...'
     spinner.start()
+
     shelljs.exec(`cd "${folderPath}" && npm install`, {
       silent: true
     })
+
     spinner.stop()
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -94,7 +94,7 @@ function createApp(
     .exec(`git version`, { silent: true })
     .stdout.match(/(?<!git version)\d+\.\d+\.\d+/) || '')[0].replace(/\./g, '')
 
-  // NOTE: git version 2.13 and greater are using '--recurse-submodules' instead of '--recurse'
+  // NOTE: git version 2.13 and greater are using '--recurse-submodules' instead of '--recurse' attribute to clone submodules
   shelljs.exec(
     `cd "${folderPath}" && git clone --recurse${
       parseInt(gitVersion) > 2130 ? '-submodules' : ''

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -88,10 +88,20 @@ function createApp(
   const spinner = ora(`Creating SASjs project in ${folderPath}.`)
   spinner.start()
 
-  const gitBranch = repoUrl.includes('template_sasonly') ? 'master' : 'main'
+  // FIXME
+  // const gitBranch = repoUrl.includes('template_sasonly') ? 'master' : 'main'
+
+  // shelljs.exec(
+  //   `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b ${gitBranch} ${repoUrl} .`,
+  //   { silent: true }
+  // )
+
+  console.log(
+    `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b cli-issue-1167 ${repoUrl} .`
+  )
 
   shelljs.exec(
-    `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b ${gitBranch} ${repoUrl} .`,
+    `cd "${folderPath}" && git clone --recurse-submodules --depth 1 -b cli-issue-1167 ${repoUrl} .`,
     { silent: true }
   )
 


### PR DESCRIPTION
## Issue

Closes #1159 

## Intent

- On `sasjs create` command using SASjs seed apps a docs submodels also need to be cloned.

## Implementation

- Add `--recurse-submodules` attribute to `git clone` command within `createApp` utility.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
