### PR TITLE
fix: bump core to 4.45.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/adapter": "4.1.0",
-        "@sasjs/core": "4.45.3",
-        "@sasjs/lint": "^2.0.1",
+        "@sasjs/core": "^4.45.4",
+        "@sasjs/lint": "2.0.1",
         "@sasjs/utils": "2.51.2",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
@@ -2167,9 +2167,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.45.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.3.tgz",
-      "integrity": "sha512-jJACiOmijlBB787vi3kh+9dsDhAHggzU2UXxHMZu4kp8PpFIijqBW748OilQJWKlHaygQkotWE32ZG+WsZKl2Q=="
+      "version": "4.45.4",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.4.tgz",
+      "integrity": "sha512-zf0foZHXNUb7hTHQAbGcQbHhiwX7qNK9g3PTT5XkjR8aDgcYeBpSxu1bEj7GTVvOmv49YF/3xrVZNh5J+38+DA=="
     },
     "node_modules/@sasjs/lint": {
       "version": "2.0.1",
@@ -9400,9 +9400,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "4.45.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.3.tgz",
-      "integrity": "sha512-jJACiOmijlBB787vi3kh+9dsDhAHggzU2UXxHMZu4kp8PpFIijqBW748OilQJWKlHaygQkotWE32ZG+WsZKl2Q=="
+      "version": "4.45.4",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.45.4.tgz",
+      "integrity": "sha512-zf0foZHXNUb7hTHQAbGcQbHhiwX7qNK9g3PTT5XkjR8aDgcYeBpSxu1bEj7GTVvOmv49YF/3xrVZNh5J+38+DA=="
     },
     "@sasjs/lint": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@sasjs/adapter": "4.1.0",
-    "@sasjs/core": "4.45.3",
+    "@sasjs/core": "4.45.4",
     "@sasjs/lint": "2.0.1",
     "@sasjs/utils": "2.51.2",
     "adm-zip": "0.5.9",


### PR DESCRIPTION
## Issue

n/a

## Intent

bump core to 4.45.4

## Implementation

`npm i @sasjs/core@latest` then fixing the version by removing the `^` in package.json

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
