### PR TITLE
fix: create command git init fix

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -118,7 +118,7 @@ function createApp(
     spinner.text = 'Installing dependencies...'
     spinner.start()
 
-    shelljs.exec(`cd "${folderPath}" && npm install`, {
+    shelljs.exec(`cd "${folderPath}" && git init && npm install`, {
       silent: true
     })
 


### PR DESCRIPTION
## Intent

When running `sasjs create` command after removing `.git` folder and installing dependencies `prepare` command was not running since it wasn't a git repository.

## Implementation

I added `git init`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
