### PR TITLE
feat: add the ability to lint or lint fix some specific files/folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5803,9 +5803,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -12171,9 +12171,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@sasjs/adapter": "4.1.0",
         "@sasjs/core": "4.45.4",
-        "@sasjs/lint": "^2.1.2",
-        "@sasjs/utils": "2.51.5",
+        "@sasjs/lint": "2.1.3",
+        "@sasjs/utils": "2.52.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
         "csv-stringify": "5.6.5",
@@ -2172,9 +2172,9 @@
       "integrity": "sha512-zf0foZHXNUb7hTHQAbGcQbHhiwX7qNK9g3PTT5XkjR8aDgcYeBpSxu1bEj7GTVvOmv49YF/3xrVZNh5J+38+DA=="
     },
     "node_modules/@sasjs/lint": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.1.2.tgz",
-      "integrity": "sha512-UMCYglo9fv7XQiCCVgaAH+HwHg8IFv63dGfd0LlLjlWgPHgD6gGbo2aDq7wOSqkOuaRpaWHZdcPG8GiMgEd8aQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.1.3.tgz",
+      "integrity": "sha512-ISH8ccbSEE8jNtCmHOph3PrFoaXv/cc9JLE2iSU5ZYw50kd+nqJys+oUjSeVMd8gvIFCxrmrnD31Jpeq4LSrCg==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "^2.19.0",
@@ -2182,9 +2182,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.51.5",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.5.tgz",
-      "integrity": "sha512-EIYJz2y7DryJ7I7rez4OmkzRc2Mw/H6PoOBKWJm2Ji6Hn6IUQSMOGxuI4fARjeULgxf6rKytk18pFo7Syl8IfA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.52.0.tgz",
+      "integrity": "sha512-UbmYCdfCvjRpmoKRnbmKEcE2YZJh9zHjjGyuZ5BIDxThDtOsGZUOiZrW1J7WcrzjAwQiRBzYoV7xF5MiZqtgiQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/fs-extra": "9.0.13",
@@ -9405,18 +9405,18 @@
       "integrity": "sha512-zf0foZHXNUb7hTHQAbGcQbHhiwX7qNK9g3PTT5XkjR8aDgcYeBpSxu1bEj7GTVvOmv49YF/3xrVZNh5J+38+DA=="
     },
     "@sasjs/lint": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.1.2.tgz",
