### PR TITLE
fix(web): compiling for SAS9 streaming, replaced three slashes with GUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "3.9.4",
-        "@sasjs/core": "^4.32.2",
+        "@sasjs/core": "4.32.2",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.45.0",
         "adm-zip": "0.5.9",

--- a/src/commands/compile/internal/spec/compileTestFile.spec.ts
+++ b/src/commands/compile/internal/spec/compileTestFile.spec.ts
@@ -256,13 +256,16 @@ describe('compileTestFile', () => {
 
       await compile(target)
 
-      expect(process.logger.info).toHaveBeenCalledTimes(15)
+      const totalCalls = 16
+
+      expect(process.logger.info).toHaveBeenCalledTimes(totalCalls)
       expect(process.logger.info).toHaveBeenNthCalledWith(13, `Test coverage:`)
       expect(process.logger.info).toHaveBeenNthCalledWith(
         14,
         `Services coverage: 0/4 (${chalk.greenBright('0%')})`
       )
-      expect(process.logger.info).toHaveBeenLastCalledWith(
+      expect(process.logger.info).toHaveBeenNthCalledWith(
+        totalCalls - 1,
         `Overall coverage: 0/4 (${chalk.greenBright('0%')})`
       )
     })

--- a/src/commands/compile/internal/spec/compileTestFile.spec.ts
+++ b/src/commands/compile/internal/spec/compileTestFile.spec.ts
@@ -103,7 +103,7 @@ describe('compileTestFile', () => {
 %put testing, termed;
 * TestTerm end;`)
 
-        const mvWebout = `%macro mv_webout(action,ds,fref=_mvwtemp,dslabel=,fmt=Y,stream=Y,missing=NULL<br>  ,showmeta=NO<br>);`
+        const mvWebout = `%macro mv_webout(action,ds,fref=_mvwtemp,dslabel=,fmt=Y,stream=Y,missing=NULL<br>  ,showmeta=N`
 
         expect(testFileContent.indexOf(testVar)).toBeGreaterThan(-1)
         expect(testFileContent.indexOf(testInit)).toBeGreaterThan(-1)

--- a/src/commands/deploy/spec/cbd.spec.ts
+++ b/src/commands/deploy/spec/cbd.spec.ts
@@ -1,12 +1,17 @@
 import SASjs from '@sasjs/adapter/node'
+import { encode } from 'js-base64'
 import {
   ServerType,
   Target,
   generateTimestamp,
   readFile,
-  StreamConfig
+  ServiceConfig
 } from '@sasjs/utils'
-import { createTestMinimalApp, removeTestApp } from '../../../utils/test'
+import {
+  createTestMinimalApp,
+  removeTestApp,
+  updateConfig
+} from '../../../utils/test'
 import { TargetScope } from '../../../types'
 import { build } from '../../build/build'
 import { deploy } from '../deploy'
@@ -42,6 +47,12 @@ describe('sasjs cbd with server type SASJS', () => {
       })
     )
 
+    await updateConfig({
+      serviceConfig: {
+        serviceFolders: ['sasjs/services/common']
+      } as ServiceConfig
+    })
+
     await updateLocalTarget(target.name, {
       jobConfig: undefined,
       serviceConfig: undefined,
@@ -72,13 +83,6 @@ describe('sasjs cbd with server type SASJS', () => {
       '    )' +
       '  %mend;\n'
 
-    const streamConfig: StreamConfig = {
-      assetPaths: [],
-      streamServiceName: 'clickme',
-      streamWeb: false,
-      streamWebFolder: '',
-      webSourcePath: ''
-    }
     expect(sasjs.deployToSASjs).toHaveBeenCalledWith(
       {
         appLoc: target.appLoc,
@@ -93,11 +97,25 @@ describe('sasjs cbd with server type SASJS', () => {
                   type: 'folder',
                   members: [
                     {
+                      name: 'appinit.js',
+                      type: 'file',
+                      code: encode(
+                        `// mock a constant in the pre-existing _webout variable\n_webout = \`\n{"SYSDATE":"21JUN22","SYSTIME":"16:46","areas":[{"AREA":"Adak"},{"AREA":"Adel"},{"AREA":"Afognak"},{"AREA":"Ajo"},{"AREA":"Albany"},{"AREA":"Albuquerque"},{"AREA":"Alturas"},{"AREA":"Ashton"},{"AREA":"Atka"},{"AREA":"Atlanta"},{"AREA":"Attu"},{"AREA":"Aztec"},{"AREA":"Baker"},{"AREA":"Bakersfield"},{"AREA":"Baltimore"},{"AREA":"Beaver"},{"AREA":"Bend"},{"AREA":"Bendeleben"},{"AREA":"Bering Glacier"},{"AREA":"Bettles"},{"AREA":"Bluefield"},{"AREA":"Boise"},{"AREA":"Bozeman"},{"AREA":"Bradfield Cana"},{"AREA":"Brigham City"},{"AREA":"Burns"},{"AREA":"Butte"},{"AREA":"Caliente"},{"AREA":"Candle"},{"AREA":"Canyon City"},{"AREA":"Carlsbad"},{"AREA":"Casper"},{"AREA":"Cedar City"},{"AREA":"Challis"},{"AREA":"Charley River"},{"AREA":"Charlottesvill"},{"AREA":"Chico"},{"AREA":"Chignik"},{"AREA":"Choteau"},{"AREA":"Circle"},{"AREA":"Clifton"},{"AREA":"Cody"},{"AREA":"Cold Bay"},{"AREA":"Concrete"},{"AREA":"Cortez"},{"AREA":"Craig"},{"AREA":"Crescent"},{"AREA":"Cumberland"},{"AREA":"Death Valley"},{"AREA":"Delta"},{"AREA":"Denver"},{"AREA":"Dillon"},{"AREA":"Douglas"},{"AREA":"Driggs"},{"AREA":"Dubois"},{"AREA":"Durango"},{"AREA":"El Centro"},{"AREA":"Elk City"},{"AREA":"Elko"},{"AREA":"Ely"},{"AREA":"Emory Peak"},{"AREA":"Escalante"},{"AREA":"False Pass"},{"AREA":"Fresno"},{"AREA":"Gareloi Island"},{"AREA":"Goldfield"},{"AREA":"Grand Canyon"},{"AREA":"Grangeville"},{"AREA":"Gulkana"},{"AREA":"Hailey"},{"AREA":"Hamilton"},{"AREA":"Hawaii"},{"AREA":"Holbrook"},{"AREA":"Hoquiam"},{"AREA":"Hot Springs"},{"AREA":"Hughes"},{"AREA":"Idaho Falls"},{"AREA":"Iditarod"},{"AREA":"Jordan Valley"},{"AREA":"Ketchikan"},{"AREA":"Kingman"},{"AREA":"Klamath Falls"},{"AREA":"Knoxville"},{"AREA":"Lander"},{"AREA":"Las Cruces"},{"AREA":"Las Vegas"},{"AREA":"Leadville"},{"AREA":"Lewistown"},{"AREA":"Little Rock"},{"AREA":"Livengood"},{"AREA":"Long Beach"},{"AREA":"Los Angeles"},{"AREA":"Lovelock"},{"AREA":"Lukeville"},{"AREA":"Lund"},{"AREA":"Marble Canyon"},{"AREA":"Marfa"},{"AREA":"Mariposa"},{"AREA":"Mcdermitt"},{"AREA":"Medford"},{"AREA":"Melozitna"},{"AREA":"Mesa"},{"AREA":"Millett"},{"AREA":"Moab"},{"AREA":"Montrose"},{"AREA":"Mt. Fairweathe"},{"AREA":"Mt. Katmai"},{"AREA":"Mt. Mckinley"},{"AREA":"Mt. Michelson"},{"AREA":"Needles"},{"AREA":"Nogales"},{"AREA":"Nulato"},{"AREA":"Ogden"},{"AREA":"Okanogan"},{"AREA":"Pendleton"},{"AREA":"Petersburg"},{"AREA":"Phenix City"},{"AREA":"Phoenix"},{"AREA":"Phoenix South"},{"AREA":"Pocatello"},{"AREA":"Poplar Bluff"},{"AREA":"Port Alexander"},{"AREA":"Port Moller"},{"AREA":"Prescott"},{"AREA":"Presidio"},{"AREA":"Preston"},{"AREA":"Price"},{"AREA":"Pueblo"},{"AREA":"Rat Islands"},{"AREA":"Raton"},{"AREA":"Rawlins"},{"AREA":"Redding"},{"AREA":"Reno"},{"AREA":"Richfield"},{"AREA":"Roanoke"},{"AREA":"Roseburg"},{"AREA":"Roundup"},{"AREA":"Ruby"},{"AREA":"Russian Missio"},{"AREA":"Sacramento"},{"AREA":"Saint Johns"},{"AREA":"Salem"},{"AREA":"Salina"},{"AREA":"Salt Lake City"},{"AREA":"Salton Sea"},{"AREA":"Samalga Island"},{"AREA":"San Bernardino"},{"AREA":"San Diego"},{"AREA":"San Francisco"},{"AREA":"San Jose"},{"AREA":"San Luis Obisp"},{"AREA":"Santa Ana"},{"AREA":"Santa Cruz"},{"AREA":"Santa Fe"},{"AREA":"Santa Maria"},{"AREA":"Santa Rosa"},{"AREA":"Seattle"},{"AREA":"Seguam"},{"AREA":"Shungnak"},{"AREA":"Silver City"},{"AREA":"Sitka"},{"AREA":"Sleetmute"},{"AREA":"Socorro"},{"AREA":"Solomon"},{"AREA":"Survey Pass"},{"AREA":"Susanville"},{"AREA":"Tampa"},{"AREA":"Tanana"},{"AREA":"The Dalles"},{"AREA":"Thermopolis"},{"AREA":"Tonopah"},{"AREA":"Tooele"},{"AREA":"Torrington"},{"AREA":"Trinidad"},{"AREA":"Trona"},{"AREA":"Tucson"},{"AREA":"Tularosa"},{"AREA":"Twin Falls"},{"AREA":"Tyonek"},{"AREA":"Ugashik"},{"AREA":"Ukiah"},{"AREA":"Umnak"},{"AREA":"Unalaska"},{"AREA":"Unimak"},{"AREA":"Vancouver"},{"AREA":"Vernal"},{"AREA":"Vya"},{"AREA":"Walker Lake"},{"AREA":"Walla Walla"},{"AREA":"Wallace"},{"AREA":"Weed"},{"AREA":"Wells"},{"AREA":"Wenatchee"},{"AREA":"White Sulphur"},{"AREA":"Williams"},{"AREA":"Winnemucca"},{"AREA":"Yakima"}],\n"SYSUSERID":"sasjs"\n,"MF_GETUSER":"sasjs","_DEBUG":"",\n"_PROGRAM":"/Public/app/minimal-seed-app/services/common/appinit",\n"SYSCC":"0",\n"SYSERRORTEXT":"",\n"SYSHOSTINFOLONG":"",\n"SYSHOSTNAME":"sas",\n"SYSPROCESSID":"41DD607B5567F09E0000000000000000",\n"SYSPROCESSMODE":"Stored Program",\n"SYSPROCESSNAME":"",\n"SYSJOBID":"540520",\n"SYSSCPL":"LINUX",\n"SYSSITE":"0",\n"SYSTCPIPHOSTNAME":"https://sasjs.com",\n"SYSVLONG":"",\n"SYSWARNINGTEXT":"",\n"END_DTTM":"2022-06-21T16:46:40.740543",\n"AUTOEXEC":" ",\n"MEMSIZE":"0KB"}\n\`;\n\nconsole.log(_webout)\n`
+                      )
+                    },
+                    {
                       name: 'appinit',
                       type: 'service',
                       code: removeComments(
                         `${mf_getuser}${mp_jsonout}${ms_webout}${webout}` +
-                          '/* provide additional debug info */\n%global _program;\n%put &=syscc;\n%put user=%mf_getuser();\n%put pgm=&_program;\n%put timestamp=%sysfunc(datetime(),datetime19.);\n* Service Variables start;\n* Service Variables end;\n* SAS Macros start;\n* SAS Macros end;\n* SAS Includes start;\n* SAS Includes end;\n* Binary Files start;\n* Binary Files end;\n* Service start;\nproc sql;\ncreate table areas as select distinct area\n  from sashelp.springs;\n%webout(OPEN)\n%webout(OBJ,areas)\n%webout(CLOSE)\n* Service end;'
+                          '/* provide additional debug info */\n%global _program;\n%put &=syscc;\n%put user=%mf_getuser();\n%put pgm=&_program;\n%put timestamp=%sysfunc(datetime(),datetime19.);\n* Service Variables start;\n* Service Variables end;\n* SAS Macros start;\n* SAS Macros end;\n* SAS Includes start;\n* SAS Includes end;\n* Binary Files start;\n* Binary Files end;\n* Service start;\nproc sql;\ncreate table areas as select distinct area\n  from mydb.springs;\n%webout(OPEN)\n%webout(OBJ,areas)\n%webout(CLOSE)\n* Service end;'
+                      )
+                    },
+                    {
+                      name: 'getdata.js',
+                      type: 'file',
+                      code: encode(
+                        `// this file will take input and return a response\n\n_webout = \`\n{"SYSDATE":"21JUN22","SYSTIME":"17:59","springs":[{"LATITUDE":51.925,"LONGITUDE":-177.16,"NAME":"Fumaroles on Kanaga Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":219,"CELSIUS":104},{"LATITUDE":52.042,"LONGITUDE":-176.108,"NAME":"Hot Springs on Great Sitkin Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":210,"CELSIUS":99},{"LATITUDE":51.81,"LONGITUDE":-177.79,"NAME":"Hot Spring on Tanaga Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":null,"CELSIUS":null},{"LATITUDE":51.97,"LONGITUDE":-176.61,"NAME":"Hot Springs on Adak Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":154,"CELSIUS":68}],\n"SYSUSERID":"sasjsuser",\n"MF_GETUSER":"SASjs User",\n"_DEBUG":"",\n"_PROGRAM":"/Public/app/minimal-seed-app/services/common/getdata",\n"SYSCC":"0",\n"SYSERRORTEXT":"","SYSHOSTINFOLONG":"","SYSHOSTNAME":"sas",\n"SYSPROCESSID":"41DD607F9C7200B90000000000000000",\n"SYSPROCESSMODE":"Stored Program","SYSPROCESSNAME":"",\n"SYSJOBID":"542908",\n"SYSSCPL":"LINUX","SYSSITE":"0",\n"SYSTCPIPHOSTNAME":"https://sasjs.com",\n"SYSVLONG":"",\n"SYSWARNINGTEXT":"",\n"END_DTTM":"2022-06-21T17:59:14.515731",\n"AUTOEXEC":"","MEMSIZE":"0KB"}\n\`;\n`
                       )
                     },
                     {
@@ -105,7 +123,7 @@ describe('sasjs cbd with server type SASJS', () => {
                       type: 'service',
                       code: removeComments(
                         `${mf_getuser}${mp_jsonout}${ms_webout}${webout}` +
-                          '/* provide additional debug info */\n%global _program;\n%put &=syscc;\n%put user=%mf_getuser();\n%put pgm=&_program;\n%put timestamp=%sysfunc(datetime(),datetime19.);\n* Service Variables start;\n* Service Variables end;\n* SAS Macros start;\n* SAS Macros end;\n* SAS Includes start;\n* SAS Includes end;\n* Binary Files start;\n* Binary Files end;\n* Service start;\n%webout(FETCH)\nproc sql;\ncreate table springs as select * from sashelp.springs\n  where area in (select area from work.areas);\n%webout(OPEN)\n%webout(OBJ,springs)\n%webout(CLOSE)\n* Service end;'
+                          '/* provide additional debug info */\n%global _program;\n%put &=syscc;\n%put user=%mf_getuser();\n%put pgm=&_program;\n%put timestamp=%sysfunc(datetime(),datetime19.);\n* Service Variables start;\n* Service Variables end;\n* SAS Macros start;\n* SAS Macros end;\n* SAS Includes start;\n* SAS Includes end;\n* Binary Files start;\n* Binary Files end;\n* Service start;\n%webout(FETCH)\nproc sql;\ncreate table springs as select * from mydb.springs\n  where area in (select area from work.areas);\n%webout(OPEN)\n%webout(OBJ,springs)\n%webout(CLOSE)\n* Service end;'
                       )
                     }
                   ]

--- a/src/commands/deploy/spec/cbd.spec.ts
+++ b/src/commands/deploy/spec/cbd.spec.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import SASjs from '@sasjs/adapter/node'
 import { encode } from 'js-base64'
 import {
@@ -83,6 +84,23 @@ describe('sasjs cbd with server type SASJS', () => {
       '    )' +
       '  %mend;\n'
 
+    const mocksPath = path.join(__dirname, appName, 'sasjs', 'mocks')
+    const appinitJSPath = path.join(
+      mocksPath,
+      'services',
+      'common',
+      'appinit.js'
+    )
+    const getdataJSPath = path.join(
+      mocksPath,
+      'services',
+      'common',
+      'getdata.js'
+    )
+
+    const appinitJSContents = await readFile(appinitJSPath)
+    const getdataJSContents = await readFile(getdataJSPath)
+
     expect(sasjs.deployToSASjs).toHaveBeenCalledWith(
       {
         appLoc: target.appLoc,
@@ -99,9 +117,7 @@ describe('sasjs cbd with server type SASJS', () => {
                     {
                       name: 'appinit.js',
                       type: 'file',
-                      code: encode(
-                        `// mock a constant in the pre-existing _webout variable\n_webout = \`\n{"SYSDATE":"21JUN22","SYSTIME":"16:46","areas":[{"AREA":"Adak"},{"AREA":"Adel"},{"AREA":"Afognak"},{"AREA":"Ajo"},{"AREA":"Albany"},{"AREA":"Albuquerque"},{"AREA":"Alturas"},{"AREA":"Ashton"},{"AREA":"Atka"},{"AREA":"Atlanta"},{"AREA":"Attu"},{"AREA":"Aztec"},{"AREA":"Baker"},{"AREA":"Bakersfield"},{"AREA":"Baltimore"},{"AREA":"Beaver"},{"AREA":"Bend"},{"AREA":"Bendeleben"},{"AREA":"Bering Glacier"},{"AREA":"Bettles"},{"AREA":"Bluefield"},{"AREA":"Boise"},{"AREA":"Bozeman"},{"AREA":"Bradfield Cana"},{"AREA":"Brigham City"},{"AREA":"Burns"},{"AREA":"Butte"},{"AREA":"Caliente"},{"AREA":"Candle"},{"AREA":"Canyon City"},{"AREA":"Carlsbad"},{"AREA":"Casper"},{"AREA":"Cedar City"},{"AREA":"Challis"},{"AREA":"Charley River"},{"AREA":"Charlottesvill"},{"AREA":"Chico"},{"AREA":"Chignik"},{"AREA":"Choteau"},{"AREA":"Circle"},{"AREA":"Clifton"},{"AREA":"Cody"},{"AREA":"Cold Bay"},{"AREA":"Concrete"},{"AREA":"Cortez"},{"AREA":"Craig"},{"AREA":"Crescent"},{"AREA":"Cumberland"},{"AREA":"Death Valley"},{"AREA":"Delta"},{"AREA":"Denver"},{"AREA":"Dillon"},{"AREA":"Douglas"},{"AREA":"Driggs"},{"AREA":"Dubois"},{"AREA":"Durango"},{"AREA":"El Centro"},{"AREA":"Elk City"},{"AREA":"Elko"},{"AREA":"Ely"},{"AREA":"Emory Peak"},{"AREA":"Escalante"},{"AREA":"False Pass"},{"AREA":"Fresno"},{"AREA":"Gareloi Island"},{"AREA":"Goldfield"},{"AREA":"Grand Canyon"},{"AREA":"Grangeville"},{"AREA":"Gulkana"},{"AREA":"Hailey"},{"AREA":"Hamilton"},{"AREA":"Hawaii"},{"AREA":"Holbrook"},{"AREA":"Hoquiam"},{"AREA":"Hot Springs"},{"AREA":"Hughes"},{"AREA":"Idaho Falls"},{"AREA":"Iditarod"},{"AREA":"Jordan Valley"},{"AREA":"Ketchikan"},{"AREA":"Kingman"},{"AREA":"Klamath Falls"},{"AREA":"Knoxville"},{"AREA":"Lander"},{"AREA":"Las Cruces"},{"AREA":"Las Vegas"},{"AREA":"Leadville"},{"AREA":"Lewistown"},{"AREA":"Little Rock"},{"AREA":"Livengood"},{"AREA":"Long Beach"},{"AREA":"Los Angeles"},{"AREA":"Lovelock"},{"AREA":"Lukeville"},{"AREA":"Lund"},{"AREA":"Marble Canyon"},{"AREA":"Marfa"},{"AREA":"Mariposa"},{"AREA":"Mcdermitt"},{"AREA":"Medford"},{"AREA":"Melozitna"},{"AREA":"Mesa"},{"AREA":"Millett"},{"AREA":"Moab"},{"AREA":"Montrose"},{"AREA":"Mt. Fairweathe"},{"AREA":"Mt. Katmai"},{"AREA":"Mt. Mckinley"},{"AREA":"Mt. Michelson"},{"AREA":"Needles"},{"AREA":"Nogales"},{"AREA":"Nulato"},{"AREA":"Ogden"},{"AREA":"Okanogan"},{"AREA":"Pendleton"},{"AREA":"Petersburg"},{"AREA":"Phenix City"},{"AREA":"Phoenix"},{"AREA":"Phoenix South"},{"AREA":"Pocatello"},{"AREA":"Poplar Bluff"},{"AREA":"Port Alexander"},{"AREA":"Port Moller"},{"AREA":"Prescott"},{"AREA":"Presidio"},{"AREA":"Preston"},{"AREA":"Price"},{"AREA":"Pueblo"},{"AREA":"Rat Islands"},{"AREA":"Raton"},{"AREA":"Rawlins"},{"AREA":"Redding"},{"AREA":"Reno"},{"AREA":"Richfield"},{"AREA":"Roanoke"},{"AREA":"Roseburg"},{"AREA":"Roundup"},{"AREA":"Ruby"},{"AREA":"Russian Missio"},{"AREA":"Sacramento"},{"AREA":"Saint Johns"},{"AREA":"Salem"},{"AREA":"Salina"},{"AREA":"Salt Lake City"},{"AREA":"Salton Sea"},{"AREA":"Samalga Island"},{"AREA":"San Bernardino"},{"AREA":"San Diego"},{"AREA":"San Francisco"},{"AREA":"San Jose"},{"AREA":"San Luis Obisp"},{"AREA":"Santa Ana"},{"AREA":"Santa Cruz"},{"AREA":"Santa Fe"},{"AREA":"Santa Maria"},{"AREA":"Santa Rosa"},{"AREA":"Seattle"},{"AREA":"Seguam"},{"AREA":"Shungnak"},{"AREA":"Silver City"},{"AREA":"Sitka"},{"AREA":"Sleetmute"},{"AREA":"Socorro"},{"AREA":"Solomon"},{"AREA":"Survey Pass"},{"AREA":"Susanville"},{"AREA":"Tampa"},{"AREA":"Tanana"},{"AREA":"The Dalles"},{"AREA":"Thermopolis"},{"AREA":"Tonopah"},{"AREA":"Tooele"},{"AREA":"Torrington"},{"AREA":"Trinidad"},{"AREA":"Trona"},{"AREA":"Tucson"},{"AREA":"Tularosa"},{"AREA":"Twin Falls"},{"AREA":"Tyonek"},{"AREA":"Ugashik"},{"AREA":"Ukiah"},{"AREA":"Umnak"},{"AREA":"Unalaska"},{"AREA":"Unimak"},{"AREA":"Vancouver"},{"AREA":"Vernal"},{"AREA":"Vya"},{"AREA":"Walker Lake"},{"AREA":"Walla Walla"},{"AREA":"Wallace"},{"AREA":"Weed"},{"AREA":"Wells"},{"AREA":"Wenatchee"},{"AREA":"White Sulphur"},{"AREA":"Williams"},{"AREA":"Winnemucca"},{"AREA":"Yakima"}],\n"SYSUSERID":"sasjs"\n,"MF_GETUSER":"sasjs","_DEBUG":"",\n"_PROGRAM":"/Public/app/minimal-seed-app/services/common/appinit",\n"SYSCC":"0",\n"SYSERRORTEXT":"",\n"SYSHOSTINFOLONG":"",\n"SYSHOSTNAME":"sas",\n"SYSPROCESSID":"41DD607B5567F09E0000000000000000",\n"SYSPROCESSMODE":"Stored Program",\n"SYSPROCESSNAME":"",\n"SYSJOBID":"540520",\n"SYSSCPL":"LINUX",\n"SYSSITE":"0",\n"SYSTCPIPHOSTNAME":"https://sasjs.com",\n"SYSVLONG":"",\n"SYSWARNINGTEXT":"",\n"END_DTTM":"2022-06-21T16:46:40.740543",\n"AUTOEXEC":" ",\n"MEMSIZE":"0KB"}\n\`;\n\nconsole.log(_webout)\n`
-                      )
+                      code: encode(appinitJSContents)
                     },
                     {
                       name: 'appinit',
@@ -114,9 +130,7 @@ describe('sasjs cbd with server type SASJS', () => {
                     {
                       name: 'getdata.js',
                       type: 'file',
-                      code: encode(
-                        `// this file will take input and return a response\n\n_webout = \`\n{"SYSDATE":"21JUN22","SYSTIME":"17:59","springs":[{"LATITUDE":51.925,"LONGITUDE":-177.16,"NAME":"Fumaroles on Kanaga Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":219,"CELSIUS":104},{"LATITUDE":52.042,"LONGITUDE":-176.108,"NAME":"Hot Springs on Great Sitkin Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":210,"CELSIUS":99},{"LATITUDE":51.81,"LONGITUDE":-177.79,"NAME":"Hot Spring on Tanaga Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":null,"CELSIUS":null},{"LATITUDE":51.97,"LONGITUDE":-176.61,"NAME":"Hot Springs on Adak Island","AREA":"Adak","TYPE":"Hotspring","FARENHEIT":154,"CELSIUS":68}],\n"SYSUSERID":"sasjsuser",\n"MF_GETUSER":"SASjs User",\n"_DEBUG":"",\n"_PROGRAM":"/Public/app/minimal-seed-app/services/common/getdata",\n"SYSCC":"0",\n"SYSERRORTEXT":"","SYSHOSTINFOLONG":"","SYSHOSTNAME":"sas",\n"SYSPROCESSID":"41DD607F9C7200B90000000000000000",\n"SYSPROCESSMODE":"Stored Program","SYSPROCESSNAME":"",\n"SYSJOBID":"542908",\n"SYSSCPL":"LINUX","SYSSITE":"0",\n"SYSTCPIPHOSTNAME":"https://sasjs.com",\n"SYSVLONG":"",\n"SYSWARNINGTEXT":"",\n"END_DTTM":"2022-06-21T17:59:14.515731",\n"AUTOEXEC":"","MEMSIZE":"0KB"}\n\`;\n`
-                      )
+                      code: encode(getdataJSContents)
                     },
                     {
                       name: 'getdata',

--- a/src/commands/testing/spec/testing.spec.ts
+++ b/src/commands/testing/spec/testing.spec.ts
@@ -22,7 +22,9 @@ import * as sasJsModules from '../../../utils/createSASjsInstance'
 import { testResponses } from './mockedAdapter/testResponses'
 import * as fileModule from '@sasjs/utils/file'
 import * as utilsModule from '@sasjs/utils/utils'
+import * as configUtils from '../../../utils/config'
 import chalk from 'chalk'
+import { mockAuthConfig } from '../../context/spec/mocks'
 
 describe('sasjs test', () => {
   const expectedCoverageLcov = `TN:testsetup.sas
@@ -893,6 +895,10 @@ const copyTestFiles = async (appName: string) => {
 }
 
 const setupMocksForSASVIYA = () => {
+  jest
+    .spyOn(configUtils, 'getAuthConfig')
+    .mockImplementation(() => Promise.resolve(mockAuthConfig))
+
   jest
     .spyOn(sasJsModules, 'createSASjsInstance')
     .mockImplementation((config: Partial<SASjsConfig>) => {

--- a/src/commands/web/internal/createAssetServices.ts
+++ b/src/commands/web/internal/createAssetServices.ts
@@ -186,6 +186,6 @@ const getAssetPath = (
     // for Viya, fileName is a FILE, with replacement in build.sas only
     serverType === ServerType.SasViya
       ? `/SASJobExecution?_FILE=${appLoc}/services/${streamWebFolder}`
-      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}/${streamWebFolder}`
+      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}${streamWebFolder}`
   return `${storedProcessPath}/${fileName}`
 }

--- a/src/commands/web/internal/createAssetServices.ts
+++ b/src/commands/web/internal/createAssetServices.ts
@@ -157,6 +157,7 @@ const getAssetPath = (
   streamWebFolder: string,
   fileName: string
 ) => {
+  const { sas9GUID } = process.sasjsConstants
   const storedProcessPath =
     // the appLoc is inserted dynamically by SAS
     // using three forward slashes as a marker
@@ -164,6 +165,6 @@ const getAssetPath = (
     // for Viya, fileName is a FILE, with replacement in build.sas only
     serverType === ServerType.SasViya
       ? `/SASJobExecution?_FILE=${appLoc}/services/${streamWebFolder}`
-      : `/SASStoredProcess/?_PROGRAM=///${streamWebFolder}`
+      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}${streamWebFolder}`
   return `${storedProcessPath}/${fileName}`
 }

--- a/src/commands/web/internal/createAssetServices.ts
+++ b/src/commands/web/internal/createAssetServices.ts
@@ -186,6 +186,6 @@ const getAssetPath = (
     // for Viya, fileName is a FILE, with replacement in build.sas only
     serverType === ServerType.SasViya
       ? `/SASJobExecution?_FILE=${appLoc}/services/${streamWebFolder}`
-      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}${streamWebFolder}`
+      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}/${streamWebFolder}`
   return `${storedProcessPath}/${fileName}`
 }

--- a/src/commands/web/internal/getAssetPath.ts
+++ b/src/commands/web/internal/getAssetPath.ts
@@ -8,12 +8,12 @@ export const getAssetPath = (
 ) => {
   const { sas9GUID } = process.sasjsConstants
   const storedProcessPath =
-    // the appLoc is inserted dynamically by SAS
-    // using three forward slashes as a marker
-    // for SAS 9 fileName is a program, with replacement in sasjsout.ts
-    // for Viya, fileName is a FILE, with replacement in build.sas only
+    // the appLoc is inserted dynamically
+    // for SAS 9 files are Base 64 encoded into STPs, with
+    //   dynamic runtime replacement of appLoc (see sasjsout.ts)
+    // for Viya, fileName is a FILE, with replacement harcoded in build.sas
     serverType === ServerType.SasViya
-      ? `/SASJobExecution?_FILE=${appLoc}/services/${streamWebFolder}`
-      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}/${streamWebFolder}`
-  return `${storedProcessPath}/${fileName}`
+      ? `/SASJobExecution?_FILE=${appLoc}/services`
+      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}`
+  return `${storedProcessPath}/${streamWebFolder}/${fileName}`
 }

--- a/src/commands/web/internal/getAssetPath.ts
+++ b/src/commands/web/internal/getAssetPath.ts
@@ -1,0 +1,19 @@
+import { ServerType } from '@sasjs/utils'
+
+export const getAssetPath = (
+  appLoc: string,
+  serverType: ServerType,
+  streamWebFolder: string,
+  fileName: string
+) => {
+  const { sas9GUID } = process.sasjsConstants
+  const storedProcessPath =
+    // the appLoc is inserted dynamically by SAS
+    // using three forward slashes as a marker
+    // for SAS 9 fileName is a program, with replacement in sasjsout.ts
+    // for Viya, fileName is a FILE, with replacement in build.sas only
+    serverType === ServerType.SasViya
+      ? `/SASJobExecution?_FILE=${appLoc}/services/${streamWebFolder}`
+      : `/SASStoredProcess/?_PROGRAM=${sas9GUID}/${streamWebFolder}`
+  return `${storedProcessPath}/${fileName}`
+}

--- a/src/commands/web/internal/getWebServiceContent.ts
+++ b/src/commands/web/internal/getWebServiceContent.ts
@@ -8,10 +8,11 @@ export const getWebServiceContent = async (
 ) => {
   let lines = [contentBase64]
 
-  // Encode to base64 *.js and *.css files if target server type is SAS 9.
+  // Encode to base64 *.svg, *.js and *.css files if target server type is SAS 9.
   const typesToEncode: { [key: string]: string } = {
     JS: 'JS64',
-    CSS: 'CSS64'
+    CSS: 'CSS64',
+    SVG: 'SVG64'
   }
 
   let serviceContent = `${sasjsout()}\nfilename sasjs temp lrecl=99999999;

--- a/src/commands/web/internal/getWebServiceContent.ts
+++ b/src/commands/web/internal/getWebServiceContent.ts
@@ -14,7 +14,7 @@ export const getWebServiceContent = async (
     CSS: 'CSS64'
   }
 
-  let serviceContent = `${sasjsout}\nfilename sasjs temp lrecl=99999999;
+  let serviceContent = `${sasjsout()}\nfilename sasjs temp lrecl=99999999;
 data _null_;
 file sasjs;
 `

--- a/src/commands/web/internal/modifyLinksInContent.ts
+++ b/src/commands/web/internal/modifyLinksInContent.ts
@@ -1,0 +1,15 @@
+import { AssetPathMap } from './createAssetServices'
+
+export const modifyLinksInContent = (
+  _content: string,
+  assetPathMap: AssetPathMap[]
+) => {
+  let content = _content
+  assetPathMap.forEach((pathEntry) => {
+    content = content.replace(
+      new RegExp(pathEntry.source, 'g'),
+      pathEntry.target
+    )
+  })
+  return content
+}

--- a/src/commands/web/internal/sas9/createClickMeService.ts
+++ b/src/commands/web/internal/sas9/createClickMeService.ts
@@ -1,0 +1,45 @@
+import path from 'path'
+import { chunk, createFile } from '@sasjs/utils'
+import { sasjsout } from '../sasjsout'
+
+/**
+ * Creates index service file for SAS9 server only.
+ * @param {string} indexHtmlContent contents of index source file.
+ * @param {string} fileName name of index service file.
+ */
+export const createClickMeService = async (
+  indexHtmlContent: string,
+  fileName: string
+) => {
+  const lines = indexHtmlContent.replace(/\r\n/g, '\n').split('\n')
+  let clickMeServiceContent = `${sasjsout()}\nfilename sasjs temp lrecl=99999999;\ndata _null_;\nfile sasjs;\n`
+
+  lines.forEach((line) => {
+    const chunkedLines = chunk(line)
+    if (chunkedLines.length === 1) {
+      if (chunkedLines[0].length == 0) chunkedLines[0] = ' '
+
+      clickMeServiceContent += `put '${chunkedLines[0]
+        .split("'")
+        .join("''")}';\n`
+    } else {
+      let combinedLines = ''
+      chunkedLines.forEach((chunkedLine, index) => {
+        let text = `put '${chunkedLine.split("'").join("''")}'`
+        if (index !== chunkedLines.length - 1) {
+          text += '@;\n'
+        } else {
+          text += ';\n'
+        }
+        combinedLines += text
+      })
+      clickMeServiceContent += combinedLines
+    }
+  })
+  clickMeServiceContent += 'run;\n%sasjsout(HTML)'
+  const { buildDestinationServicesFolder } = process.sasjsConstants
+  await createFile(
+    path.join(buildDestinationServicesFolder, `${fileName}.sas`),
+    clickMeServiceContent
+  )
+}

--- a/src/commands/web/internal/sas9/generateAssetService.ts
+++ b/src/commands/web/internal/sas9/generateAssetService.ts
@@ -1,0 +1,30 @@
+import path from 'path'
+import { base64EncodeFile, createFile } from '@sasjs/utils'
+import { getWebServiceContent } from './'
+
+/**
+ * Creates service file for SAS9 server only.
+ * @param {string} sourcePath path of source file.
+ * @param {string} destinationPath path of destination service file.
+ * @returns {string} name of created service file.
+ */
+export const generateAssetService = async (
+  sourcePath: string,
+  destinationPath: string
+): Promise<string> => {
+  const fileExtension = path.extname(sourcePath)
+  const fileType = fileExtension.replace('.', '').toUpperCase()
+  const fileName = path
+    .basename(sourcePath)
+    .replace(new RegExp(fileExtension + '$'), fileExtension.replace('.', '-'))
+  const base64string = await base64EncodeFile(sourcePath)
+
+  const serviceContent = await getWebServiceContent(base64string, fileType)
+
+  await createFile(
+    path.join(destinationPath, `${fileName}.sas`),
+    serviceContent
+  )
+
+  return `${fileName}.sas`
+}

--- a/src/commands/web/internal/sas9/getWebServiceContent.ts
+++ b/src/commands/web/internal/sas9/getWebServiceContent.ts
@@ -1,10 +1,15 @@
-import { ServerType, chunk } from '@sasjs/utils'
-import { sasjsout } from './sasjsout'
+import { chunk } from '@sasjs/utils'
+import { sasjsout } from '../sasjsout'
 
+/**
+ * Prepares service code for SAS9 server only.
+ * @param {string} contentBase64 source code in base64.
+ * @param {string} type extension of source code's file in uppercase.
+ * @returns {string} service contents of provided source code.
+ */
 export const getWebServiceContent = async (
   contentBase64: string,
-  type = 'JS',
-  serverType: ServerType
+  type = 'JS'
 ) => {
   let lines = [contentBase64]
 
@@ -39,10 +44,8 @@ file sasjs;
     }
   })
 
-  if (serverType === ServerType.Sas9 && typesToEncode.hasOwnProperty(type)) {
+  if (typesToEncode.hasOwnProperty(type)) {
     serviceContent += `\nrun;\n%sasjsout(${typesToEncode[type]})`
-  } else {
-    serviceContent += `\nrun;\n%sasjsout(${type})`
   }
 
   return serviceContent

--- a/src/commands/web/internal/sas9/index.ts
+++ b/src/commands/web/internal/sas9/index.ts
@@ -1,0 +1,3 @@
+export * from './createClickMeService'
+export * from './generateAssetService'
+export * from './getWebServiceContent'

--- a/src/commands/web/internal/sasViya/createClickMeFile.ts
+++ b/src/commands/web/internal/sasViya/createClickMeFile.ts
@@ -1,0 +1,18 @@
+import { createFile } from '@sasjs/utils'
+import path from 'path'
+
+/**
+ * Creates index file for SASVIYA server only.
+ * @param {string} indexHtmlContent contents of index file.
+ * @param {string} fileName name of index file.
+ */
+export const createClickMeFile = async (
+  indexHtmlContent: string,
+  fileName: string
+) => {
+  const { buildDestinationServicesFolder } = process.sasjsConstants
+  await createFile(
+    path.join(buildDestinationServicesFolder, `${fileName}.html`),
+    indexHtmlContent
+  )
+}

--- a/src/commands/web/internal/sasViya/index.ts
+++ b/src/commands/web/internal/sasViya/index.ts
@@ -1,0 +1,1 @@
+export * from './createClickMeFile'

--- a/src/commands/web/internal/sasjsout.ts
+++ b/src/commands/web/internal/sasjsout.ts
@@ -105,95 +105,43 @@ run;
 
 %macro sasjsout(type,fref=sasjs);
 %global sysprocessmode SYS_JES_JOB_URI;
-%if "&sysprocessmode"="SAS Compute Server" %then %do;
-  %if &type=HTML %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name="_webout.json"
-      contenttype="text/html";
-  %end;
-  %else %if &type=JS or &type=JS64 %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.js'
-      contenttype='application/javascript';
-  %end;
-  %else %if &type=CSS or &type=CSS64 %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.css'
-      contenttype='text/css';
-  %end;
-  %else %if &type=PNG or &type=GIF or &type=JPEG or &type=JPG %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI"
-      name="_webout.%lowcase(&type)"
-      contenttype="image/%lowcase(&type)" lrecl=2000000 recfm=n;
-  %end;
-  %else %if &type=SVG or &type=SVG64 %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI"
-      name="_webout.svg"
-      contenttype="image/svg+xml" lrecl=2000000 recfm=n;
-  %end;
-  %else %if &type=ICO %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.ico'
-      contenttype='image/vnd.microsoft.icon' lrecl=2000000 recfm=n;
-  %end;
-  %else %if &type=JSON %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.json'
-      contenttype='application/json' lrecl=2000000 recfm=n;
-  %end;
-  %else %if &type=MP3 %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.mp3'
-      contenttype='audio/mpeg' lrecl=2000000 recfm=n;
-  %end;
-  %else %if &type=WAV %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.wav'
-      contenttype='audio/x-wav' lrecl=2000000 recfm=n;
-  %end;
-  %else %if &type=OGG %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.ogg'
-      contenttype='audio/ogg' lrecl=2000000 recfm=n;
-  %end;
-  %else %if &type=WOFF or &type=WOFF2 or &type=TTF %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI"
-      contenttype="font/%lowcase(&type)";
-  %end;
-  %else %if &type=MP4 %then %do;
-    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI"
-      contenttype="video/mp4";
-  %end;
+
+%if &type=JS or &type=JS64 %then %do;
+  %let rc=%sysfunc(stpsrv_header(
+    Content-type,application/javascript%str(;)charset=UTF-8
+  ));
 %end;
-%else %do;
-  %if &type=JS or &type=JS64 %then %do;
-    %let rc=%sysfunc(stpsrv_header(
-      Content-type,application/javascript%str(;)charset=UTF-8
-    ));
-  %end;
-  %else %if &type=CSS or &type=CSS64 %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,text/css));
-  %end;
-  %else %if &type=PNG or &type=GIF or &type=JPEG or &type=JPG %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,image/%lowcase(&type)));
-  %end;
-  %else %if &type=SVG or &type=SVG64 %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,image/svg+xml));
-  %end;
-  %else %if &type=ICO %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,image/vnd.microsoft.icon));
-  %end;
-  %else %if &type=JSON %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,application/json));
-  %end;
-  %else %if &type=MP3 %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,audio/mpeg));
-  %end;
-  %else %if &type=WAV %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,audio/x-wav));
-  %end;
-  %else %if &type=OGG %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,audio/ogg));
-  %end;
-  %else %if &type=WOFF or &type=WOFF2 or &type=TTF %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,font/%lowcase(&type)));
-  %end;
-  %else %if &type=MP4 %then %do;
-    %let rc=%sysfunc(stpsrv_header(Content-type,video/mp4));
-  %end;
+%else %if &type=CSS or &type=CSS64 %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,text/css));
 %end;
