### PR TITLE
fix(build): fixed getWebServiceScriptInvocation for SAS9

### DIFF
--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -265,7 +265,7 @@ async function getCreateFileScript(serverType: ServerType) {
   }
 }
 
-function getWebServiceScriptInvocation(
+export function getWebServiceScriptInvocation(
   serverType: ServerType,
   isSASFile: boolean = true,
   encoded: boolean = false
@@ -275,13 +275,15 @@ function getWebServiceScriptInvocation(
   switch (serverType) {
     case ServerType.SasViya:
       return isSASFile
-        ? `%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode ,replace=yes)`
+        ? `%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode,replace=yes)`
         : `%mv_createfile(path=&appLoc/&path, name=&filename, inref=filecode${encodedParam})`
     case ServerType.Sas9:
-      return `%mm_createwebservice(path=&appLoc/&path, name=&service, code=sascode, server=&serverName, replace=yes)`
+      return isSASFile
+        ? `%mm_createwebservice(path=&appLoc/&path, name=&service, code=sascode, server=&serverName, replace=yes)`
+        : `%mm_createwebservice(path=&appLoc/&path, name=&filename, code=${encodedParam}, server=&serverName, replace=yes)`
     case ServerType.Sasjs:
       return isSASFile
-        ? `%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode ,replace=yes)`
+        ? `%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode,replace=yes)`
         : `%mv_createfile(path=&appLoc/&path, name=&filename, inref=filecode${encodedParam})`
     default:
       throw new ServerTypeError()

--- a/src/commands/build/spec/build.spec.ts
+++ b/src/commands/build/spec/build.spec.ts
@@ -4,10 +4,11 @@ import {
   LogLevel,
   generateTimestamp,
   readFile,
-  createFile
+  createFile,
+  ServerType
 } from '@sasjs/utils'
 import { findTargetInConfiguration } from '../../../utils'
-import { build } from '../build'
+import { build, getWebServiceScriptInvocation } from '../build'
 import { compile } from '../..'
 import path from 'path'
 
@@ -93,5 +94,85 @@ describe('sasjs build', () => {
     ).toBeTruthy()
     expect(commentLine2.split(`'`).join(`'`.repeat(2))).toBeTruthy()
     expect(finalSasFile.includes(afterComment)).toBeTruthy()
+  })
+})
+
+describe('getWebServiceScriptInvocation', () => {
+  describe(ServerType.SasViya, () => {
+    it('should return not encoded web service script invocation for sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.SasViya, true, false)
+      ).toEqual(
+        '%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode,replace=yes)'
+      )
+    })
+
+    it('should return encoded web service script invocation for sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.SasViya, true, true)
+      ).toEqual(
+        '%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode,replace=yes)'
+      )
+    })
+
+    it('should return encoded web service script invocation for not sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.SasViya, false, true)
+      ).toEqual(
+        '%mv_createfile(path=&appLoc/&path, name=&filename, inref=filecode, intype=BASE64)'
+      )
+    })
+  })
+
+  describe(ServerType.Sas9, () => {
+    it('should return not encoded web service script invocation for sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.Sas9, true, false)
+      ).toEqual(
+        '%mm_createwebservice(path=&appLoc/&path, name=&service, code=sascode, server=&serverName, replace=yes)'
+      )
+    })
+
+    it('should return encoded web service script invocation for sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.Sas9, true, true)
+      ).toEqual(
+        '%mm_createwebservice(path=&appLoc/&path, name=&service, code=sascode, server=&serverName, replace=yes)'
+      )
+    })
+
+    it('should return encoded web service script invocation for not sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.Sas9, false, true)
+      ).toEqual(
+        '%mm_createwebservice(path=&appLoc/&path, name=&filename, code=, intype=BASE64, server=&serverName, replace=yes)'
+      )
+    })
+  })
+
+  describe(ServerType.Sasjs, () => {
+    it('should return not encoded web service script invocation for sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.Sasjs, true, false)
+      ).toEqual(
+        '%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode,replace=yes)'
+      )
+    })
+
+    it('should return encoded web service script invocation for sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.Sasjs, true, true)
+      ).toEqual(
+        '%mv_createwebservice(path=&appLoc/&path, name=&service, code=sascode,replace=yes)'
+      )
+    })
+
+    it('should return encoded web service script invocation for not sas file', () => {
+      expect(
+        getWebServiceScriptInvocation(ServerType.Sasjs, false, true)
+      ).toEqual(
+        '%mv_createfile(path=&appLoc/&path, name=&filename, inref=filecode, intype=BASE64)'
+      )
+    })
   })
 })


### PR DESCRIPTION
## Issue

closes #1239 

## Intent

Fix `getWebServiceScriptInvocation` function for `SAS9`.

## Implementation

- Fixed return string for `SAS9` target.
- Covered `getWebServiceScriptInvocation` function with unit tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
