### PR TITLE
feat: enabling choice of serverName in SAS 9 code deploys

### DIFF
--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -130,7 +130,7 @@ async function getBuildInfo(target: Target, streamWeb: boolean) {
   // The buildConfig variable contains the files for which we are fetching
   // dependencies, eg mv_createwebservice.sas and mv_createfile.sas
   let buildConfig = ''
-  const { serverType, appLoc } = target
+  const { serverType, appLoc, serverName } = target
   const macroFolders = await getMacroFolders(target)
 
   const createWebServiceScript = await getCreateWebServiceScript(serverType)
@@ -197,6 +197,8 @@ async function getBuildInfo(target: Target, streamWeb: boolean) {
 
 %global appLoc serverName;
 %let compiled_apploc=${appLoc};
+
+${serverType === ServerType.Sas9 ? `%let serverName=${serverName};` : ''}
 
 %let appLoc=%sysfunc(coalescec(&appLoc,&compiled_apploc));
 

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -195,7 +195,7 @@ async function getBuildInfo(target: Target, streamWeb: boolean) {
   *
   */
 
-%global appLoc;
+%global appLoc serverName;
 %let compiled_apploc=${appLoc};
 
 %let appLoc=%sysfunc(coalescec(&appLoc,&compiled_apploc));

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -262,7 +262,7 @@ function getWebServiceScriptInvocation(
         ? `%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode ,replace=yes)`
         : `%mv_createfile(path=&appLoc/&path, name=&filename, inref=filecode${encodedParam})`
     case ServerType.Sas9:
-      return `%mm_createwebservice(path=&appLoc/&path, name=&service, code=sascode ,replace=yes)`
+      return `%mm_createwebservice(path=&appLoc/&path, name=&service, code=sascode, server=&serverName, replace=yes)`
     case ServerType.Sasjs:
       return isSASFile
         ? `%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode ,replace=yes)`


### PR DESCRIPTION
## Issue

#1218

## Intent

Enable the choice of serverName when deploying to SAS 9 with SAS code

## Implementation

* Added server=&serverName to build.ts mm_createwebservice invocation
* Added `%let servername=$(servername);` to the build.sas where servertype is SAS9

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