+%else %if &type=PNG or &type=GIF or &type=JPEG or &type=JPG %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,image/%lowcase(&type)));
+%end;
+%else %if &type=SVG or &type=SVG64 %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,image/svg+xml));
+%end;
+%else %if &type=ICO %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,image/vnd.microsoft.icon));
+%end;
+%else %if &type=JSON %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,application/json));
+%end;
+%else %if &type=MP3 %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,audio/mpeg));
+%end;
+%else %if &type=WAV %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,audio/x-wav));
+%end;
+%else %if &type=OGG %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,audio/ogg));
+%end;
+%else %if &type=WOFF or &type=WOFF2 or &type=TTF %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,font/%lowcase(&type)));
+%end;
+%else %if &type=MP4 %then %do;
+  %let rc=%sysfunc(stpsrv_header(Content-type,video/mp4));
+%end;
+
 %if &type=HTML %then %do;
   /*
   We need to perform some substitutions -eg to get the APPLOC and SERVERTYPE.
@@ -216,8 +164,7 @@ run;
     end;
     if find(_infile_,' appLoc: ') then put '    appLoc: ' apploc:$quote1048. ',';
     else if find(_infile_,' serverType: ') then do;
-      if symexist('_metaperson') then put '    serverType: "SAS9" ,';
-      else put '    serverType: "SASVIYA" ,';
+      put '    serverType: "SAS9" ,';
     end;
     else if find(_infile_,' serverUrl: ') then do;
       /* nothing - we are streaming, so remove to default as hostname */
