### PR TITLE
fix: bumping lint to v2 (also core to 4.45.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "4.1.0",
-        "@sasjs/core": "4.45.2",
-        "@sasjs/lint": "1.15.0",
+        "@sasjs/core": "^4.45.3",
+        "@sasjs/lint": "2.0.0",
         "@sasjs/utils": "2.51.2",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
@@ -2167,14 +2167,14 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.45.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.2.tgz",
-      "integrity": "sha512-zS2afGxxMfAuX5ssD4brkuOEeIrwQVnlgxgUfUuTGh4IykZN3x8urfwR5fxxoQO1Gf/liKFlT2gxpRjz2woSYg=="
+      "version": "4.45.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.3.tgz",
+      "integrity": "sha512-jJACiOmijlBB787vi3kh+9dsDhAHggzU2UXxHMZu4kp8PpFIijqBW748OilQJWKlHaygQkotWE32ZG+WsZKl2Q=="
     },
     "node_modules/@sasjs/lint": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.15.0.tgz",
-      "integrity": "sha512-3y1Zv+LEbDJRlDjgMF3KtUFv2JxapAX8ksR9sj5i4ShJ3h6od5RuScLjBtLK3A61phxK+cYu05C/tjUZVc9NMQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.0.0.tgz",
+      "integrity": "sha512-Hf4HmYc6hx+JtFwewqjPbEcw5iYHzMh2jXVAdHwynyzkw6jQSY+fGcwWs0vqqmwpA6Shoe3ea2OLZ8FXyV9K/Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "^2.19.0",
@@ -9400,14 +9400,14 @@
       }
     },
     "@sasjs/core": {
-      "version": "4.45.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.2.tgz",
-      "integrity": "sha512-zS2afGxxMfAuX5ssD4brkuOEeIrwQVnlgxgUfUuTGh4IykZN3x8urfwR5fxxoQO1Gf/liKFlT2gxpRjz2woSYg=="
+      "version": "4.45.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.3.tgz",
+      "integrity": "sha512-jJACiOmijlBB787vi3kh+9dsDhAHggzU2UXxHMZu4kp8PpFIijqBW748OilQJWKlHaygQkotWE32ZG+WsZKl2Q=="
     },
     "@sasjs/lint": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-1.15.0.tgz",
-      "integrity": "sha512-3y1Zv+LEbDJRlDjgMF3KtUFv2JxapAX8ksR9sj5i4ShJ3h6od5RuScLjBtLK3A61phxK+cYu05C/tjUZVc9NMQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.0.0.tgz",
+      "integrity": "sha512-Hf4HmYc6hx+JtFwewqjPbEcw5iYHzMh2jXVAdHwynyzkw6jQSY+fGcwWs0vqqmwpA6Shoe3ea2OLZ8FXyV9K/Q==",
       "requires": {
         "@sasjs/utils": "^2.19.0",
         "ignore": "^5.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "4.1.0",
-        "@sasjs/core": "^4.45.3",
-        "@sasjs/lint": "2.0.0",
+        "@sasjs/core": "4.45.3",
+        "@sasjs/lint": "^2.0.1",
         "@sasjs/utils": "2.51.2",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
@@ -2172,9 +2172,9 @@
       "integrity": "sha512-jJACiOmijlBB787vi3kh+9dsDhAHggzU2UXxHMZu4kp8PpFIijqBW748OilQJWKlHaygQkotWE32ZG+WsZKl2Q=="
     },
     "node_modules/@sasjs/lint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.0.0.tgz",
-      "integrity": "sha512-Hf4HmYc6hx+JtFwewqjPbEcw5iYHzMh2jXVAdHwynyzkw6jQSY+fGcwWs0vqqmwpA6Shoe3ea2OLZ8FXyV9K/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.0.1.tgz",
+      "integrity": "sha512-1KnB/KXyZ9Ex1UrCzwoaCBad5wfPi/z7mizfaJA1HHux3Zi4Ruj5E+s0PbxOYCmDARzkNCEnuQYtvyt0bQEDkA==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "^2.19.0",
@@ -9405,9 +9405,9 @@
       "integrity": "sha512-jJACiOmijlBB787vi3kh+9dsDhAHggzU2UXxHMZu4kp8PpFIijqBW748OilQJWKlHaygQkotWE32ZG+WsZKl2Q=="
     },
     "@sasjs/lint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.0.0.tgz",
-      "integrity": "sha512-Hf4HmYc6hx+JtFwewqjPbEcw5iYHzMh2jXVAdHwynyzkw6jQSY+fGcwWs0vqqmwpA6Shoe3ea2OLZ8FXyV9K/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.0.1.tgz",
+      "integrity": "sha512-1KnB/KXyZ9Ex1UrCzwoaCBad5wfPi/z7mizfaJA1HHux3Zi4Ruj5E+s0PbxOYCmDARzkNCEnuQYtvyt0bQEDkA==",
       "requires": {
         "@sasjs/utils": "^2.19.0",
         "ignore": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   },
   "dependencies": {
     "@sasjs/adapter": "4.1.0",
-    "@sasjs/core": "4.45.2",
-    "@sasjs/lint": "1.15.0",
+    "@sasjs/core": "4.45.3",
+    "@sasjs/lint": "2.0.0",
     "@sasjs/utils": "2.51.2",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@sasjs/adapter": "4.1.0",
     "@sasjs/core": "4.45.3",
-    "@sasjs/lint": "2.0.0",
+    "@sasjs/lint": "2.0.1",
     "@sasjs/utils": "2.51.2",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",


### PR DESCRIPTION
## Issue

n/a

## Intent

Enabling the latest version of lint in the CLI (`noTabs` feature)

## Implementation

Bumped lint (also core)

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
