### PR TITLE
Issue 1191

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@sasjs/adapter": "4.0.1",
         "@sasjs/core": "4.43.1",
         "@sasjs/lint": "1.13.0",
-        "@sasjs/utils": "2.50.0",
+        "@sasjs/utils": "2.51.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
         "csv-stringify": "5.6.5",
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.50.0.tgz",
-      "integrity": "sha512-PtoLK5C7J8Wqy2o2nUYz9q/iV0BRwc34lw2dLG+98qao153nBas7kiWfZnPXZqtElD9j2OFHbCZM1pxw9582/Q==",
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.0.tgz",
+      "integrity": "sha512-DxrR+Hco3QecPuDN1KtuT0lPAw5Bb1a06rcP0ntDJFf1MIQ+stQzOtUZcYhOWfm3B4ZQ/M1qn0dz2KUp80gNqA==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -9233,9 +9233,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.50.0.tgz",
-      "integrity": "sha512-PtoLK5C7J8Wqy2o2nUYz9q/iV0BRwc34lw2dLG+98qao153nBas7kiWfZnPXZqtElD9j2OFHbCZM1pxw9582/Q==",
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.0.tgz",
+      "integrity": "sha512-DxrR+Hco3QecPuDN1KtuT0lPAw5Bb1a06rcP0ntDJFf1MIQ+stQzOtUZcYhOWfm3B4ZQ/M1qn0dz2KUp80gNqA==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@sasjs/adapter": "4.0.1",
     "@sasjs/core": "4.43.1",
     "@sasjs/lint": "1.13.0",
-    "@sasjs/utils": "2.50.0",
+    "@sasjs/utils": "2.51.0",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",
     "csv-stringify": "5.6.5",

--- a/src/commands/compile/internal/compileFile.ts
+++ b/src/commands/compile/internal/compileFile.ts
@@ -38,79 +38,10 @@ export async function compileFile(
   )
 
   if (fileType === SASJsFileType.service) {
-    const serverType = await getServerType(target)
-    const preCode = await getPreCodeForServicePack(serverType)
-
-    dependencies = `${programVar}\n${preCode}\n${dependencies}`
+    dependencies = `${programVar}\n${dependencies}`
   } else {
     dependencies = `${programVar ? programVar + '\n' : ''}${dependencies}`
   }
 
   await createFile(filePath, dependencies)
-}
-
-export async function getPreCodeForServicePack(serverType: ServerType) {
-  let content = ''
-  const { macroCorePath } = process.sasjsConstants
-
-  switch (serverType) {
-    case ServerType.SasViya:
-      content += await readFile(`${macroCorePath}/base/mf_getuser.sas`)
-      content += await readFile(`${macroCorePath}/base/mp_jsonout.sas`)
-      content += await readFile(`${macroCorePath}/viya/mv_webout.sas`)
-      content +=
-        '/* if calling viya service with _job param, _program will conflict */\n' +
-        '/* so we provide instead as __program */\n' +
-        '%global __program _program;\n' +
-        '%let _program=%sysfunc(coalescec(&__program,&_program));\n' +
-        '%macro webout(action,ds,dslabel=,fmt=,missing=NULL,showmeta=NO,maxobs=MAX);\n' +
-        '  %mv_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt\n' +
-        '    ,missing=&missing\n' +
-        '    ,showmeta=&showmeta\n' +
-        '    ,maxobs=&maxobs\n' +
-        '  )' +
-        '%mend;\n'
-      break
-
-    case ServerType.Sas9:
-      content += await readFile(`${macroCorePath}/base/mf_getuser.sas`)
-      content += await readFile(`${macroCorePath}/base/mp_jsonout.sas`)
-      content += await readFile(`${macroCorePath}/meta/mm_webout.sas`)
-      content +=
-        '  %macro webout(action,ds,dslabel=,fmt=,missing=NULL,showmeta=NO,maxobs=MAX);\n' +
-        '    %mm_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt\n' +
-        '      ,missing=&missing\n' +
-        '      ,showmeta=&showmeta\n' +
-        '      ,maxobs=&maxobs\n' +
-        '    )' +
-        '  %mend;\n'
-      break
-
-    case ServerType.Sasjs:
-      content += await readFile(`${macroCorePath}/base/mf_getuser.sas`)
-      content += await readFile(`${macroCorePath}/base/mp_jsonout.sas`)
-      content += await readFile(`${macroCorePath}/server/ms_webout.sas`)
-      content +=
-        '  %macro webout(action,ds,dslabel=,fmt=,missing=NULL,showmeta=NO,maxobs=MAX);\n' +
-        '    %ms_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt\n' +
-        '      ,missing=&missing\n' +
-        '      ,showmeta=&showmeta\n' +
-        '      ,maxobs=&maxobs\n' +
-        '    )' +
-        '  %mend;\n'
-      break
-
-    default:
-      throw new ServerTypeError()
-  }
-
-  content +=
-    '/* provide additional debug info */\n' +
-    '%global _program;\n' +
-    '%put &=syscc;\n' +
-    '%put user=%mf_getuser();\n' +
-    '%put pgm=&_program;\n' +
-    '%put timestamp=%sysfunc(datetime(),datetime19.);\n'
-
-  return content
 }