@@ -240,11 +187,7 @@ run;
         in1=substr(infile,1,spos2+11);
         in2=subpad(infile,spos2+12);
         in2=substr(in2,index(in2,'"'));
-        if symexist('sasjsprocessmode') then infile=cats(in1,"SASJS",in2);
-        else if "&sysprocessmode"="SAS Object Server"
-        or "&sysprocessmode"= "SAS Compute Server"
-        then infile=cats(in1,"SASVIYA",in2);
-        else infile=cats(in1,"SAS9",in2);
+        infile=cats(in1,"SAS9",in2);
         putlog "new servertype:  " infile=;
       end;
       /* find & replace serverUrl in HTML attributes */

--- a/src/commands/web/internal/sasjsout.ts
+++ b/src/commands/web/internal/sasjsout.ts
@@ -123,6 +123,11 @@ run;
       name="_webout.%lowcase(&type)"
       contenttype="image/%lowcase(&type)" lrecl=2000000 recfm=n;
   %end;
+  %else %if &type=SVG or &type=SVG64 %then %do;
+    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI"
+      name="_webout.svg"
+      contenttype="image/svg+xml" lrecl=2000000 recfm=n;
+  %end;
   %else %if &type=ICO %then %do;
     filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.ico'
       contenttype='image/vnd.microsoft.icon' lrecl=2000000 recfm=n;
