### PR TITLE
fix: improvements to sasjs init

### DIFF
--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -6,8 +6,7 @@ import {
   setupDoxygen
 } from '../../utils/utils'
 
-import { fileExists } from '@sasjs/utils'
-import { createConfigFile } from '../shared/createConfigFile'
+import { fileExists, createFile } from '@sasjs/utils'
 import { createLintConfigFile } from '../shared/createLintConfigFile'
 
 export async function init() {
@@ -29,4 +28,32 @@ export async function init() {
   )
   if (!(await fileExists(lintConfigPath)))
     await createLintConfigFile(parentFolderName)
+}
+
+/**
+ * Creates a SASjs configuration file.
+ * Its name will be of the form 'sasjsconfig.json'
+ * @param {string} parentFolderName- the name of the project folder.
+ */
+export const createConfigFile = async (parentFolderName: string) => {
+  const config = {
+    $schema: 'https://cli.sasjs.io/sasjsconfig-schema.json',
+    macroFolders: ['sasjs/macros'],
+    defaultTarget: 'mytarget',
+    targets: [
+      {
+        name: 'mytarget',
+        serverType: 'SASJS',
+        serverUrl: ' ',
+        appLoc: '/Public/apps/myapp'
+      }
+    ]
+  }
+  const configDestinationPath = path.join(
+    process.projectDir,
+    parentFolderName,
+    'sasjs',
+    'sasjsconfig.json'
+  )
+  await createFile(configDestinationPath, JSON.stringify(config, null, 2))
 }

