### PR TITLE
fix: bumping core to 4.45.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "4.0.1",
-        "@sasjs/core": "4.43.1",
+        "@sasjs/core": "^4.45.1",
         "@sasjs/lint": "1.15.0",
         "@sasjs/utils": "2.51.1",
         "adm-zip": "0.5.9",
@@ -2167,9 +2167,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.43.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.43.1.tgz",
-      "integrity": "sha512-7N3+ptKuFCbaWAzvI9wxuyPugssfc00zGrbJ1G/zkCtjL4M3mRAgBoA/ZIZ7OUEvzLHKlQunGpvWn8ExFant3A=="
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.1.tgz",
+      "integrity": "sha512-5OU799be29iQTeX1kiE1hCrlpVoH0S5K8Hqwa5b0K+jsK0jolSVzvNaYv8dqFyyIAZiXX5HQgPB27ZgtD7c2Cw=="
     },
     "node_modules/@sasjs/lint": {
       "version": "1.15.0",
@@ -9377,9 +9377,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "4.43.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.43.1.tgz",
-      "integrity": "sha512-7N3+ptKuFCbaWAzvI9wxuyPugssfc00zGrbJ1G/zkCtjL4M3mRAgBoA/ZIZ7OUEvzLHKlQunGpvWn8ExFant3A=="
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.1.tgz",
+      "integrity": "sha512-5OU799be29iQTeX1kiE1hCrlpVoH0S5K8Hqwa5b0K+jsK0jolSVzvNaYv8dqFyyIAZiXX5HQgPB27ZgtD7c2Cw=="
     },
     "@sasjs/lint": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "4.0.1",
-    "@sasjs/core": "4.43.1",
+    "@sasjs/core": "4.45.1",
     "@sasjs/lint": "1.15.0",
     "@sasjs/utils": "2.51.1",
     "adm-zip": "0.5.9",


### PR DESCRIPTION
## Issue

https://github.com/sasjs/core/issues/320

## Intent

Bumping core so that latest webout macros are deployed with `sasjs compile`

## Implementation

`npm i @sasjs/core@latest`

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