@@ -163,6 +168,9 @@ run;
   %end;
   %else %if &type=PNG or &type=GIF or &type=JPEG or &type=JPG %then %do;
     %let rc=%sysfunc(stpsrv_header(Content-type,image/%lowcase(&type)));
+  %end;
+  %else %if &type=SVG or &type=SVG64 %then %do;
+    %let rc=%sysfunc(stpsrv_header(Content-type,image/svg+xml));
   %end;
   %else %if &type=ICO %then %do;
     %let rc=%sysfunc(stpsrv_header(Content-type,image/vnd.microsoft.icon));
@@ -288,7 +296,7 @@ run;
   data _null_;
     pgm="&_program";
     appLoc=substr(pgm,1,find(pgm,'/services/')-1);
-    call symputx('apploc',appLoc);
+    call symputx('apploc',cats(appLoc,'/services/'));
   run;
   %put &=fvar;
   %put &=apploc;
@@ -308,6 +316,7 @@ run;
   * */
 %if &type=GIF or &type=PNG or &type=JPG or &type=JPEG or &type=ICO or &type=MP3
 or &type=WAV or &type=OGG or &type=WOFF or &type=WOFF2 or &type=TTF or &type=MP4
+or &type=SVG64
 %then %do;
   data _null_;
     length filein 8 fileout 8;