--- a/src/commands/compile/internal/compileTestFile.ts
+++ b/src/commands/compile/internal/compileTestFile.ts
@@ -29,7 +29,6 @@ import {
   getMacroFolders,
   getLocalOrGlobalConfig
 } from '../../../utils/config'
-import { getPreCodeForServicePack } from './compileFile'
 
 const testsBuildFolder = () => {
   return path.join(process.projectDir, 'sasjsbuild', 'tests')
@@ -54,9 +53,7 @@ export async function compileTestFile(
     compileTree
   )
 
-  const preCode = await getPreCodeForServicePack(target.serverType)
-
-  dependencies = `${testVar ? testVar + '\n' : ''}\n${preCode}\n${dependencies}`
+  dependencies = `${testVar ? testVar + '\n' : ''}\n${dependencies}`
 
   const destinationPath = path.join(
     testsBuildFolder(),

--- a/src/commands/compile/internal/spec/compileTestFile.spec.ts
+++ b/src/commands/compile/internal/spec/compileTestFile.spec.ts
@@ -80,6 +80,7 @@ describe('compileTestFile', () => {
           'tests',
           filePath
         )
+
         await expect(fileExists(compiledTestFilePath)).resolves.toEqual(true)
 
         const testFileContent = replaceLineBreaks(

--- a/src/commands/compile/spec/compileCommand.spec.ts
+++ b/src/commands/compile/spec/compileCommand.spec.ts
@@ -151,7 +151,7 @@ describe('CompileCommand', () => {
 
     expect(command.name).toEqual('compile')
     expect(command.subCommand).toEqual('job')
-    expect(targetInfo.target).toEqual(target)
+    expect(JSON.stringify(targetInfo.target)).toEqual(JSON.stringify(target))
     expect(targetInfo.isLocal).toBeTrue()
   })
 
@@ -171,7 +171,7 @@ describe('CompileCommand', () => {
 
     expect(command.name).toEqual('compile')
     expect(command.subCommand).toEqual('job')
-    expect(targetInfo.target).toEqual(target)
+    expect(JSON.stringify(targetInfo.target)).toEqual(JSON.stringify(target))
     expect(targetInfo.isLocal).toBeTrue()
   })
 
@@ -189,8 +189,16 @@ describe('CompileCommand', () => {
     const command = new CompileCommand(args)
     await command.execute()
 
+    const expectedTarget: { [key: string]: any } = {}
+
+    Object.keys(target).forEach((key: string) => {
+      expectedTarget[key] = (target as any)[key]
+    })
+
+    delete expectedTarget.getConfig
+
     expect(compileSingleFileModule.compileSingleFile).toHaveBeenCalledWith(
-      target,
+      expect.objectContaining(expectedTarget),
       'job',
       path.join(os.homedir(), 'test.sas'),
       expect.anything()

--- a/src/commands/compile/spec/loadDependencies.spec.ts
+++ b/src/commands/compile/spec/loadDependencies.spec.ts
@@ -7,7 +7,8 @@ import {
   ServerType,
   SASJsFileType,
   DependencyHeader,
-  CompileTree
+  CompileTree,
+  capitalizeFirstChar
 } from '@sasjs/utils'
 import * as internalModule from '@sasjs/utils/sasjsCli/getInitTerm'
 import { mockGetProgram } from '@sasjs/utils/sasjsCli/getInitTerm'
@@ -19,6 +20,7 @@ import {
 } from '../../../utils/test'
 import { setConstants } from '../../../utils'
 import { loadDependencies, getCompileTree } from '../internal/loadDependencies'
+import { SasFileType } from '../internal/getAllFolders'
 
 const fakeInit = `/**
   @file serviceinit.sas
@@ -158,13 +160,15 @@ const serviceConfig = (root: boolean = true): ServiceConfig => ({
       }
 })
 
-const compiledVars = (type: 'Job' | 'Service') => `* ${type} Variables start;
+const compiledVars = (
+  type: SasFileType.Job | SasFileType.Service
+) => `* ${capitalizeFirstChar(type)} Variables start;
 
 %let macrovar1=macro ${type.toLowerCase()} value configuration 1;
 %let macrovar2=macro ${type.toLowerCase()} value target 2;
 %let macrovar3=macro ${type.toLowerCase()} value target 3;
 
-* ${type} Variables end;`
+* ${capitalizeFirstChar(type)} Variables end;`
 
 describe('loadDependencies', () => {
   const appName = `cli-tests-load-dependencies-${generateTimestamp()}`
@@ -215,7 +219,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Service'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Service))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -236,7 +240,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Job'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Job))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -257,7 +261,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Service'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Service))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -278,7 +282,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Job'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Job))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -299,7 +303,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Service'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Service))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -320,7 +324,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Job'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Job))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -341,7 +345,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Service'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Service))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -362,7 +366,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Job'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Job))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -383,7 +387,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Job'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Job))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -410,7 +414,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Job'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Job))
     expect(/\* JobInit start;/.test(dependencies)).toEqual(true)
     expect(/\* JobInit end;/.test(dependencies)).toEqual(true)
     expect(/\* JobTerm start;/.test(dependencies)).toEqual(true)
@@ -436,7 +440,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Service'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Service))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)
@@ -463,7 +467,7 @@ describe('loadDependencies', () => {
       compileTree
     )
 
-    expect(dependencies).toStartWith(compiledVars('Service'))
+    expect(dependencies).toContain(compiledVars(SasFileType.Service))
     expect(/\* ServiceInit start;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceInit end;/.test(dependencies)).toEqual(true)
     expect(/\* ServiceTerm start;/.test(dependencies)).toEqual(true)

--- a/src/commands/deploy/spec/cbd.spec.ts
+++ b/src/commands/deploy/spec/cbd.spec.ts
@@ -84,14 +84,13 @@ describe('sasjs cbd with server type SASJS', () => {
     )
     const mp_jsonout = await readFile(`${macroCorePath}/base/mp_jsonout.sas`)
     const ms_webout = await readFile(`${macroCorePath}/server/ms_webout.sas`)
-    const webout =
-      '  %macro webout(action,ds,dslabel=,fmt=,missing=NULL,showmeta=NO,maxobs=MAX);\n' +
-      '    %ms_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt\n' +
-      '      ,missing=&missing\n' +
-      '      ,showmeta=&showmeta\n' +
-      '      ,maxobs=&maxobs\n' +
-      '    )' +
-      '  %mend;\n'
+    const webout = `%macro webout(action,ds,dslabel=,fmt=,missing=NULL,showmeta=NO,maxobs=MAX);
+  %ms_webout(&action,ds=&ds,dslabel=&dslabel,fmt=&fmt
+    ,missing=&missing
+    ,showmeta=&showmeta
+    ,maxobs=&maxobs
+  ) %mend;
+`
 
     const mocksPath = path.join(__dirname, appName, 'sasjs', 'mocks')
     const appinitJSPath = path.join(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -186,8 +186,9 @@ const loadDocsSubmodule = async (
   folderPath: string,
   zipPath: string
 ) => {
-  let docsFolderPath = `${folderPath}/public/docs` //We first look if docs submodule is inside `public` folder. (react-seed-app for example)
-  if (!(await fileExists(docsFolderPath))) docsFolderPath = `${folderPath}/docs` //If not, we load submodule in root
+  let docsFolderPath = `${folderPath}/public/docs` // We first look if docs submodule is inside `public` folder. (react-seed-app for example)
+
+  if (!(await fileExists(docsFolderPath))) docsFolderPath = `${folderPath}/docs` // If not, we load submodule in root
 
   downloadFile(`${docsUrl}${zipPath}`)
 


### PR DESCRIPTION
## Issue

Closes #1191 

## Intent

- Stop adding pre-code to services and tests in `@sasjs/cli` because it is added by `@sasjs/utils`. 

## Implementation

- Removed `getPreCodeForServicePack` function from the code base.
- Fixed unit tests covering `loadDependencies` function.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
