### PR TITLE
fix(compile): fixed getNodeModulePath

### DIFF
--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { getLocalOrGlobalConfig } from './config'
-import { getCliNodeModulePath } from './utils'
+import { getNodeModulePath } from './utils'
 import { getAbsolutePath } from '@sasjs/utils'
 
 export const contextName = 'sasjs cli compute context'
@@ -38,7 +38,7 @@ export const setConstants = async () => {
   const buildDestinationJobsFolder = path.join(buildDestinationFolder, 'jobs')
   const buildDestinationDbFolder = path.join(buildDestinationFolder, 'db')
   const buildDestinationDocsFolder = path.join(buildDestinationFolder, 'docs')
-  const macroCorePath = await getCliNodeModulePath('@sasjs/core')
+  const macroCorePath = await getNodeModulePath('@sasjs/core')
 
   const buildDestinationResultsFolder = getAbsolutePath(
     buildResultsFolder,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -460,24 +460,32 @@ export const isSASjsProject = async () => {
   return false
 }
 
-export const getCliNodeModulePath = async (module: string): Promise<string> => {
+export const getNodeModulePath = async (module: string): Promise<string> => {
+  // Check if module is present in project's dependencies
+  const projectPath = path.join(process.cwd(), 'node_modules', module)
+
+  if (await folderExists(projectPath)) return projectPath
+
+  // Check if module is present in @sasjs/cli located in project's dependencies
   const cliDepsPath = path.join('@sasjs', 'cli', 'node_modules')
-  const localPath = path.join(
+  const cliLocalPath = path.join(
     process.cwd(),
     'node_modules',
     cliDepsPath,
     module
   )
 
-  if (await folderExists(localPath)) return localPath
+  if (await folderExists(cliLocalPath)) return cliLocalPath
 
-  const globalPath = path.join(
+  // Check if module is present in global @sasjs/cli
+  const cliGlobalPath = path.join(
     shelljs.exec(`npm root -g`, { silent: true }).stdout.replace(/\n/, ''),
     cliDepsPath,
     module
   )
 
-  if (await folderExists(globalPath)) return globalPath
+  if (await folderExists(cliGlobalPath)) return cliGlobalPath
 
+  // Return default value
   return ''
 }


### PR DESCRIPTION
## Issue

#1113 

## Intent

- Use `@sasjs/core` located in project's dependencies as first choice for project compilation.

## Implementation

- Adjusted `getNodeModulePath` utility.
- Adjusted `setConstants.spec`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