--- a/src/commands/web/internal/sasjsout.ts
+++ b/src/commands/web/internal/sasjsout.ts
@@ -1,4 +1,4 @@
-export const sasjsout = `
+export const sasjsout = () => `
 %macro sasjsout(type,fref=sasjs);
 %global sysprocessmode SYS_JES_JOB_URI;
 %if "&sysprocessmode"="SAS Compute Server" %then %do;
@@ -146,8 +146,8 @@ export const sasjsout = `
       end;
       if sum(spos1,spos2,spos3)>0 then put infile;
       else do;
-        /* during SAS9 sasjs compile, dependencies get three slashes /// */
-        infile=tranwrd(_infile_,'?_PROGRAM=///',cats(expanded_path));
+        /* during SAS9 sasjs compile, dependencies get static GUID */
+        infile=tranwrd(_infile_,'?_PROGRAM=${process.sasjsConstants.sas9GUID}',cats(expanded_path));
         put infile;
       end;
     end;

--- a/src/commands/web/internal/updateAllTags.ts
+++ b/src/commands/web/internal/updateAllTags.ts
@@ -11,14 +11,20 @@ import {
 import { updateScriptTag } from './updateScriptTag'
 import { updateLinkTag } from './updateLinkTag'
 import { updateStyleTag } from './updateStyleTag'
+import { AssetPathMap } from './createAssetServices'
 
 interface paramsType {
   webSourcePathFull: string
   destinationPath: string
   serverType: ServerType
-  assetPathMap: { source: string; target: string }[]
+  assetPathMap: AssetPathMap[]
 }
 
+/**
+ * Updates HTML Tags with correct link.
+ * Also updates contents to update included asset references
+ * @param {JSDOM} parsedHtml- DOMWindow for index.html
+ */
 export const updateAllTags = async (
   parsedHtml: JSDOM,
   { webSourcePathFull, destinationPath, serverType, assetPathMap }: paramsType

--- a/src/commands/web/internal/updateLinkTag.ts
+++ b/src/commands/web/internal/updateLinkTag.ts
@@ -1,6 +1,8 @@
+import { AssetPathMap } from './createAssetServices'
+
 export const updateLinkTag = (
   linkTag: HTMLLinkElement | HTMLSourceElement | HTMLImageElement,
-  assetPathMap: { source: string; target: string }[],
+  assetPathMap: AssetPathMap[],
   tagType: 'link' | 'src' = 'link'
 ) => {
   const linkSourcePath =

--- a/src/commands/web/internal/updateScriptTag.ts
+++ b/src/commands/web/internal/updateScriptTag.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { createFile, readFile, ServerType } from '@sasjs/utils'
 import { encode } from 'js-base64'
-import { getWebServiceContent } from './getWebServiceContent'
+import { getWebServiceContent } from './sas9'
 import { AssetPathMap } from './createAssetServices'
 import { modifyLinksInContent } from './modifyLinksInContent'
 
@@ -25,21 +25,29 @@ export const updateScriptTag = async (
 
       const content = modifyLinksInContent(_content, assetPathMap)
 
-      if (serverType === ServerType.SasViya) {
-        await createFile(path.join(destinationPath, scriptPath), content)
-      } else {
-        const serviceContent = await getWebServiceContent(
-          encode(content),
-          'JS',
-          serverType
-        )
-        await createFile(
-          path.join(
-            destinationPath,
-            `${scriptPath.replace(/\.js$/, '-js')}.sas`
-          ),
-          serviceContent
-        )
+      switch (serverType) {
+        case ServerType.SasViya:
+          await createFile(path.join(destinationPath, scriptPath), content)
+          break
+
+        case ServerType.Sas9:
+          const serviceContent = await getWebServiceContent(
+            encode(content),
+            'JS'
+          )
+          await createFile(
+            path.join(
+              destinationPath,
+              `${scriptPath.replace(/\.js$/, '-js')}.sas`
+            ),
+            serviceContent
+          )
+          break
+
+        default:
+          throw new Error(
+            `Server Type: ${serverType} is not supported for updating script tag.`
+          )
       }
 
       tag.setAttribute(

--- a/src/commands/web/internal/updateScriptTag.ts
+++ b/src/commands/web/internal/updateScriptTag.ts
@@ -2,13 +2,15 @@ import path from 'path'
 import { createFile, readFile, ServerType } from '@sasjs/utils'
 import { encode } from 'js-base64'
 import { getWebServiceContent } from './getWebServiceContent'
+import { AssetPathMap } from './createAssetServices'
+import { modifyLinksInContent } from './modifyLinksInContent'
 
 export const updateScriptTag = async (
   tag: HTMLScriptElement,
   webSourcePathFull: string,
   destinationPath: string,
   serverType: ServerType,
-  assetPathMap: { source: string; target: string }[]
+  assetPathMap: AssetPathMap[]
 ) => {
   const scriptPath = tag.getAttribute('src')
 
@@ -54,18 +56,4 @@ export const updateScriptTag = async (
 
     tag.innerHTML = content
   }
-}
-
-const modifyLinksInContent = (
-  _content: string,
-  assetPathMap: { source: string; target: string }[]
-) => {
-  let content = _content
-  assetPathMap.forEach((pathEntry) => {
-    content = content.replace(
-      new RegExp(pathEntry.source, 'g'),
-      pathEntry.target
-    )
-  })
-  return content
 }

--- a/src/commands/web/internal/updateStyleTag.ts
+++ b/src/commands/web/internal/updateStyleTag.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { createFile, readFile, ServerType } from '@sasjs/utils'
 import { encode } from 'js-base64'
-import { getWebServiceContent } from './getWebServiceContent'
+import { getWebServiceContent } from './sas9'
 import { AssetPathMap } from './createAssetServices'
 import { modifyLinksInContent } from './modifyLinksInContent'
 
@@ -25,21 +25,29 @@ export const updateStyleTag = async (
 
       const content = modifyLinksInContent(_content, assetPathMap)
 
-      if (serverType === ServerType.SasViya) {
-        await createFile(path.join(destinationPath, scriptPath), content)
-      } else {
-        const serviceContent = await getWebServiceContent(
-          encode(content),
-          'CSS',
-          serverType
-        )
-        await createFile(
-          path.join(
-            destinationPath,
-            `${scriptPath.replace(/\.css$/, '-css')}.sas`
-          ),
-          serviceContent
-        )
+      switch (serverType) {
+        case ServerType.SasViya:
+          await createFile(path.join(destinationPath, scriptPath), content)
+          break
+
+        case ServerType.Sas9:
+          const serviceContent = await getWebServiceContent(
+            encode(content),
+            'CSS'
+          )
+          await createFile(
+            path.join(
+              destinationPath,
+              `${scriptPath.replace(/\.css$/, '-css')}.sas`
+            ),
+            serviceContent
+          )
+          break
+
+        default:
+          throw new Error(
+            `Server Type: ${serverType} is not supported for updating style tag.`
+          )
       }
 
       tag.setAttribute(

--- a/src/commands/web/internal/updateStyleTag.ts
+++ b/src/commands/web/internal/updateStyleTag.ts
@@ -2,13 +2,15 @@ import path from 'path'
 import { createFile, readFile, ServerType } from '@sasjs/utils'
 import { encode } from 'js-base64'
 import { getWebServiceContent } from './getWebServiceContent'
+import { AssetPathMap } from './createAssetServices'
+import { modifyLinksInContent } from './modifyLinksInContent'
 
 export const updateStyleTag = async (
   tag: HTMLStyleElement | HTMLLinkElement,
   webSourcePathFull: string,
   destinationPath: string,
   serverType: ServerType,
-  assetPathMap: { source: string; target: string }[]
+  assetPathMap: AssetPathMap[]
 ) => {
   const scriptPath = tag.getAttribute('href')
 
@@ -34,7 +36,7 @@ export const updateStyleTag = async (
         await createFile(
           path.join(
             destinationPath,
-            `${scriptPath.replace(/\.js$/, '-js')}.sas`
+            `${scriptPath.replace(/\.css$/, '-css')}.sas`
           ),
           serviceContent
         )
@@ -54,18 +56,4 @@ export const updateStyleTag = async (
 
     tag.innerHTML = content
   }
-}
-
-const modifyLinksInContent = (
-  _content: string,
-  assetPathMap: { source: string; target: string }[]
-) => {
-  let content = _content
-  assetPathMap.forEach((pathEntry) => {
-    content = content.replace(
-      new RegExp(pathEntry.source, 'g'),
-      pathEntry.target
-    )
-  })
-  return content
 }

--- a/src/commands/web/web.ts
+++ b/src/commands/web/web.ts
@@ -8,17 +8,17 @@ import {
   deleteFolder,
   ServerType,
   Target,
-  chunk,
   getAbsolutePath
 } from '@sasjs/utils'
 import { getStreamConfig } from '../../utils/config'
 import path from 'path'
 import jsdom from 'jsdom'
-import { sasjsout } from './internal/sasjsout'
 import { adjustIframeScript } from './internal/adjustIframeScript'
 import { StreamConfig } from '@sasjs/utils/types/config'
 import { createAssetServices } from './internal/createAssetServices'
 import { updateAllTags } from './internal/updateAllTags'
+import { createClickMeService } from './internal/sas9'
+import { createClickMeFile } from './internal/sasViya'
 
 const exampleStreamConfig: StreamConfig = {
   streamWeb: true,
@@ -79,17 +79,29 @@ export async function createWebAppServices(target: Target) {
     assetPathMap
   })
 
-  if (target.serverType === ServerType.SasViya) {
-    indexHtml.window.document.body.innerHTML += adjustIframeScript
-    await createClickMeFile(
-      indexHtml.serialize(),
-      streamConfig.streamServiceName as string
-    )
-  } else
-    await createClickMeService(
-      indexHtml.serialize(),
-      streamConfig.streamServiceName as string
-    )
+  switch (target.serverType) {
+    case ServerType.SasViya:
+      indexHtml.window.document.body.innerHTML += adjustIframeScript
+      await createClickMeFile(
+        indexHtml.serialize(),
+        streamConfig.streamServiceName as string
+      )
+
+      break
+
+    case ServerType.Sas9:
+      await createClickMeService(
+        indexHtml.serialize(),
+        streamConfig.streamServiceName as string
+      )
+
+      break
+
+    default:
+      throw new Error(
+        `Server Type: ${target.serverType} is not supported for processing streaming index file.`
+      )
+  }
 }
 
 const validateStreamConfig = async (streamConfig: StreamConfig) => {
@@ -160,49 +172,4 @@ async function createTargetDestinationFolder(destinationPath: string) {
     await deleteFolder(destinationPath)
   }
   await createFolder(destinationPath)
-}
-
-async function createClickMeService(
-  indexHtmlContent: string,
-  fileName: string
-) {
-  const lines = indexHtmlContent.replace(/\r\n/g, '\n').split('\n')
-  let clickMeServiceContent = `${sasjsout()}\nfilename sasjs temp lrecl=99999999;\ndata _null_;\nfile sasjs;\n`
-
-  lines.forEach((line) => {
-    const chunkedLines = chunk(line)
-    if (chunkedLines.length === 1) {
-      if (chunkedLines[0].length == 0) chunkedLines[0] = ' '
-
-      clickMeServiceContent += `put '${chunkedLines[0]
-        .split("'")
-        .join("''")}';\n`
-    } else {
-      let combinedLines = ''
-      chunkedLines.forEach((chunkedLine, index) => {
-        let text = `put '${chunkedLine.split("'").join("''")}'`
-        if (index !== chunkedLines.length - 1) {
-          text += '@;\n'
-        } else {
-          text += ';\n'
-        }
-        combinedLines += text
-      })
-      clickMeServiceContent += combinedLines
-    }
-  })
-  clickMeServiceContent += 'run;\n%sasjsout(HTML)'
-  const { buildDestinationServicesFolder } = process.sasjsConstants
-  await createFile(
-    path.join(buildDestinationServicesFolder, `${fileName}.sas`),
-    clickMeServiceContent
-  )
-}
-
-async function createClickMeFile(indexHtmlContent: string, fileName: string) {
-  const { buildDestinationServicesFolder } = process.sasjsConstants
-  await createFile(
-    path.join(buildDestinationServicesFolder, `${fileName}.html`),
-    indexHtmlContent
-  )
 }

