### PR TITLE
fix: sasjs add should not add empty config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@sasjs/adapter": "3.7.12",
         "@sasjs/core": "4.15.3",
         "@sasjs/lint": "1.11.2",
-        "@sasjs/utils": "2.36.0",
+        "@sasjs/utils": "2.40.1",
         "chalk": "4.1.2",
         "csv-stringify": "5.6.5",
         "dotenv": "10.0.0",
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.36.0.tgz",
-      "integrity": "sha512-8vVbekmc71QV4Zqm+RkmbOAC51+0Nelbujl9h7Mp/o+S8KnehaJoioM4w62M+iqjiwbk6xTEf9bEoVSIw3+9ZQ==",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.40.1.tgz",
+      "integrity": "sha512-wWYElDH71bSZTdZ5V38743vAnw2EPDhzH7+1s7zxINHpaQWK/qrDldI0vgVFLeGpxVU0D7WPZ/ltG6MoE2obeg==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -9755,9 +9755,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.36.0.tgz",
-      "integrity": "sha512-8vVbekmc71QV4Zqm+RkmbOAC51+0Nelbujl9h7Mp/o+S8KnehaJoioM4w62M+iqjiwbk6xTEf9bEoVSIw3+9ZQ==",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.40.1.tgz",
+      "integrity": "sha512-wWYElDH71bSZTdZ5V38743vAnw2EPDhzH7+1s7zxINHpaQWK/qrDldI0vgVFLeGpxVU0D7WPZ/ltG6MoE2obeg==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@sasjs/adapter": "3.7.12",
     "@sasjs/core": "4.15.3",
     "@sasjs/lint": "1.11.2",
-    "@sasjs/utils": "2.36.0",
+    "@sasjs/utils": "2.40.1",
     "chalk": "4.1.2",
     "csv-stringify": "5.6.5",
     "dotenv": "10.0.0",

--- a/src/commands/add/addTarget.ts
+++ b/src/commands/add/addTarget.ts
@@ -20,8 +20,6 @@ export async function addTarget(insecure: boolean): Promise<boolean> {
   const { scope, serverType, name, appLoc, serverUrl, existingTarget } =
     await getCommonFields()
 
-  const saveWithDefaultValues = !existingTarget
-
   let targetJson: any = {
     ...existingTarget,
     name,
@@ -31,7 +29,7 @@ export async function addTarget(insecure: boolean): Promise<boolean> {
   }
 
   const target = new Target(targetJson)
-  let filePath = await saveConfig(scope, target, false, saveWithDefaultValues)
+  let filePath = await saveConfig(scope, target, false, false)
 
   process.logger?.info(`Target configuration has been saved to ${filePath} .`)
 
@@ -65,11 +63,7 @@ export async function addTarget(insecure: boolean): Promise<boolean> {
         )
 
       targetJson = {
-        contextName,
-        deployConfig: {
-          deployServicePack: true,
-          deployScripts: []
-        }
+        contextName
       }
 
       targetJson = { ...updatedViyaTarget.toJson(false), ...targetJson }
@@ -92,12 +86,7 @@ export async function addTarget(insecure: boolean): Promise<boolean> {
 
   const isDefault = await getIsDefault()
 
-  filePath = await saveConfig(
-    scope,
-    new Target(targetJson),
-    isDefault,
-    saveWithDefaultValues
-  )
+  filePath = await saveConfig(scope, new Target(targetJson), isDefault, false)
 
   process.logger?.info(`Target configuration has been saved to ${filePath}`)
   return true


### PR DESCRIPTION
## Issue

closes #1151 

## Intent

- Avoid extra empty attributes in creating of the target.

## Implementation

- `saveWithDefaultValues` param is set to false for `saveConfig` function.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
