### PR TITLE
fix: handle updated response from sasjs.executeJobSASjs method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.10.15",
+        "@sasjs/adapter": "3.10.16",
         "@sasjs/core": "4.35.3",
         "@sasjs/lint": "1.12.0",
         "@sasjs/utils": "2.47.1",
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.10.15",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.15.tgz",
-      "integrity": "sha512-QBm0jPGiaRhoukJ8pmnnO/2IXU/yIA7WOZwjxfVAi248A66JokL2ly2WOaIRt9VhplelnCGmYdybN/+WqRg2uQ==",
+      "version": "3.10.16",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.16.tgz",
+      "integrity": "sha512-SOlld03Ty6kFg6eq4i0952VAFVUksNa2lnMWhZgsDcOJRrS67BhcvluhejY/9LLXtgx1EBTbcqi2G4dpYxhxSQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.44.0",
@@ -9009,9 +9009,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.10.15",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.15.tgz",
-      "integrity": "sha512-QBm0jPGiaRhoukJ8pmnnO/2IXU/yIA7WOZwjxfVAi248A66JokL2ly2WOaIRt9VhplelnCGmYdybN/+WqRg2uQ==",
+      "version": "3.10.16",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.16.tgz",
+      "integrity": "sha512-SOlld03Ty6kFg6eq4i0952VAFVUksNa2lnMWhZgsDcOJRrS67BhcvluhejY/9LLXtgx1EBTbcqi2G4dpYxhxSQ==",
       "requires": {
         "@sasjs/utils": "2.44.0",
         "axios": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.10.15",
+    "@sasjs/adapter": "3.10.16",
     "@sasjs/core": "4.35.3",
     "@sasjs/lint": "1.12.0",
     "@sasjs/utils": "2.47.1",

--- a/src/commands/job/internal/execute/sas9.ts
+++ b/src/commands/job/internal/execute/sas9.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import SASjs from '@sasjs/adapter/node'
 import { MacroVars, createFile, createFolder, folderExists } from '@sasjs/utils'
 import { displayError, displaySuccess } from '../../../../utils/displayResult'
-import { saveLog } from '../utils'
+import { saveLog, saveOutput } from '../utils'
 import { parseSourceFile } from '../../../../utils/parseSourceFile'
 
 /**
@@ -45,35 +45,7 @@ export async function executeJobSas9(
       }
 
       if (!!output && result.result) {
-        try {
-          const outputJson = JSON.stringify(result.result, null, 2)
-
-          const currentDirPath = path.isAbsolute(output)
-            ? ''
-            : process.projectDir
-          const outputPath = path.join(
-            currentDirPath,
-            /\.[a-z]{3,4}$/i.test(output)
-              ? output
-              : path.join(output, 'output.json')
-          )
-
-          let folderPath = outputPath.split(path.sep)
-          folderPath.pop()
-          const parentFolderPath = folderPath.join(path.sep)
-
-          if (!(await folderExists(parentFolderPath)))
-            await createFolder(parentFolderPath)
-
-          await createFile(outputPath, outputJson)
-
-          displaySuccess(`Output saved to: ${outputPath}`)
-        } catch (error) {
-          displayError(
-            error,
-            'An error has occurred when parsing an output of the job.'
-          )
-        }
+        saveOutput(result.result, output, false)
       }
     } else {
       process.logger.error(result.message)

--- a/src/commands/job/internal/execute/sasjs.ts
+++ b/src/commands/job/internal/execute/sasjs.ts
@@ -1,32 +1,32 @@
 import SASjs from '@sasjs/adapter/node'
 import { AuthConfig } from '@sasjs/utils'
-import { saveLog } from '../utils'
+import { saveLog, saveOutput } from '../utils'
 
 export async function executeJobSasjs(
   sasjs: SASjs,
   jobPath: string,
-  logFile: string | undefined,
+  logFile?: string,
+  output?: string,
   authConfig?: AuthConfig
 ) {
-  const result = await sasjs.executeJobSASjs(
+  const response = await sasjs.executeJobSASjs(
     {
       _program: jobPath
     },
     authConfig
   )
 
-  if (result) {
-    if (result.status === 'success') {
-      process.logger.success('Job executed successfully!')
+  if (response) {
+    process.logger.success('Job executed successfully!')
 
-      if (logFile && result.log) {
-        await saveLog(result.log, logFile, jobPath, false)
-      }
-    } else {
-      process.logger.error(result.message)
-      process.logger.error(JSON.stringify(result.error, null, 2))
+    if (!!logFile && response.log) {
+      await saveLog(response.log, logFile, jobPath, false)
+    }
+
+    if (!!output && response.result) {
+      await saveOutput(response.result, output, false)
     }
   }
 
-  return result
+  return response
 }

--- a/src/commands/job/internal/utils.ts
+++ b/src/commands/job/internal/utils.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { createFile, createFolder, folderExists } from '@sasjs/utils'
 import { parseLogLines } from '../../../utils/utils'
-import { displaySuccess } from '../../../utils/displayResult'
+import { displayError, displaySuccess } from '../../../utils/displayResult'
 
 export const saveLog = async (
   logData: any,
@@ -34,4 +34,39 @@ export const saveLog = async (
   await createFile(logPath, logLines)
 
   if (!returnStatusOnly) displaySuccess(`Log saved to ${logPath}`)
+}
+
+export const saveOutput = async (
+  outputData: any,
+  outputFile: string,
+  returnStatusOnly: boolean
+) => {
+  try {
+    outputData = JSON.stringify(outputData, null, 2)
+  } catch (error) {
+    displayError(
+      error,
+      'An error has occurred when parsing the output of the job.'
+    )
+  }
+
+  const currentDirPath = path.isAbsolute(outputFile) ? '' : process.projectDir
+  const outputPath = path.join(
+    currentDirPath,
+    /\.[a-z]{3,4}$/i.test(outputFile)
+      ? outputFile
+      : path.join(outputFile, 'output.json')
+  )
+
+  const folderPath = outputPath.split(path.sep)
+  folderPath.pop()
+  const parentFolderPath = folderPath.join(path.sep)
+
+  if (!(await folderExists(parentFolderPath))) {
+    await createFolder(parentFolderPath)
+  }
+
+  await createFile(outputPath, outputData)
+
+  if (!returnStatusOnly) displaySuccess(`Output saved to: ${outputPath}`)
 }

--- a/src/commands/job/jobCommand.ts
+++ b/src/commands/job/jobCommand.ts
@@ -182,10 +182,16 @@ export class JobCommand extends TargetCommand {
   ) {
     const jobPath = prefixAppLoc(target.appLoc, this.parsed.jobPath as string)
 
+    const log = getLogFilePath(this.parsed.log, jobPath)
+    const output = (this.parsed.output as string)?.length
+      ? (this.parsed.output as string)
+      : undefined
+
     const returnCode = await executeJobSasjs(
       sasjs,
       jobPath,
-      this.parsed.log as string,
+      log,
+      output,
       authConfig
     )
       .then(() => ReturnCode.Success)


### PR DESCRIPTION
## Intent

* bump adapter version
* handle response from `executeJobSASjs`
* implement logic for handling `-o` flag for `sasjs job execute` when server type is `sasjs` 
* Create a utility function for saving output


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