--- a/src/commands/web/web.ts
+++ b/src/commands/web/web.ts
@@ -167,7 +167,7 @@ async function createClickMeService(
   fileName: string
 ) {
   const lines = indexHtmlContent.replace(/\r\n/g, '\n').split('\n')
-  let clickMeServiceContent = `${sasjsout}\nfilename sasjs temp lrecl=99999999;\ndata _null_;\nfile sasjs;\n`
+  let clickMeServiceContent = `${sasjsout()}\nfilename sasjs temp lrecl=99999999;\ndata _null_;\nfile sasjs;\n`
 
   lines.forEach((line) => {
     const chunkedLines = chunk(line)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,4 +13,5 @@ export interface Constants {
   contextName: string
   sas9CredentialsError: string
   invalidSasError: string
+  sas9GUID: string
 }

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -57,6 +57,8 @@ export const setConstants = async () => {
   const invalidSasError =
     'Url specified does not contain a valid sas program. Please provide valid url.'
 
+  const sas9GUID = 'pZKd6F95jECvRQlN0LCfdA=='
+
   process.sasjsConstants = {
     buildSourceFolder,
     buildSourceDbFolder,
@@ -71,6 +73,7 @@ export const setConstants = async () => {
     macroCorePath,
     contextName,
     sas9CredentialsError,
-    invalidSasError
+    invalidSasError,
+    sas9GUID
   }
 }


### PR DESCRIPTION
## Issue

#1219 

## Intent

Instead of three forward slashes we need to use static GUID

## Implementation

Changed `sasjsout.ts` string to function.
Using `sas9GUID` variable from `process.sasjsConstants` as GUID for paths.

### Refactoring
- De-coupled code for web.ts
- moved sas9 explicit modules to sas9 folder
- moved sasviya explicit modules to sasViya folder
- add JSDoc comments on them
- used switch for serverType decisions (making it serverType explicit code, not using if-else anymore)


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
