### PR TITLE
fix(pipeline):  running sasjs server on windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -47,7 +47,9 @@ jobs:
         run: START .\api-win.exe >> run-sasjs-server.txt
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm config set registry http://registry.npmjs.org
+          npm ci
 
       - name: Check code style
         run: npm run lint

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -38,13 +38,13 @@ jobs:
           echo NODE_PATH=node >> .env
 
       - name: download sasjs/server package from github using curl
-        run: curl -L https://github.com/sasjs/server/releases/latest/download/windows.zip > windows.zip
+        run: curl -L https://github.com/sasjs/server/releases/latest/download/windows.zip --output windows.zip
 
       - name: unzip downloaded package
-        run: 7z x windows.zip
+        run: npx extract-zip windows.zip
 
-      - name: run sasjs server
-        run: api-windows.exe
+      - name: run sasjs server in background
+        run: START .\api-win.exe >> run-sasjs-server.txt
 
       - name: Install dependencies
         run: npm ci
@@ -60,6 +60,9 @@ jobs:
 
       - name: npm prefix for user
         run: echo prefix=C:\npm\prefix >> ~\.npmrc
+
+      - name: Sasjs Server started
+        run: cat run-sasjs-server.txt
 
       - name: Run mocked tests
         run: npm run test:mocked


### PR DESCRIPTION
## Issue

Not able to download and run latest [sasjs/server release](https://github.com/sasjs/server/releases)

## Intent

Fix windows related command for CI/CD

## Implementation

7z commandline on windows not supporting sasjs/server archive
- using npm package to unzip

Running sasjs/server in background

Before running mocked tests, displaying sasjs/server execution log

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
