### PR TITLE
feat: deploy zipped file to sasjs server if available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.0.1",
+        "@sasjs/adapter": "4.1.0",
         "@sasjs/core": "^4.45.2",
         "@sasjs/lint": "1.15.0",
         "@sasjs/utils": "2.51.1",
@@ -2118,9 +2118,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.0.1.tgz",
-      "integrity": "sha512-yl2+d+lfd3SAB/7Kj+JaB+uzqd/uQecMAj6asg7el3HL0RX4vKF6S9J9nl5W1g+3AhD6l0E4GofWH7N2gYAy0Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.1.0.tgz",
+      "integrity": "sha512-TgERj/DT/RSV1jfCzgzJtYOY5uLYghrkzkidyk+if/S8pSRDCc8AHZUwNn1T0aNSTGUvbEDo+9eTSEwfGSF0Ag==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.48.2",
@@ -9334,9 +9334,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.0.1.tgz",
-      "integrity": "sha512-yl2+d+lfd3SAB/7Kj+JaB+uzqd/uQecMAj6asg7el3HL0RX4vKF6S9J9nl5W1g+3AhD6l0E4GofWH7N2gYAy0Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.1.0.tgz",
+      "integrity": "sha512-TgERj/DT/RSV1jfCzgzJtYOY5uLYghrkzkidyk+if/S8pSRDCc8AHZUwNn1T0aNSTGUvbEDo+9eTSEwfGSF0Ag==",
       "requires": {
         "@sasjs/utils": "2.48.2",
         "axios": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "4.0.1",
+    "@sasjs/adapter": "4.1.0",
     "@sasjs/core": "4.45.2",
     "@sasjs/lint": "1.15.0",
     "@sasjs/utils": "2.51.1",


### PR DESCRIPTION
## Intent

* sasjs deploy for server type `sasjs` should upload the `targetName.json.zip` file

## Implementation

* modify the logic of `deployToSasjsWithServicePack` to check if the zipped file exists then upload that one else read the contents of the JSON file and pass it as payload.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
