### PR TITLE
fix: bumping sasjs/core and sasjs/lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "3.10.11",
-        "@sasjs/core": "4.35.0",
-        "@sasjs/lint": "1.11.2",
+        "@sasjs/core": "^4.35.3",
+        "@sasjs/lint": "^1.12.0",
         "@sasjs/utils": "2.47.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
@@ -2121,16 +2121,18 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.35.0.tgz",
-      "integrity": "sha512-7mk4dT3ilftN4oEnlcfJZ19WRUGyJLks+aPkcmE8X259QiAwTTwMVcH/CuADd1bQL/vkVPQgh66SU0cQAtX6wA=="
+      "version": "4.35.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.35.3.tgz",
+      "integrity": "sha512-ZomfcasVHVIIx2WhiSlX1knl05IlOphqS6fEG5y9TgDn9+VrjkrDXGDtuHjD2nsI+2aHXQ4a14wzufTVdpZatQ=="
     },
     "node_modules/@sasjs/lint": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.11.2.tgz",
-      "integrity": "sha512-zEonhvha9kwrD+hxhG0hEhtfqpXwffH4vRDIr6eDiXkC7S8M3yImpjyFBvX/THJO5+8iuY8TYkOXKl7+nK/wAg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.12.0.tgz",
+      "integrity": "sha512-+2BDqTUK8woiDRu0f12dsCSzc5t27J1Zw9jXqXkhfCZ7JqK0hAeZAqJL9FLHJcYNFt2vK2IMBd5/d0zK2IW/Xw==",
+      "hasInstallScript": true,
       "dependencies": {
-        "@sasjs/utils": "^2.19.0"
+        "@sasjs/utils": "^2.19.0",
+        "ignore": "^5.2.0"
       }
     },
     "node_modules/@sasjs/utils": {
@@ -4044,6 +4046,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -9051,16 +9061,17 @@
       }
     },
     "@sasjs/core": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.35.0.tgz",
-      "integrity": "sha512-7mk4dT3ilftN4oEnlcfJZ19WRUGyJLks+aPkcmE8X259QiAwTTwMVcH/CuADd1bQL/vkVPQgh66SU0cQAtX6wA=="
+      "version": "4.35.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.35.3.tgz",
+      "integrity": "sha512-ZomfcasVHVIIx2WhiSlX1knl05IlOphqS6fEG5y9TgDn9+VrjkrDXGDtuHjD2nsI+2aHXQ4a14wzufTVdpZatQ=="
     },
     "@sasjs/lint": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.11.2.tgz",
-      "integrity": "sha512-zEonhvha9kwrD+hxhG0hEhtfqpXwffH4vRDIr6eDiXkC7S8M3yImpjyFBvX/THJO5+8iuY8TYkOXKl7+nK/wAg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.12.0.tgz",
+      "integrity": "sha512-+2BDqTUK8woiDRu0f12dsCSzc5t27J1Zw9jXqXkhfCZ7JqK0hAeZAqJL9FLHJcYNFt2vK2IMBd5/d0zK2IW/Xw==",
       "requires": {
-        "@sasjs/utils": "^2.19.0"
+        "@sasjs/utils": "^2.19.0",
+        "ignore": "^5.2.0"
       }
     },
     "@sasjs/utils": {
@@ -10519,6 +10530,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "ignore-by-default": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "dependencies": {
     "@sasjs/adapter": "3.10.11",
-    "@sasjs/core": "4.35.0",
-    "@sasjs/lint": "1.11.2",
+    "@sasjs/core": "4.35.3",
+    "@sasjs/lint": "1.12.0",
     "@sasjs/utils": "2.47.0",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",

--- a/src/commands/compile/internal/spec/compileTestFile.spec.ts
+++ b/src/commands/compile/internal/spec/compileTestFile.spec.ts
@@ -103,7 +103,7 @@ describe('compileTestFile', () => {
 %put testing, termed;
 * TestTerm end;`)
 
-        const mvWebout = `%macro mv_webout(action,ds,fref=_mvwtemp,dslabel=,fmt=Y,stream=Y,missing=NULL<br>  ,showmeta=N`
+        const mvWebout = `%macro mv_webout(action,ds,fref=_mvwtemp,dslabel=,fmt=Y,stream=Y,missing=NULL`
 
         expect(testFileContent.indexOf(testVar)).toBeGreaterThan(-1)
         expect(testFileContent.indexOf(testInit)).toBeGreaterThan(-1)

--- a/src/commands/compile/internal/spec/compileTestFile.spec.ts
+++ b/src/commands/compile/internal/spec/compileTestFile.spec.ts
@@ -103,7 +103,7 @@ describe('compileTestFile', () => {
 %put testing, termed;
 * TestTerm end;`)
 
-        const mvWebout = `%macro mv_webout(action,ds,fref=_mvwtemp,dslabel=,fmt=Y,stream=Y,missing=NULL`
+        const mvWebout = `%macro mv_webout(action,ds,fref=_mvwtemp,dslabel=,fmt=N,stream=Y,missing=NULL`
 
         expect(testFileContent.indexOf(testVar)).toBeGreaterThan(-1)
         expect(testFileContent.indexOf(testInit)).toBeGreaterThan(-1)


### PR DESCRIPTION
## Issue

https://github.com/sasjs/lint/issues/166

## Intent

Bumping core (for more efficient JSON generation) and lint (for ignoring particular sas files)

## Implementation

Bumped @sasjs/core and @sasjs/lint

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