--- a/src/commands/init/spec/init.spec.ts
+++ b/src/commands/init/spec/init.spec.ts
@@ -69,6 +69,6 @@ const verifyInit = async () => {
 
   const gitIgnoreFilePath = path.join(process.projectDir, '.gitignore')
   const gitIgnoreContent = await readFile(gitIgnoreFilePath)
-  expect(gitIgnoreContent.match(/^sasjsbuild\//gm)!.length).toEqual(1)
-  expect(gitIgnoreContent.match(/^node_modules\//gm)!.length).toEqual(1)
+  expect(gitIgnoreContent.match(/^sasjsbuild/gm)!.length).toEqual(1)
+  expect(gitIgnoreContent.match(/^node_modules/gm)!.length).toEqual(1)
 }

--- a/src/config.json
+++ b/src/config.json
@@ -195,14 +195,126 @@
   ],
   "config": {
     "$schema": "https://cli.sasjs.io/sasjsconfig-schema.json",
+    "docConfig": {
+      "displayMacroCore": true,
+      "enableLineage": true,
+      "outDirectory": "",
+      "dataControllerUrl": "",
+      "doxyContent": {
+        "favIcon": "favicon.ico",
+        "footer": "new_footer.html",
+        "header": "new_header.html",
+        "layout": "DoxygenLayout.xml",
+        "logo": "logo.png",
+        "readMe": "../../README.md",
+        "stylesheet": "new_stylesheet.css",
+        "path": "./sasjs/doxy/"
+      }
+    },
+    "buildConfig": {
+      "initProgram": "sasjs/build/buildinit.sas",
+      "termProgram": "sasjs/build/buildterm.sas",
+      "buildOutputFolder": "sasjsbuild",
+      "buildResultsFolder": "sasjsresults",
+      "macroVars": {
+        "name": "value",
+        "numvar": "42"
+      }
+    },
+    "deployConfig": {
+      "deployScripts": ["sasjs/build/deployscript.sh"]
+    },
+    "serviceConfig": {
+      "serviceFolders": ["sasjs/services/common", "sasjs/services/admin"],
+      "initProgram": "sasjs/build/serviceinit.sas",
+      "termProgram": "sasjs/build/serviceterm.sas",
+      "macroVars": {
+        "name": "value",
+        "numvar": "42"
+      }
+    },
     "macroFolders": ["sasjs/macros"],
-    "defaultTarget": "mytarget",
+    "programFolders": ["sasjs/programs"],
+    "binaryFolders": ["sasjs/binaries"],
+    "serverType": "SASVIYA",
     "targets": [
       {
-        "name": "mytarget",
-        "serverType": "SASJS",
-        "serverUrl": "",
-        "appLoc": "/Public/apps/myapp"
+        "name": "viya",
+        "serverType": "SASVIYA",
+        "serverUrl": "https://sas.analytium.co.uk",
+        "httpsAgentOptions": {
+          "allowInsecureRequests": false
+        },
+        "appLoc": "/Public/app",
+        "contextName": "SAS Job Execution compute context",
+        "buildConfig": {
+          "buildOutputFileName": "myviyadeploy.sas",
+          "initProgram": "sasjs/build/buildinitviya.sas",
+          "termProgram": "sasjs/targets/viya/viyabuildterm.sas",
+          "macroVars": {
+            "name": "viyavalue",
+            "extravar": "this too"
+          }
+        },
+        "deployConfig": {
+          "deployServicePack": true,
+          "deployScripts": ["sasjsbuild/myviyadeploy.sas"]
+        },
+        "serviceConfig": {
+          "serviceFolders": ["sasjs/targets/viya/services/admin"],
+          "initProgram": "sasjs/build/serviceinit.sas",
+          "termProgram": "sasjs/build/serviceinit.sas",
+          "macroVars": {
+            "name": "viyavalue",
+            "extravar": "this too"
+          }
+        },
+        "jobConfig": {
+          "jobFolders": [],
+          "initProgram": "",
+          "termProgram": "",
+          "macroVars": {}
+        },
+        "streamConfig": {
+          "assetPaths": [],
+          "streamWeb": false,
+          "streamWebFolder": "webv",
+          "webSourcePath": "dist"
+        },
+        "macroFolders": ["sasjs/targets/viya/macros"],
+        "programFolders": []
+      },
+      {
+        "name": "sas9",
+        "serverType": "SAS9",
+        "serverUrl": "https://sas.analytium.co.uk:8343",
+        "appLoc": "/User Folders/&sysuserid/My Folder",
+        "serverName": "Foundation",
+        "repositoryName": "SASApp",
+        "buildConfig": {
+          "buildOutputFileName": "mysas9deploy.sas",
+          "initProgram": "",
+          "termProgram": "",
+          "macroVars": {}
+        },
+        "deployConfig": {
+          "deployScripts": ["sasjs/build/deploysas9.sh"],
+          "deployServicePack": false
+        },
+        "serviceConfig": {
+          "serviceFolders": ["sasjs/targets/sas9/services/admin"],
+          "initProgram": "",
+          "termProgram": "sasjs/build/servicetermother.sas",
+          "macroVars": {}
+        },
+        "streamConfig": {
+          "assetPaths": [],
+          "streamWeb": false,
+          "streamWebFolder": "web9",
+          "webSourcePath": "dist"
+        },
+        "macroFolders": ["sasjs/targets/sas9/macros"],
+        "programFolders": []
       }
     ]
   }

--- a/src/config.json
+++ b/src/config.json
@@ -195,126 +195,14 @@
   ],
   "config": {
     "$schema": "https://cli.sasjs.io/sasjsconfig-schema.json",
-    "docConfig": {
-      "displayMacroCore": true,
-      "enableLineage": true,
-      "outDirectory": "",
-      "dataControllerUrl": "",
-      "doxyContent": {
-        "favIcon": "favicon.ico",
-        "footer": "new_footer.html",
-        "header": "new_header.html",
-        "layout": "DoxygenLayout.xml",
-        "logo": "logo.png",
-        "readMe": "../../README.md",
-        "stylesheet": "new_stylesheet.css",
-        "path": "./sasjs/doxy/"
-      }
-    },
-    "buildConfig": {
-      "initProgram": "sasjs/build/buildinit.sas",
-      "termProgram": "sasjs/build/buildterm.sas",
-      "buildOutputFolder": "sasjsbuild",
-      "buildResultsFolder": "sasjsresults",
-      "macroVars": {
-        "name": "value",
-        "numvar": "42"
-      }
-    },
-    "deployConfig": {
-      "deployScripts": ["sasjs/build/deployscript.sh"]
-    },
-    "serviceConfig": {
-      "serviceFolders": ["sasjs/services/common", "sasjs/services/admin"],
-      "initProgram": "sasjs/build/serviceinit.sas",
-      "termProgram": "sasjs/build/serviceterm.sas",
-      "macroVars": {
-        "name": "value",
-        "numvar": "42"
-      }
-    },
     "macroFolders": ["sasjs/macros"],
-    "programFolders": ["sasjs/programs"],
-    "binaryFolders": ["sasjs/binaries"],
-    "serverType": "SASVIYA",
+    "defaultTarget": "mytarget",
     "targets": [
       {
-        "name": "viya",
-        "serverType": "SASVIYA",
-        "serverUrl": "https://sas.analytium.co.uk",
-        "httpsAgentOptions": {
-          "allowInsecureRequests": false
-        },
-        "appLoc": "/Public/app",
-        "contextName": "SAS Job Execution compute context",
-        "buildConfig": {
-          "buildOutputFileName": "myviyadeploy.sas",
-          "initProgram": "sasjs/build/buildinitviya.sas",
-          "termProgram": "sasjs/targets/viya/viyabuildterm.sas",
-          "macroVars": {
-            "name": "viyavalue",
-            "extravar": "this too"
-          }
-        },
-        "deployConfig": {
-          "deployServicePack": true,
-          "deployScripts": ["sasjsbuild/myviyadeploy.sas"]
-        },
-        "serviceConfig": {
-          "serviceFolders": ["sasjs/targets/viya/services/admin"],
-          "initProgram": "sasjs/build/serviceinit.sas",
-          "termProgram": "sasjs/build/serviceinit.sas",
-          "macroVars": {
-            "name": "viyavalue",
-            "extravar": "this too"
-          }
-        },
-        "jobConfig": {
-          "jobFolders": [],
-          "initProgram": "",
-          "termProgram": "",
-          "macroVars": {}
-        },
-        "streamConfig": {
-          "assetPaths": [],
-          "streamWeb": false,
-          "streamWebFolder": "webv",
-          "webSourcePath": "dist"
-        },
-        "macroFolders": ["sasjs/targets/viya/macros"],
-        "programFolders": []
-      },
-      {
-        "name": "sas9",
-        "serverType": "SAS9",
-        "serverUrl": "https://sas.analytium.co.uk:8343",
-        "appLoc": "/User Folders/&sysuserid/My Folder",
-        "serverName": "Foundation",
-        "repositoryName": "SASApp",
-        "buildConfig": {
-          "buildOutputFileName": "mysas9deploy.sas",
-          "initProgram": "",
-          "termProgram": "",
-          "macroVars": {}
-        },
-        "deployConfig": {
-          "deployScripts": ["sasjs/build/deploysas9.sh"],
-          "deployServicePack": false
-        },
-        "serviceConfig": {
-          "serviceFolders": ["sasjs/targets/sas9/services/admin"],
-          "initProgram": "",
-          "termProgram": "sasjs/build/servicetermother.sas",
-          "macroVars": {}
-        },
-        "streamConfig": {
-          "assetPaths": [],
-          "streamWeb": false,
-          "streamWebFolder": "web9",
-          "webSourcePath": "dist"
-        },
-        "macroFolders": ["sasjs/targets/sas9/macros"],
-        "programFolders": []
+        "name": "mytarget",
+        "serverType": "SASJS",
+        "serverUrl": "",
+        "appLoc": "/Public/apps/myapp"
       }
     ]
   }

--- a/src/utils/spec/utils.spec.ts
+++ b/src/utils/spec/utils.spec.ts
@@ -152,7 +152,7 @@ describe('utils', () => {
 
       const gitIgnoreContent = await readFile(gitFilePath)
 
-      expect(gitIgnoreContent.includes('sasjsbuild/')).toEqual(true)
+      expect(gitIgnoreContent.includes('sasjsbuild')).toEqual(true)
 
       await deleteFile(gitFilePath)
     })
@@ -164,7 +164,7 @@ describe('utils', () => {
 
       await expect(setupGitIgnore(folderPath)).toResolve()
 
-      const regExp = new RegExp(`^node_modules\/\nsasjsbuild\/\n`, 'gm')
+      const regExp = new RegExp(`^node_modules\/\nsasjsbuild\n`, 'gm')
 
       gitIgnoreContent = await readFile(gitFilePath)
 
@@ -176,7 +176,7 @@ describe('utils', () => {
 
       await expect(setupGitIgnore(folderPath)).toResolve()
 
-      const regExp = new RegExp(`^sasjsbuild\/`, 'gm')
+      const regExp = new RegExp(`^sasjsbuild`, 'gm')
 
       expect(gitIgnoreContent.match(regExp)).toBeTruthy()
       expect(gitIgnoreContent.match(regExp)!.length).toEqual(1)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -225,7 +225,7 @@ function downloadFile(url: string, filename?: string): ShellString {
 export async function setupNpmProject(folderName: string): Promise<void> {
   const folderPath = path.join(process.projectDir, folderName)
   return new Promise(async (resolve, _) => {
-    const isExistingProject = await inExistingProject(folderPath)
+    const isExistingProject = await inExistingProject(folderName)
     if (!isExistingProject) {
       process.logger?.info(`Initialising NPM project in ${folderPath}`)
       shelljs.exec(`cd "${folderPath}" && npm init --yes`, {
@@ -255,21 +255,24 @@ export async function setupGitIgnore(folderName: string): Promise<void> {
     let newgitIgnoreContent = gitIgnoreContent
 
     const regExpSasjsBuild = new RegExp(`^sasjsbuild\/`, 'gm')
-    newgitIgnoreContent = newgitIgnoreContent.match(regExpSasjsBuild)
-      ? newgitIgnoreContent
-      : `${newgitIgnoreContent ? newgitIgnoreContent + '\n' : ''}sasjsbuild/\n`
-
     const regExpSasjsResults = new RegExp(`^sasjsresults\/`, 'gm')
-    newgitIgnoreContent = newgitIgnoreContent.match(regExpSasjsResults)
-      ? newgitIgnoreContent
-      : `${
-          newgitIgnoreContent ? newgitIgnoreContent + '\n' : ''
-        }sasjsresults/\n`
-
     const regExpNodeModules = new RegExp(`^node_modules\/`, 'gm')
-    newgitIgnoreContent = newgitIgnoreContent.match(regExpNodeModules)
-      ? newgitIgnoreContent
-      : `${newgitIgnoreContent + '\n'}node_modules/\n`
+
+    if (newgitIgnoreContent) {
+      if (!regExpSasjsBuild.test(newgitIgnoreContent)) {
+        newgitIgnoreContent += '\nsasjsbuild/'
+      }
+
+      if (!regExpSasjsResults.test(newgitIgnoreContent)) {
+        newgitIgnoreContent += '\nsasjsresults/'
+      }
+
+      if (!regExpNodeModules.test(newgitIgnoreContent)) {
+        newgitIgnoreContent += '\nnode_modules/'
+      }
+    } else {
+      newgitIgnoreContent = 'node_modules/\nsasjsbuild/\nsasjsresults/\n.env*\n'
+    }
 
     if (gitIgnoreContent !== newgitIgnoreContent) {
       await createFile(gitIgnoreFilePath, newgitIgnoreContent)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -254,24 +254,29 @@ export async function setupGitIgnore(folderName: string): Promise<void> {
     const gitIgnoreContent = await readFile(gitIgnoreFilePath)
     let newgitIgnoreContent = gitIgnoreContent
 
-    const regExpSasjsBuild = new RegExp(`^sasjsbuild\/`, 'gm')
-    const regExpSasjsResults = new RegExp(`^sasjsresults\/`, 'gm')
-    const regExpNodeModules = new RegExp(`^node_modules\/`, 'gm')
+    const regExpSasjsBuild = new RegExp(`^sasjsbuild`, 'gm')
+    const regExpSasjsResults = new RegExp(`^sasjsresults`, 'gm')
+    const regExpNodeModules = new RegExp(`^node_modules`, 'gm')
+    const regExpEnv = new RegExp(`^\.env\*`, 'gm')
 
     if (newgitIgnoreContent) {
       if (!regExpSasjsBuild.test(newgitIgnoreContent)) {
-        newgitIgnoreContent += '\nsasjsbuild/'
+        newgitIgnoreContent += '\nsasjsbuild'
       }
 
       if (!regExpSasjsResults.test(newgitIgnoreContent)) {
-        newgitIgnoreContent += '\nsasjsresults/'
+        newgitIgnoreContent += '\nsasjsresults'
       }
 
       if (!regExpNodeModules.test(newgitIgnoreContent)) {
-        newgitIgnoreContent += '\nnode_modules/'
+        newgitIgnoreContent += '\nnode_modules'
+      }
+
+      if (!regExpEnv.test(newgitIgnoreContent)) {
+        newgitIgnoreContent += '\n.env*'
       }
     } else {
-      newgitIgnoreContent = 'node_modules/\nsasjsbuild/\nsasjsresults/\n.env*\n'
+      newgitIgnoreContent = 'node_modules\nsasjsbuild\nsasjsresults\n.env*\n'
     }
 
     if (gitIgnoreContent !== newgitIgnoreContent) {
@@ -281,7 +286,7 @@ export async function setupGitIgnore(folderName: string): Promise<void> {
   } else {
     await createFile(
       gitIgnoreFilePath,
-      'node_modules/\nsasjsbuild/\nsasjsresults/\n.env*\n'
+      'node_modules\nsasjsbuild\nsasjsresults\n.env*\n'
     )
 
     process.logger?.success('.gitignore file has been created.')


### PR DESCRIPTION
## Issue

closes #1305

## Intent

* on sasjs init command, create minimal `sasjs/sasjsconfig.json` file
* sasjs init command should not destroy existing packages.json
* fix logic for updating the `.gitignore` file

## Implementation

* pass just folder name instead of whole path to `isExistingProject` function

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