-      "integrity": "sha512-UMCYglo9fv7XQiCCVgaAH+HwHg8IFv63dGfd0LlLjlWgPHgD6gGbo2aDq7wOSqkOuaRpaWHZdcPG8GiMgEd8aQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.1.3.tgz",
+      "integrity": "sha512-ISH8ccbSEE8jNtCmHOph3PrFoaXv/cc9JLE2iSU5ZYw50kd+nqJys+oUjSeVMd8gvIFCxrmrnD31Jpeq4LSrCg==",
       "requires": {
         "@sasjs/utils": "^2.19.0",
         "ignore": "^5.2.0"
       }
     },
     "@sasjs/utils": {
-      "version": "2.51.5",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.51.5.tgz",
-      "integrity": "sha512-EIYJz2y7DryJ7I7rez4OmkzRc2Mw/H6PoOBKWJm2Ji6Hn6IUQSMOGxuI4fARjeULgxf6rKytk18pFo7Syl8IfA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.52.0.tgz",
+      "integrity": "sha512-UbmYCdfCvjRpmoKRnbmKEcE2YZJh9zHjjGyuZ5BIDxThDtOsGZUOiZrW1J7WcrzjAwQiRBzYoV7xF5MiZqtgiQ==",
       "requires": {
         "@types/fs-extra": "9.0.13",
         "@types/prompts": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "dependencies": {
     "@sasjs/adapter": "4.1.0",
     "@sasjs/core": "4.45.4",
-    "@sasjs/lint": "2.1.2",
-    "@sasjs/utils": "2.51.5",
+    "@sasjs/lint": "2.1.3",
+    "@sasjs/utils": "2.52.0",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",
     "csv-stringify": "5.6.5",

--- a/src/commands/lint/processLint.ts
+++ b/src/commands/lint/processLint.ts
@@ -1,5 +1,15 @@
+import path from 'path'
 import chalk from 'chalk'
-import { lintProject, Diagnostic, Severity, formatProject } from '@sasjs/lint'
+import {
+  lintProject,
+  lintFile,
+  Diagnostic,
+  Severity,
+  formatProject,
+  FormatResult,
+  formatFile
+} from '@sasjs/lint'
+import { asyncForEach, listSasFilesInFolder } from '@sasjs/utils'
 
 interface LintResult {
   warnings: boolean
@@ -7,34 +17,157 @@ interface LintResult {
 }
 
 /**
- * Fixes lint violations in all .sas files in the current project
+ * Fixes lint violations in all .sas files in the current project if no filterArray is provided
+ * Otherwise fixes lint violations of only those .sas files which matches filter array
  * @returns {Promise<void>} resolves successfully when formatting has completed
  */
-export async function lintFix() {
-  await formatProject().then((result) => {
-    process.logger?.success(
-      `Resolved ${result.fixedDiagnosticsCount} violations.`
+export async function lintFix(filterArray: string[] = []) {
+  const results: FormatResult[] = []
+  let result: FormatResult = {
+    updatedFilePaths: [],
+    fixedDiagnosticsCount: 0,
+    unfixedDiagnostics: new Map<string, Diagnostic[]>()
+  }
+
+  if (filterArray.length) {
+    // We can simply format files with absolute path.
+    // No need to include these filter values to regex for matching patterns
+    const absoluteFilePaths = filterArray.filter((pattern) =>
+      path.isAbsolute(pattern)
     )
+    await asyncForEach(absoluteFilePaths, async (filePath) => {
+      const formatResult = await formatFile(filePath)
+
+      result.updatedFilePaths.push(...formatResult.updatedFilePaths)
+      result.fixedDiagnosticsCount += formatResult.fixedDiagnosticsCount
+
+      const unfixedDiagnostics = formatResult.unfixedDiagnostics as Diagnostic[]
+      if (unfixedDiagnostics.length) {
+        ;(<Map<string, Diagnostic[]>>result.unfixedDiagnostics).set(
+          filePath,
+          unfixedDiagnostics
+        )
+      }
+    })
+
+    // Remove absolute file path patterns.
+    // No need to include these patterns in regex,
+    // Because we have already formatted on these patterns
+    const nonAbsoluteFilePathPatterns = filterArray.filter(
+      (pattern) => !path.isAbsolute(pattern)
+    )
+
+    if (nonAbsoluteFilePathPatterns.length) {
+      const regexPattern = nonAbsoluteFilePathPatterns
+        .map((pattern) => `(${pattern})`)
+        .join('|')
+
+      const regex = new RegExp(regexPattern)
+      const sasFiles = await listSasFilesInFolder(process.projectDir, true, [
+        'node_modules'
+      ])
+
+      const filesToLint = sasFiles.filter((file) => regex.test(file))
+
+      await asyncForEach(filesToLint, async (file) => {
+        const formatResult = await formatFile(file)
+
+        result.updatedFilePaths.push(...formatResult.updatedFilePaths)
+        result.fixedDiagnosticsCount += formatResult.fixedDiagnosticsCount
+
+        const unfixedDiagnostics =
+          formatResult.unfixedDiagnostics as Diagnostic[]
+        if (unfixedDiagnostics.length) {
+          ;(<Map<string, Diagnostic[]>>result.unfixedDiagnostics).set(
+            file,
+            unfixedDiagnostics
+          )
+        }
+      })
+    }
+  } else {
+    result = await formatProject()
+  }
+
+  process.logger?.success(
+    `Resolved ${result.fixedDiagnosticsCount} violations.`
+  )
+
+  if (result.updatedFilePaths.length) {
     process.logger?.info('Updated files:')
     result.updatedFilePaths.forEach((filePath: string) => {
       process.logger?.info(filePath)
     })
+  }
+
+  const unfixedDiagnostics = <Map<string, Diagnostic[]>>(
+    result.unfixedDiagnostics
+  )
+
+  if (unfixedDiagnostics.size) {
     process.logger?.warn('Unresolved violations: ')
     ;(<Map<string, Diagnostic[]>>result.unfixedDiagnostics).forEach(
       (diagnostics: Diagnostic[], filePath: string) => {
-        displayDiagnostics(filePath, diagnostics)
+        if (diagnostics.length) {
+          displayDiagnostics(filePath, diagnostics)
+        }
       }
     )
-  })
+  }
 }
 
 /**
- * Lints all .sas files in the current project
+ * Lints all .sas files in the current project if no filterArray is provided
+ * Otherwise lints .sas files which matches filter array
  * @returns an object containing booleans `warnings` and `errors`
  */
-export async function processLint(): Promise<LintResult> {
+export async function processLint(
+  filterArray: string[] = []
+): Promise<LintResult> {
   const found: LintResult = { warnings: false, errors: false }
-  const sasjsDiagnosticsMap: Map<string, Diagnostic[]> = await lintProject()
+  let sasjsDiagnosticsMap: Map<string, Diagnostic[]> = new Map<
+    string,
+    Diagnostic[]
+  >()
+
+  if (filterArray.length) {
+    // We can simply run lintFile on files with absolute path.
+    // No need to include these filter values to regex for matching patterns
+    const absoluteFilePaths = filterArray.filter((pattern) =>
+      path.isAbsolute(pattern)
+    )
+    await asyncForEach(absoluteFilePaths, async (filePath) => {
+      sasjsDiagnosticsMap.set(filePath, await lintFile(filePath))
+    })
+
+    // Remove absolute file path patterns.
+    // No need to include these patterns in regex,
+    // Because we have already run lint on these patterns
+    const nonAbsoluteFilePathPatterns = filterArray.filter(
+      (pattern) => !path.isAbsolute(pattern)
+    )
+
+    if (nonAbsoluteFilePathPatterns.length) {
+      const regexPattern = nonAbsoluteFilePathPatterns
+        .map((pattern) => `(${pattern})`)
+        .join('|')
+
+      const regex = new RegExp(regexPattern)
+      const sasFiles = await listSasFilesInFolder(process.projectDir, true, [
+        'node_modules'
+      ])
+
+      const filesToLint = sasFiles.filter((file) => regex.test(file))
+
+      await asyncForEach(filesToLint, async (file) => {
+        const filePath = path.join(process.projectDir, file)
+        sasjsDiagnosticsMap.set(filePath, await lintFile(filePath))
+      })
+    }
+  } else {
+    // if filterArray is empty, lint whole project
+    sasjsDiagnosticsMap = await lintProject()
+  }
 
   sasjsDiagnosticsMap.forEach(
     (sasjsDiagnostics: Diagnostic[], filePath: string) => {

--- a/src/commands/lint/spec/lintCommand.spec.ts
+++ b/src/commands/lint/spec/lintCommand.spec.ts
@@ -20,6 +20,15 @@ describe('LintCommand', () => {
     expect(command.subCommand).toEqual('find')
   })
 
+  it('should parse a sasjs lint command with filter strings', () => {
+    const args = [...defaultArgs, 'lint', 'find', 'pattern1', 'pattern2']
+
+    const command = new LintCommand(args)
+
+    expect(command.name).toEqual('lint')
+    expect(command.subCommand).toEqual('find')
+  })
+
   it('should log success and return the success code when execution is successful', async () => {
     const args = [...defaultArgs, 'lint']
 
@@ -81,6 +90,15 @@ describe('LintCommand - fix', () => {
 
   it('should parse a simple sasjs lint command', () => {
     const args = [...defaultArgs, 'lint', 'fix']
+
+    const command = new LintCommand(args)
+
+    expect(command.name).toEqual('lint')
+    expect(command.subCommand).toEqual('fix')
+  })
+
+  it('should parse sasjs lint command', () => {
+    const args = [...defaultArgs, 'lint', 'fix', 'pattern1', 'pattern2']
 
     const command = new LintCommand(args)
 

--- a/src/commands/lint/spec/lintCommand.spec.ts
+++ b/src/commands/lint/spec/lintCommand.spec.ts
@@ -17,7 +17,7 @@ describe('LintCommand', () => {
     const command = new LintCommand(args)
 
     expect(command.name).toEqual('lint')
-    expect(command.subCommand).toEqual('')
+    expect(command.subCommand).toEqual('find')
   })
 
   it('should log success and return the success code when execution is successful', async () => {

--- a/src/types/command/commandBase.ts
+++ b/src/types/command/commandBase.ts
@@ -10,7 +10,7 @@ const subCommandMap = new Map<string, string[]>([
   ['doc', ['init', 'lineage']],
   ['servicepack', ['deploy']],
   ['add', ['cred']],
-  ['lint', ['init', 'fix']],
+  ['lint', ['init', 'fix', 'find']],
   ['flow', ['execute']]
 ])
 


### PR DESCRIPTION
## Issue

closes #1304 

## Intent

* In the lint command if any arguments ate provided after the subCommand, they will be treated as filter patterns. And `lint` or `lint fix` will be performed on files that match the specified pattern.


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
