### PR TITLE
fix: enabling dynamic streaming apps 

### DIFF
--- a/src/commands/web/internal/sasjsout.ts
+++ b/src/commands/web/internal/sasjsout.ts
@@ -107,14 +107,49 @@ export const sasjsout = `
       if symexist('_metaperson') then put '    serverType: "SAS9" ,';
       else put '    serverType: "SASVIYA" ,';
     end;
-    else if find(_infile_,' hostUrl: ') then do;
+    else if find(_infile_,' serverUrl: ') then do;
       /* nothing - we are streaming, so remove to default as hostname */
     end;
     else do;
-      length newline $32767;
-      /* during SAS9 compilation, dependencies are assigned three slashes /// */
-      newline=tranwrd(_infile_,'?_PROGRAM=///',cats(expanded_path));
-      put newline;
+      /* More recently, SASjs apps avoid inline JS to allow strict CSP */
+      length infile $32767;
+      infile=cats(_infile_);
+      spos1=index(upcase(infile),'APPLOC="');
+      if spos1>0 then do;
+        in1=substr(infile,1,spos1+7);
+        in2=subpad(infile,spos1+8,length(infile)-8);
+        in2=substr(in2,index(in2,'"'));
+        infile=cats(in1,"NEWAPPLOC",in2);
+        put "new apploc:  " infile=;
+      end;
+      /* find & replace serverType in HTML attributes */
+      spos2=index(upcase(infile),'SERVERTYPE="');
+      if spos2>0 then do;
+        in1=substr(infile,1,spos2+11);
+        in2=subpad(infile,spos2+13,length(infile)-13);
+        in2=substr(in2,index(in2,'"'));
+        if symexist('sasjsprocessmode') then infile=cats(in1,"SAS9",in2);
+        else if "&sysprocessmode"="SAS Object Server" 
+        or "&sysprocessmode"= "SAS Compute Server"
+        then infile=cats(in1,"SASVIYA",in2);
+        else infile=cats(in1,"SASJS",in2);
+        put "new servertype:  " infile=;
+      end;
+      /* find & replace serverUrl in HTML attributes */
+      spos3=index(upcase(infile),'SERVERURL="');
+      if spos3>0 then do;
+        in1=substr(infile,1,spos3+10);
+        in2=subpad(infile,spos3+12,length(infile)-12);
+        in2=substr(in2,index(in2,'"'));
+        infile=catx(' ',in1,in2);
+        put "new serverUrl:  " infile=;
+      end;
+      if sum(spos1,spos2,spos3)>0 then put infile;
+      else do;
+        /* during SAS9 sasjs compile, dependencies get three slashes /// */
+        infile=tranwrd(_infile_,'?_PROGRAM=///',cats(expanded_path));
+        put infile;
+      end;
     end;
   run;
   %let fref=_sjs;

--- a/src/commands/web/internal/sasjsout.ts
+++ b/src/commands/web/internal/sasjsout.ts
@@ -112,12 +112,12 @@ export const sasjsout = `
     end;
     else do;
       /* More recently, SASjs apps avoid inline JS to allow strict CSP */
-      length infile $32767;
+      length infile in1 in2 $32767;
       infile=cats(_infile_);
       spos1=index(upcase(infile),'APPLOC="');
       if spos1>0 then do;
         in1=substr(infile,1,spos1+7);
-        in2=subpad(infile,spos1+8,length(infile)-8);
+        in2=subpad(infile,spos1+8);
         in2=substr(in2,index(in2,'"'));
         infile=cats(in1,appLoc,in2);
         putlog "new apploc:  " infile=;
@@ -126,10 +126,10 @@ export const sasjsout = `
       spos2=index(upcase(infile),'SERVERTYPE="');
       if spos2>0 then do;
         in1=substr(infile,1,spos2+11);
-        in2=subpad(infile,spos2+13,length(infile)-13);
+        in2=subpad(infile,spos2+12);
         in2=substr(in2,index(in2,'"'));
         if symexist('sasjsprocessmode') then infile=cats(in1,"SASJS",in2);
-        else if "&sysprocessmode"="SAS Object Server" 
+        else if "&sysprocessmode"="SAS Object Server"
         or "&sysprocessmode"= "SAS Compute Server"
         then infile=cats(in1,"SASVIYA",in2);
         else infile=cats(in1,"SAS9",in2);
@@ -139,9 +139,9 @@ export const sasjsout = `
       spos3=index(upcase(infile),'SERVERURL="');
       if spos3>0 then do;
         in1=substr(infile,1,spos3+10);
-        in2=subpad(infile,spos3+12,length(infile)-12);
+        in2=subpad(infile,spos3+11);
         in2=substr(in2,index(in2,'"'));
-        infile=catx(' ',in1,in2);
+        infile=cats(in1,in2);
         putlog "new serverUrl:  " infile=;
       end;
       if sum(spos1,spos2,spos3)>0 then put infile;

--- a/src/commands/web/internal/sasjsout.ts
+++ b/src/commands/web/internal/sasjsout.ts
@@ -119,8 +119,8 @@ export const sasjsout = `
         in1=substr(infile,1,spos1+7);
         in2=subpad(infile,spos1+8,length(infile)-8);
         in2=substr(in2,index(in2,'"'));
-        infile=cats(in1,"NEWAPPLOC",in2);
-        put "new apploc:  " infile=;
+        infile=cats(in1,appLoc,in2);
+        putlog "new apploc:  " infile=;
       end;
       /* find & replace serverType in HTML attributes */
       spos2=index(upcase(infile),'SERVERTYPE="');
@@ -128,12 +128,12 @@ export const sasjsout = `
         in1=substr(infile,1,spos2+11);
         in2=subpad(infile,spos2+13,length(infile)-13);
         in2=substr(in2,index(in2,'"'));
-        if symexist('sasjsprocessmode') then infile=cats(in1,"SAS9",in2);
+        if symexist('sasjsprocessmode') then infile=cats(in1,"SASJS",in2);
         else if "&sysprocessmode"="SAS Object Server" 
         or "&sysprocessmode"= "SAS Compute Server"
         then infile=cats(in1,"SASVIYA",in2);
-        else infile=cats(in1,"SASJS",in2);
-        put "new servertype:  " infile=;
+        else infile=cats(in1,"SAS9",in2);
+        putlog "new servertype:  " infile=;
       end;
       /* find & replace serverUrl in HTML attributes */
       spos3=index(upcase(infile),'SERVERURL="');
@@ -142,7 +142,7 @@ export const sasjsout = `
         in2=subpad(infile,spos3+12,length(infile)-12);
         in2=substr(in2,index(in2,'"'));
         infile=catx(' ',in1,in2);
-        put "new serverUrl:  " infile=;
+        putlog "new serverUrl:  " infile=;
       end;
       if sum(spos1,spos2,spos3)>0 then put infile;
       else do;


### PR DESCRIPTION
Where attributes are HTML tags rather than a JS object.

## Issue

No issue - but the problem has arisen in contexts where strict CSP is applied.

## Intent

Avoid dependency on JS objects in index.html

## Implementation

SAS code updated in a backwards compatible fashion

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
![image](https://user-images.githubusercontent.com/83717836/171841227-077da543-7a2e-49a9-a086-542566c77a99.png)
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
Mocked:
![image](https://user-images.githubusercontent.com/83717836/171842523-6da28fdf-6608-473f-922a-096babbed8d3.png)
Server(without `request.spec.server` and `run.spec.server`):
![image](https://user-images.githubusercontent.com/83717836/171844722-08c0c1d5-5a6e-4260-b5bc-13dd4e9ef946.png)
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
