### PR TITLE
fix: sasjs fs sync with no arguments should deploy per the sasjsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "^4.0.1",
+        "@sasjs/adapter": "4.0.1",
         "@sasjs/core": "4.43.1",
         "@sasjs/lint": "1.15.0",
-        "@sasjs/utils": "2.51.0",
+        "@sasjs/utils": "2.51.1",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
         "csv-stringify": "5.6.5",
@@ -2182,9 +2182,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.51.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.0.tgz",
-      "integrity": "sha512-DxrR+Hco3QecPuDN1KtuT0lPAw5Bb1a06rcP0ntDJFf1MIQ+stQzOtUZcYhOWfm3B4ZQ/M1qn0dz2KUp80gNqA==",
+      "version": "2.51.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.1.tgz",
+      "integrity": "sha512-Z6sHdJtk5buKzk/q5UjqFZgy76Un65oxAMcH5+IQQezx8e0MhbgtMC7Q8lRdezzUkyThJw6cTSCg7ySpzTX/0Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -9391,9 +9391,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.51.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.0.tgz",
-      "integrity": "sha512-DxrR+Hco3QecPuDN1KtuT0lPAw5Bb1a06rcP0ntDJFf1MIQ+stQzOtUZcYhOWfm3B4ZQ/M1qn0dz2KUp80gNqA==",
+      "version": "2.51.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.1.tgz",
+      "integrity": "sha512-Z6sHdJtk5buKzk/q5UjqFZgy76Un65oxAMcH5+IQQezx8e0MhbgtMC7Q8lRdezzUkyThJw6cTSCg7ySpzTX/0Q==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@sasjs/adapter": "4.0.1",
     "@sasjs/core": "4.43.1",
     "@sasjs/lint": "1.15.0",
-    "@sasjs/utils": "2.51.0",
+    "@sasjs/utils": "2.51.1",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",
     "csv-stringify": "5.6.5",

--- a/src/commands/fs/fsCommand.ts
+++ b/src/commands/fs/fsCommand.ts
@@ -1,6 +1,6 @@
 import { CommandExample, ReturnCode } from '../../types/command'
 import { TargetCommand } from '../../types/command/targetCommand'
