### PR TITLE
fix: bumping core to fix the latin1 sas9 issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "3.9.4",
-        "@sasjs/core": "^4.32.1",
+        "@sasjs/core": "^4.32.2",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.45.0",
         "adm-zip": "0.5.9",
@@ -2121,9 +2121,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.32.1.tgz",
-      "integrity": "sha512-1iG6D5Y8gAX51ft6vIKyb8sxgzQeMG8K26Jwilvvrl1MBrIzIuUCBDGbCnok9FjZJzQ/Zjl3Z5nbIJlW2+rN/A=="
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.32.2.tgz",
+      "integrity": "sha512-WQ0H/RCUIMQdQDUtMxJu3uYIAe2LMl6I1OgdZICXP3GCt8Vj4N0usAHCTuODjRX/Z48k2gir5COuRGG4c9GFAg=="
     },
     "node_modules/@sasjs/lint": {
       "version": "1.11.2",
@@ -9697,9 +9697,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.32.1.tgz",
-      "integrity": "sha512-1iG6D5Y8gAX51ft6vIKyb8sxgzQeMG8K26Jwilvvrl1MBrIzIuUCBDGbCnok9FjZJzQ/Zjl3Z5nbIJlW2+rN/A=="
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.32.2.tgz",
+      "integrity": "sha512-WQ0H/RCUIMQdQDUtMxJu3uYIAe2LMl6I1OgdZICXP3GCt8Vj4N0usAHCTuODjRX/Z48k2gir5COuRGG4c9GFAg=="
     },
     "@sasjs/lint": {
       "version": "1.11.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "3.9.4",
-    "@sasjs/core": "4.32.1",
+    "@sasjs/core": "4.32.2",
     "@sasjs/lint": "1.11.2",
     "@sasjs/utils": "2.45.0",
     "adm-zip": "0.5.9",


### PR DESCRIPTION
## Issue

The previous change caused problems with webout on wlatin1 encoded SAS 9 Stored Process windows environments

## Intent

Fix the aforementioned issue

## Implementation

Bumped core to enable this fix: https://github.com/sasjs/core/pull/266

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
