### PR TITLE
fix: sasjs server type default to clientID1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "3.10.11",
-        "@sasjs/core": "^4.35.3",
-        "@sasjs/lint": "^1.12.0",
+        "@sasjs/core": "4.35.3",
+        "@sasjs/lint": "1.12.0",
         "@sasjs/utils": "2.47.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",

--- a/src/commands/add/internal/input.ts
+++ b/src/commands/add/internal/input.ts
@@ -302,7 +302,7 @@ export const getCredentialsInputSasjs = async (target: Target) => {
   const client = await getString(
     'Please enter your Client ID: ',
     (v) => !!v || 'Client ID is required.',
-    getDefaultValues(target.name).client
+    getDefaultValues(target.name, ServerType.Sasjs).client
   )
   return { client }
 }
@@ -351,10 +351,10 @@ export const getCredentialsInputSas9 = async (
   return { userName, password }
 }
 
-export const getDefaultValues = (targetName: string) => {
+export const getDefaultValues = (targetName: string, serverType?: string) => {
   dotenv.config({ path: path.join(process.projectDir, `.env.${targetName}`) })
 
-  const defaultClient =
+  let defaultClient =
     process.env.CLIENT === 'undefined' ||
     process.env.CLIENT === 'null' ||
     !process.env.CLIENT
@@ -367,6 +367,8 @@ export const getDefaultValues = (targetName: string) => {
       ? ''
       : process.env.SECRET
 
+  if (serverType === ServerType.Sasjs && defaultClient === '') defaultClient = 'clientID1' 
+    
   return { client: defaultClient, secret: defaultSecret }
 }
 

--- a/src/commands/add/internal/input.ts
+++ b/src/commands/add/internal/input.ts
@@ -367,8 +367,9 @@ export const getDefaultValues = (targetName: string, serverType?: string) => {
       ? ''
       : process.env.SECRET
 
-  if (serverType === ServerType.Sasjs && defaultClient === '') defaultClient = 'clientID1' 
-    
+  if (serverType === ServerType.Sasjs && defaultClient === '')
+    defaultClient = 'clientID1'
+
   return { client: defaultClient, secret: defaultSecret }
 }
 


### PR DESCRIPTION
## Issue

Fixes #1235

## Intent

- Default `client` to `clientID1` when running `sasjs auth` on `SASJS` server type.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
