### PR TITLE
fix: remove the invocation of checkNodeVersion script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "3.10.18",
-        "@sasjs/core": "4.35.3",
+        "@sasjs/core": "4.40.0",
         "@sasjs/lint": "1.12.0",
         "@sasjs/utils": "2.48.2",
         "adm-zip": "0.5.9",
@@ -2074,9 +2074,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.35.3.tgz",
-      "integrity": "sha512-ZomfcasVHVIIx2WhiSlX1knl05IlOphqS6fEG5y9TgDn9+VrjkrDXGDtuHjD2nsI+2aHXQ4a14wzufTVdpZatQ=="
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.40.0.tgz",
+      "integrity": "sha512-6qVukUNL/H541XSuaJ1Jco6JgTnKJPJ5zfFeCpgFy6CQSJErlMeXz7KDOgyDdIVbQSixtGS44HrZBhPvqa06ZQ=="
     },
     "node_modules/@sasjs/lint": {
       "version": "1.12.0",
@@ -8975,9 +8975,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.35.3.tgz",
-      "integrity": "sha512-ZomfcasVHVIIx2WhiSlX1knl05IlOphqS6fEG5y9TgDn9+VrjkrDXGDtuHjD2nsI+2aHXQ4a14wzufTVdpZatQ=="
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.40.0.tgz",
+      "integrity": "sha512-6qVukUNL/H541XSuaJ1Jco6JgTnKJPJ5zfFeCpgFy6CQSJErlMeXz7KDOgyDdIVbQSixtGS44HrZBhPvqa06ZQ=="
     },
     "@sasjs/lint": {
       "version": "1.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "3.10.16",
+        "@sasjs/adapter": "3.10.18",
         "@sasjs/core": "4.35.3",
         "@sasjs/lint": "1.12.0",
-        "@sasjs/utils": "2.47.1",
+        "@sasjs/utils": "2.48.2",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
         "csv-stringify": "5.6.5",
@@ -2060,64 +2060,17 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "3.10.16",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.16.tgz",
-      "integrity": "sha512-SOlld03Ty6kFg6eq4i0952VAFVUksNa2lnMWhZgsDcOJRrS67BhcvluhejY/9LLXtgx1EBTbcqi2G4dpYxhxSQ==",
+      "version": "3.10.18",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.18.tgz",
+      "integrity": "sha512-QclGm7om/ufymu44GdUdVbZtl8nBsIzOOREsZQJSVOmjswesDqsQ6WVAUehuOsn9t1IJzzWO89cn21uDQAy+lA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@sasjs/utils": "2.44.0",
+        "@sasjs/utils": "2.48.2",
         "axios": "0.26.0",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
         "https": "1.0.0",
         "tough-cookie": "4.0.0"
-      }
-    },
-    "node_modules/@sasjs/adapter/node_modules/@sasjs/utils": {
-      "version": "2.44.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.44.0.tgz",
-      "integrity": "sha512-hpC4erHYA8Mcb38mzxFEP0cXehfa0iKeqSW2d9MmxZ9g2qpy0BU6xyZJohN9kOiafXo5H359ndNKsg4DOq5YgA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@types/fs-extra": "9.0.13",
-        "@types/prompts": "2.0.13",
-        "chalk": "4.1.1",
-        "cli-table": "0.3.6",
-        "consola": "2.15.0",
-        "csv-stringify": "5.6.5",
-        "find": "0.3.0",
-        "fs-extra": "10.0.0",
-        "jwt-decode": "3.1.2",
-        "prompts": "2.4.1",
-        "rimraf": "3.0.2",
-        "valid-url": "1.0.9"
-      }
-    },
-    "node_modules/@sasjs/adapter/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@sasjs/adapter/node_modules/prompts": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
-      "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@sasjs/core": {
@@ -2136,9 +2089,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.47.1.tgz",
-      "integrity": "sha512-1bF+QE2zyY8VKJQfDC3gEY6J3n52cAmMYNuLxZlh9euatr2Ccg4iWLsg+NwT1wcP20tgfze/0UR7J2a8PESvZA==",
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
+      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -9009,55 +8962,16 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "3.10.16",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.16.tgz",
-      "integrity": "sha512-SOlld03Ty6kFg6eq4i0952VAFVUksNa2lnMWhZgsDcOJRrS67BhcvluhejY/9LLXtgx1EBTbcqi2G4dpYxhxSQ==",
+      "version": "3.10.18",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-3.10.18.tgz",
+      "integrity": "sha512-QclGm7om/ufymu44GdUdVbZtl8nBsIzOOREsZQJSVOmjswesDqsQ6WVAUehuOsn9t1IJzzWO89cn21uDQAy+lA==",
       "requires": {
-        "@sasjs/utils": "2.44.0",
+        "@sasjs/utils": "2.48.2",
         "axios": "0.26.0",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
         "https": "1.0.0",
         "tough-cookie": "4.0.0"
-      },
-      "dependencies": {
-        "@sasjs/utils": {
-          "version": "2.44.0",
-          "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.44.0.tgz",
-          "integrity": "sha512-hpC4erHYA8Mcb38mzxFEP0cXehfa0iKeqSW2d9MmxZ9g2qpy0BU6xyZJohN9kOiafXo5H359ndNKsg4DOq5YgA==",
-          "requires": {
-            "@types/fs-extra": "9.0.13",
-            "@types/prompts": "2.0.13",
-            "chalk": "4.1.1",
-            "cli-table": "0.3.6",
-            "consola": "2.15.0",
-            "csv-stringify": "5.6.5",
-            "find": "0.3.0",
-            "fs-extra": "10.0.0",
-            "jwt-decode": "3.1.2",
-            "prompts": "2.4.1",
-            "rimraf": "3.0.2",
-            "valid-url": "1.0.9"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "prompts": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
-          "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
-          "requires": {
-            "kleur": "^3.0.3",
-            "sisteransi": "^1.0.5"
-          }
-        }
       }
     },
     "@sasjs/core": {
@@ -9075,9 +8989,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.47.1.tgz",
-      "integrity": "sha512-1bF+QE2zyY8VKJQfDC3gEY6J3n52cAmMYNuLxZlh9euatr2Ccg4iWLsg+NwT1wcP20tgfze/0UR7J2a8PESvZA==",
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
+      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build/**/*"
   ],
   "scripts": {
+    "nodeVersionMessage": "echo \u001b[33m make sure you are running node lts version \u001b[0m",
     "checkNodeVersion": "node -e \"console.log('\u001b[36m', 'Checking your Node.js version...'); if (!process.versions || !process.versions.node) { console.log('\u001b[31m', 'Error determining Node.js version. Exiting...') } if (parseInt(process.versions.node) < 14) { console.log('\u001b[31m', '❌ You must be running at least Node.js 14 to install SASjs CLI.\\nYour current version is ' + process.versions.node + '.\\nPlease install a more recent version and try again.'); process.exit(1); } else { console.log('\u001b[32m', '✅ Node.js version check passed. Continuing...'); } console.log('\u001b[0m', '');\"",
     "start": "nodemon --watch \"src/**/*\" --exec \"npm run build && npm run set:permissions\"",
     "set:permissions": "node -e \"require('fs').chmodSync('build/index.js', '755')\"",
@@ -17,7 +18,7 @@
     "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
-    "preinstall": "npm run checkNodeVersion -s",
+    "preinstall": "npm run nodeVersionMessage",
     "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
   },
   "testServerTypes": "viya,sas9,sasjs",
@@ -48,10 +49,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "3.10.16",
+    "@sasjs/adapter": "3.10.18",
     "@sasjs/core": "4.35.3",
     "@sasjs/lint": "1.12.0",
-    "@sasjs/utils": "2.47.1",
+    "@sasjs/utils": "2.48.2",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",
     "csv-stringify": "5.6.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "3.10.18",
-    "@sasjs/core": "4.35.3",
+    "@sasjs/core": "4.40.0",
     "@sasjs/lint": "1.12.0",
     "@sasjs/utils": "2.48.2",
     "adm-zip": "0.5.9",


### PR DESCRIPTION
## Intent

* calling checkNodeVersion script in preinstalling and prebuild steps causes some unexpected problems. So, removed the invocation of this script from the package.json file and rather add a new script that will advise using node lts version
* update versions of adapter, utils and core


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