-import { displayError, isSASjsProject, saveLog } from '../../utils'
+import { displayError, getSyncDirectories, saveLog } from '../../utils'
 import path, { join } from 'path'
 import {
   createFile,
@@ -11,7 +11,8 @@ import {
   generateProgramToGetRemoteHash,
   generateProgramToSyncHashDiff,
   getRelativePath,
-  generateTimestamp
+  generateTimestamp,
+  SyncDirectoryMap
 } from '@sasjs/utils'
 import { CommandOptions } from '../../types/command/commandBase'
 import { executeCode } from './internal/executeCode'
@@ -24,11 +25,13 @@ enum FsSubCommand {
 
 const syntax = 'fs <subCommand> [options]'
 const usage = 'Usage: sasjs fs <subCommand> [options]'
-// TODO: update
 const description = 'Handles operations around file system synchronisation'
+const parseOptions = {
+  output: { type: 'string', alias: 'o' }
+}
 
 const compileCommandSyntax = 'fs <subCommand> <localFolder> [options]'
-const compileCommandUsage = 'Usage: sasjs fs compile <localFolder> [options]'
+const compileCommandUsage = 'sasjs fs compile <localFolder> [options]'
 const compileCommandDescription =
   'Compiles a SAS program with the contents of a local directory'
 const compileCommandExamples: CommandExample[] = [
@@ -39,20 +42,32 @@ const compileCommandExamples: CommandExample[] = [
   }
 ]
 
-const syncCommandSyntax = 'fs <subCommand> <localFolder> <remoteFolder>'
-const syncCommandUsage = 'Usage: sasjs fs sync <localFolder> <remoteFolder>'
+const syncCommandSyntax = 'fs <subCommand> [options]'
+const syncCommandUsage = 'sasjs fs sync'
 const syncCommandDescription =
   'Synchronise the remote SAS file system with the local project folder according to the target `syncDirectories` array'
 const syncCommandExamples: CommandExample[] = [
   {
-    command: 'sasjs fs sync <path/of/folder> <path/of/remote/folder>',
-    description:
-      'Synchronise the remote SAS file system with the local project folder according to the target `syncDirectories` array'
+    command:
+      'sasjs fs sync --local <path/of/folder> --remote <path/of/remote/folder>',
+    description: ''
+  },
+  {
+    command:
+      'sasjs fs sync --local <path/of/folder> --remote <path/of/remote/folder> --target <target-name>',
+    description: ''
+  },
+  {
+    command:
+      'sasjs fs sync -l <path/of/folder> -r <path/of/remote/folder> -t <target-name>',
+    description: ''
   }
 ]
 
-const parseOptions = {
-  output: { type: 'string', alias: 'o' }
+const syncCommandParseOptions = {
+  ...parseOptions,
+  local: { type: 'string', alias: 'l' },
+  remote: { type: 'string', alias: 'r' }
 }
 
 export class FSCommand extends TargetCommand {
@@ -78,6 +93,7 @@ export class FSCommand extends TargetCommand {
         commandOptions.usage = syncCommandUsage
         commandOptions.description = syncCommandDescription
         commandOptions.examples = syncCommandExamples
+        commandOptions.parseOptions = syncCommandParseOptions
         break
     }
 
@@ -85,13 +101,13 @@ export class FSCommand extends TargetCommand {
   }
 
   public get localFolder(): string {
-    const sourcePath = this.parsed.localFolder as string
+    const sourcePath = (this.parsed.local as string) ?? ''
     const currentDirPath = path.isAbsolute(sourcePath) ? '' : process.projectDir
     return path.join(currentDirPath, sourcePath)
   }
 
   public get remoteFolder(): string {
-    const remotePath = this.parsed.remoteFolder as string
+    const remotePath = (this.parsed.remote as string) ?? ''
     return remotePath.endsWith(path.sep) ? remotePath.slice(0, -1) : remotePath
   }
 
@@ -117,14 +133,16 @@ export class FSCommand extends TargetCommand {
     if (!outputPath) {
       return path.join(
         process.sasjsConstants.buildDestinationResultsFolder,
-        'fs',
+        'fs-sync',
         generateTimestamp()
       )
     }
 
-    if (path.isAbsolute(outputPath)) return outputPath
+    if (path.isAbsolute(outputPath)) {
+      return path.join(outputPath, generateTimestamp())
+    }
 
-    return path.join(process.cwd(), outputPath)
+    return path.join(process.cwd(), outputPath, generateTimestamp())
   }
 
   public async execute() {
@@ -158,100 +176,121 @@ export class FSCommand extends TargetCommand {
   }
 
   async sync() {
-    const { target } = await this.getTargetInfo()
+    const { target, isLocal } = await this.getTargetInfo()
     const remoteFolderPath = this.remoteFolder
     const localFolderPath = this.localFolder
-    const outputFolder = await this.getOutputPath()
 
-    process.logger?.info('generating program to get remote hash')
-    const program = await generateProgramToGetRemoteHash(remoteFolderPath)
+    const syncDirectories: SyncDirectoryMap[] = []
 
-    process.logger?.info('executing program to get remote hash')
-    const { log } = await executeCode(target, program)
-    await saveLog(log, path.join(outputFolder, 'getRemoteHash.log'), '', false)
+    if (remoteFolderPath && localFolderPath) {
+      syncDirectories.push({ remote: remoteFolderPath, local: localFolderPath })
+    } else {
+      syncDirectories.push(...(await getSyncDirectories(target, isLocal)))
+    }
 
-    process.logger?.info('extracting hashes from log')
-    const remoteHashes = extractHashArray(log)
-    await createHashFile(
-      JSON.stringify(remoteHashes, null, 2),
-      path.join(outputFolder, 'hashesBeforeSync.json')
-    )
-
-    process.logger?.info('creating the hash of local folder')
-    const localHash = await getHash(localFolderPath)
-
-    const remoteHashMap = remoteHashes.reduce(
-      (map: { [key: string]: string }, item: any) => {
-        const relativePath = getRelativePath(remoteFolderPath, item.FILE_PATH)
-        map[relativePath] = item.FILE_HASH
-        return map
-      },
-      {}
-    )
-
-    if (remoteHashMap[localHash.relativePath] === localHash.hash) {
-      process.logger?.info(
-        'There are no differences between Remote and Local directory. Already synced.'
-      )
+    if (!syncDirectories.length) {
+      process.logger?.info('There are no directories to sync.')
       return ReturnCode.Success
     }
 
-    process.logger?.info('Extract differences from local and remote hash')
-    const hashedDiff = compareHashes(localHash, remoteHashMap)
-    await createHashFile(
-      JSON.stringify(hashedDiff, null, 2),
-      path.join(outputFolder, 'hashesDiff.json')
-    )
+    for (const obj of syncDirectories) {
+      const outputFolder = await this.getOutputPath()
 
-    process.logger?.info('generating program to sync differences')
-    const syncProgram = await generateProgramToSyncHashDiff(
-      hashedDiff,
-      remoteFolderPath
-    )
+      process.logger?.info('generating program to get remote hash')
+      const program = await generateProgramToGetRemoteHash(obj.remote)
 
-    process.logger?.info('executing program to sync differences')
-    const { log: syncLog } = await executeCode(target, syncProgram)
-    await saveLog(syncLog, path.join(outputFolder, 'sync.log'), '', false)
-
-    const syncedHash = extractHashArray(syncLog)
-    await createHashFile(
-      JSON.stringify(syncedHash, null, 2),
-      path.join(outputFolder, 'hashesAfterSync.json')
-    )
-    const syncedHashMap = syncedHash.reduce(
-      (map: { [key: string]: string }, item: any) => {
-        const relativePath = getRelativePath(remoteFolderPath, item.FILE_PATH)
-        map[relativePath] = item.FILE_HASH
-        return map
-      },
-      {}
-    )
-
-    const syncedResources: string[] = []
-
-    Object.entries(syncedHashMap).forEach(([key, value]) => {
-      if (remoteHashMap[key] !== value) syncedResources.push(key)
-    })
-
-    if (syncedResources.length) {
-      process.logger?.log('The following resources were synced:')
-      syncedResources.forEach((item) => {
-        process.logger?.log(`* ${item}`)
-      })
-    }
-
-    const resourcesNotPresentLocally = findResourcesNotPresentLocally(
-      localHash,
-      syncedHashMap
-    )
-
-    if (resourcesNotPresentLocally.length) {
-      process.logger?.log(
-        'The following resources are present in remote directory but not in local:'
+      process.logger?.info('executing program to get remote hash')
+      const { log } = await executeCode(target, program)
+      await saveLog(
+        log,
+        path.join(outputFolder, 'getRemoteHash.log'),
+        '',
+        false
       )
-      resourcesNotPresentLocally.forEach((item) => {
-        process.logger?.log(`* ${item}`)
+
+      process.logger?.info('extracting hashes from log')
+      const remoteHashes = extractHashArray(log)
+      await createHashFile(
+        JSON.stringify(remoteHashes, null, 2),
+        path.join(outputFolder, 'hashesBeforeSync.json')
+      )
+
+      process.logger?.info('creating the hash of local folder')
+      const localHash = await getHash(obj.local)
+
+      const remoteHashMap = remoteHashes.reduce(
+        (map: { [key: string]: string }, item: any) => {
+          const relativePath = getRelativePath(obj.remote, item.FILE_PATH)
+          map[relativePath] = item.FILE_HASH
+          return map
+        },
+        {}
+      )
+
+      if (remoteHashMap[localHash.relativePath] === localHash.hash) {
+        process.logger?.info(
+          'There are no differences between Remote and Local directory. Already synced.'
+        )
+        return ReturnCode.Success
+      }
+
+      process.logger?.info('Extract differences from local and remote hash')
+      const hashedDiff = compareHashes(localHash, remoteHashMap)
+      await createHashFile(
+        JSON.stringify(hashedDiff, null, 2),
+        path.join(outputFolder, 'hashesDiff.json')
+      )
+
+      process.logger?.info('generating program to sync differences')
+      const syncProgram = await generateProgramToSyncHashDiff(
+        hashedDiff,
+        obj.remote
+      )
+
+      process.logger?.info('executing program to sync differences')
+      const { log: syncLog } = await executeCode(target, syncProgram)
+      await saveLog(syncLog, path.join(outputFolder, 'sync.log'), '', false)
+
+      const syncedHash = extractHashArray(syncLog)
+      await createHashFile(
+        JSON.stringify(syncedHash, null, 2),
+        path.join(outputFolder, 'hashesAfterSync.json')
+      )
+      const syncedHashMap = syncedHash.reduce(
+        (map: { [key: string]: string }, item: any) => {
+          const relativePath = getRelativePath(obj.remote, item.FILE_PATH)
+          map[relativePath] = item.FILE_HASH
+          return map
+        },
+        {}
+      )
+
+      const syncedResources: string[] = []
+
+      Object.entries(syncedHashMap).forEach(([key, value]) => {
+        if (remoteHashMap[key] !== value) syncedResources.push(key)
       })
+
+      if (syncedResources.length) {
+        process.logger?.log('The following resources were synced:')
+        syncedResources.forEach((item) => {
+          process.logger?.log(`* ${item}`)
+        })
+      }
+
+      const resourcesNotPresentLocally = findResourcesNotPresentLocally(
+        localHash,
+        syncedHashMap
+      )
+
+      if (resourcesNotPresentLocally.length) {
+        process.logger?.log(
+          'The following resources are present in remote directory but not in local:'
+        )
+        resourcesNotPresentLocally.forEach((item) => {
+          process.logger?.log(`* ${item}`)
+        })
+      }
     }
 
     return ReturnCode.Success

--- a/src/commands/fs/spec/fsCommand.spec.ts
+++ b/src/commands/fs/spec/fsCommand.spec.ts
@@ -126,7 +126,9 @@ describe('FSCommand', () => {
 
       const returnCode = await executeCommandWrapper([
         'sync',
+        '-l',
         'localFolder',
+        '-r',
         'remoteFolder'
       ])
       expect(returnCode).toEqual(ReturnCode.Success)
@@ -178,7 +180,9 @@ describe('FSCommand', () => {
 
       const returnCode = await executeCommandWrapper([
         'sync',
+        '-l',
         'localFolder',
+        '-r',
         'remoteFolder'
       ])
       expect(returnCode).toEqual(ReturnCode.Success)

--- a/src/types/command/commandBase.ts
+++ b/src/types/command/commandBase.ts
@@ -65,6 +65,7 @@ export class CommandBase implements Command {
           example.description
         ])
       )
+
     if ([...subCommandMap.keys()].includes(command)) {
       builder = (y: yargs.Argv) =>
         y

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -13,7 +13,8 @@ import {
   StreamConfig,
   HttpsAgentOptions,
   ServerType,
-  AuthConfigSas9
+  AuthConfigSas9,
+  SyncDirectoryMap
 } from '@sasjs/utils'
 import {
   isAccessTokenExpiring,
@@ -383,6 +384,19 @@ export async function getLocalOrGlobalConfig(): Promise<{
   } catch (e) {
     return { configuration: await getGlobalRcFile(), isLocal: false }
   }
+}
+
+export async function getSyncDirectories(
+  target: Target,
+  isLocal: boolean
+): Promise<SyncDirectoryMap[]> {
+  const config = isLocal ? await getLocalConfig() : await getGlobalRcFile()
+
+  const rootLevelSyncDirectories: SyncDirectoryMap[] =
+    config.syncDirectories || []
+  const targetLevelSyncDirectories = target.syncDirectories || []
+
+  return [...rootLevelSyncDirectories, ...targetLevelSyncDirectories]
 }
 
 export async function saveLocalConfigFile(content: string) {


### PR DESCRIPTION
## Issue

closes #1282

## Intent

* If sasjs fs sync is executed without arguments then we should check the default (or -t specified) target in the project (and then the user-level) config file for the syncDirectories array.

## Implementation

* made localFolder and remoteFolder optional and replaced with just local (alias `l`) and remote (alias `r`)
* added a config utility to get all sync directories from target and root of sasjs config
* loop on syncDirectories array returned from `getSyncDirectories`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
