### PR TITLE
fix(compile): fixed duplicates while compilation

### DIFF
--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -217,6 +217,12 @@ const compileServiceFolder = async (
   const subFolders = await listSubFoldersInFolder(destinationPath)
   const filesNamesInPath = await listFilesInFolder(destinationPath)
 
+  await asyncForEach(filesNamesInPath, async (fileName: string, i: number) => {
+    if (!(await fileExists(path.join(serviceFolder, fileName)))) {
+      filesNamesInPath.splice(i, 1)
+    }
+  })
+
   await asyncForEach(filesNamesInPath, async (fileName) => {
     const filePath = path.join(destinationPath, fileName)
 

--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -218,6 +218,8 @@ const compileServiceFolder = async (
   const subFolders = await listSubFoldersInFolder(destinationPath)
   const filesNamesInPath = await listFilesInFolder(destinationPath)
 
+  // Checks if file in sasjsbuild folder exists in source folder.
+  // If not, it means that the file shouldn't be compiled.
   await asyncForEach(filesNamesInPath, async (fileName: string, i: number) => {
     if (!(await fileExists(path.join(serviceFolder, fileName)))) {
       filesNamesInPath.splice(i, 1)
@@ -285,6 +287,8 @@ const compileJobFolder = async (
   const subFolders = await listSubFoldersInFolder(destinationPath)
   const filesNamesInPath = await listFilesInFolder(destinationPath)
 
+  // Checks if file in sasjsbuild folder exists in source folder.
+  // If not, it means that the file shouldn't be compiled.
   await asyncForEach(filesNamesInPath, async (fileName: string, i: number) => {
     if (!(await fileExists(path.join(jobFolder, fileName)))) {
       filesNamesInPath.splice(i, 1)

--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -206,6 +206,7 @@ async function recreateBuildFolder() {
   await createFolder(buildDestinationFolder)
 }
 
+// REFACTOR: combine compileServiceFolder and compileJobFolder
 const compileServiceFolder = async (
   target: Target,
   serviceFolder: string,
@@ -283,6 +284,12 @@ const compileJobFolder = async (
   const destinationPath = getDestinationJobPath(jobFolder)
   const subFolders = await listSubFoldersInFolder(destinationPath)
   const filesNamesInPath = await listFilesInFolder(destinationPath)
+
+  await asyncForEach(filesNamesInPath, async (fileName: string, i: number) => {
+    if (!(await fileExists(path.join(jobFolder, fileName)))) {
+      filesNamesInPath.splice(i, 1)
+    }
+  })
 
   await asyncForEach(filesNamesInPath, async (fileName) => {
     const filePath = path.join(destinationPath, fileName)


### PR DESCRIPTION
## Intent

Fix compilation duplicates discovered in `DataController`.

## Implementation

- Removed not existing services in `compileServiceFolder` function.
- Removed not existing jobs in `compileJobFolder` function.
- Added a unit covering this scenario.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
