### PR TITLE
fix: add additional info to json file after completion of sasjs test

### DIFF
--- a/src/commands/testing/internal/saveOutput.ts
+++ b/src/commands/testing/internal/saveOutput.ts
@@ -40,30 +40,19 @@ export const saveLog = async (
   )
 }
 
-export const saveResultJson = async (
-  outDirectory: string,
-  result: TestResults
-) => {
-  let finaleResult
-
+export const saveResultJson = async (jsonPath: string, result: TestResults) => {
   try {
-    finaleResult = JSON.stringify(result, null, 2)
+    const finaleResult = JSON.stringify(result, null, 2)
+    await createFile(jsonPath, finaleResult)
   } catch (err) {
     displayError(err, 'Error while converting test results into a string.')
 
-    return false
+    throw new Error('Error while converting test results into a string.')
   }
-
-  const filePath = path.join(outDirectory, `${resultFileName}.json`)
-
-  if (finaleResult) await createFile(filePath, finaleResult)
-  else return false
-
-  return filePath
 }
 
 export const saveResultCsv = async (
-  outDirectory: string,
+  csvPath: string,
   result: TestResults,
   options: {} = {
     header: true,
@@ -76,7 +65,7 @@ export const saveResultCsv = async (
       test_url: 'test_url'
     }
   }
-): Promise<{ csvData: TestResultCsv[]; csvPath: string }> => {
+): Promise<TestResultCsv[]> => {
   const csvData: TestResultCsv[] = result.sasjs_test_meta.flatMap(
     (resTarget: any) =>
       resTarget.results.flatMap((res: TestResult) => {
@@ -110,23 +99,16 @@ export const saveResultCsv = async (
         reject(err)
       }
 
-      const csvPath = path.join(outDirectory, `${resultFileName}.csv`)
-
       await createFile(csvPath, output).catch((err) =>
         displayError(err, 'Error while creating CSV file.')
       )
 
-      return resolve({ csvData, csvPath })
+      return resolve(csvData)
     })
   )
 }
 
-export const saveResultXml = async (
-  outDirectory: string,
-  result: TestResults
-) => {
-  const filePath = path.join(outDirectory, `${resultFileName}.xml`)
-
+export const saveResultXml = async (xmlPath: string, result: TestResults) => {
   const getFailures = (testCase: TestResult) => {
     if (Array.isArray(testCase.result)) {
       return testCase.result
@@ -226,13 +208,11 @@ export const saveResultXml = async (
 
   const xmlString = xml(resultXml, { declaration: true, indent: '  ' })
 
-  await createFile(filePath, xmlString)
-
-  return filePath
+  await createFile(xmlPath, xmlString)
 }
 
 export const saveCoverageLcov = async (
-  outDirectory: string,
+  coverageReportPath: string,
   tests: string[]
 ) => {
   const testsPrefixRegExp = new RegExp(`^tests/`)
@@ -259,9 +239,5 @@ BRH:1
 end_of_record`)
   )
 
-  const filePath = path.join(outDirectory, 'coverage.lcov')
-
-  await createFile(filePath, coverageReport.join('\n'))
-
-  return filePath
+  await createFile(coverageReportPath, coverageReport.join('\n'))
 }

--- a/src/commands/testing/spec/testing.spec.ts
+++ b/src/commands/testing/spec/testing.spec.ts
@@ -127,7 +127,28 @@ end_of_record`
     })
 
     it('should execute tests and create result CSV, XML and JSON files using default source and output locations', async () => {
+      const resultsFolderPath = path.join(
+        __dirname,
+        target.name,
+        'sasjsresults'
+      )
+      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
+      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
+      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
+      const coverageReportPath = path.join(resultsFolderPath, 'coverage.lcov')
+
       const expectedResultsJson = {
+        csv_result_path: resultsCsvPath,
+        xml_result_path: resultsXmlPath,
+        coverage_report_path: coverageReportPath,
+        tests_that_pass: '2/7 (29%)',
+        tests_with_results: '7/8 (88%)',
+        target_name: target.name,
+        target_server_url: target.serverUrl,
+        target_server_type: target.serverType,
+        local_date_time: expect.anything(),
+        local_user_id: expect.anything(),
+        local_machine_name: expect.anything(),
         sasjs_test_meta: [
           {
             test_target: 'testsetup',
@@ -218,6 +239,7 @@ end_of_record`
           }
         ]
       }
+
       const expectedResultsCsv = `test_target,test_loc,sasjs_test_id,test_suite_result,test_description,test_url
 testsetup,tests/testsetup.sas,sasjs_test_id,not provided,,${testUrlLink(
         'testsetup'
@@ -244,19 +266,10 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
 
       await runTest(target, undefined, undefined, undefined, true)
 
-      const resultsFolderPath = path.join(
-        __dirname,
-        target.name,
-        'sasjsresults'
-      )
-      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
-
       await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
       await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
 
       const resultsJson = await readFile(resultsJsonPath)
-
-      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
 
       await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
 
@@ -281,8 +294,6 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
       )
 
       expect(resultsCsv).toEqual(expectedResultsCsv)
-
-      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
 
       await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
 
@@ -341,7 +352,32 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
     })
 
     it('should execute filtered tests and create result CSV, XML and JSON files using custom source and output locations', async () => {
+      const outputFolder = 'customOutPut'
+      const movedTestFlow = 'movedTestFlow.json'
+
+      await copy(
+        path.join(__dirname, target.name, 'sasjsbuild', 'testFlow.json'),
+        path.join(__dirname, target.name, movedTestFlow)
+      )
+
+      const resultsFolderPath = path.join(__dirname, target.name, outputFolder)
+      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
+      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
+      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
+      const coverageReportPath = path.join(resultsFolderPath, 'coverage.lcov')
+
       const expectedResultsJson = {
+        csv_result_path: resultsCsvPath,
+        xml_result_path: resultsXmlPath,
+        coverage_report_path: coverageReportPath,
+        tests_that_pass: '0/4 (0%)',
+        tests_with_results: '4/5 (80%)',
+        target_name: target.name,
+        target_server_url: target.serverUrl,
+        target_server_type: target.serverType,
+        local_date_time: expect.anything(),
+        local_user_id: expect.anything(),
+        local_machine_name: expect.anything(),
         sasjs_test_meta: [
           {
             test_target: 'testsetup',
@@ -409,14 +445,6 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
       )}
 `
 
-      const outputFolder = 'customOutPut'
-      const movedTestFlow = 'movedTestFlow.json'
-
-      await copy(
-        path.join(__dirname, target.name, 'sasjsbuild', 'testFlow.json'),
-        path.join(__dirname, target.name, movedTestFlow)
-      )
-
       await runTest(
         target,
         ['jobs/standalone', 'shouldFail', 'services/admin/dostuff.test.0'],
@@ -425,15 +453,10 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
         true
       )
 
-      const resultsFolderPath = path.join(__dirname, target.name, outputFolder)
-      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
-
       await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
       await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
 
       const resultsJson = await readFile(resultsJsonPath)
-
-      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
 
       await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
 
@@ -474,8 +497,6 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
       const log = await readFile(logPath)
 
       expect(log.length).toBeGreaterThan(0)
-
-      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
 
       await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
 
@@ -542,7 +563,28 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
     })
 
     it('should execute tests and create result CSV, XML and JSON files using default source and output locations', async () => {
+      const resultsFolderPath = path.join(
+        __dirname,
+        target.name,
+        'sasjsresults'
+      )
+      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
+      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
+      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
+      const coverageReportPath = path.join(resultsFolderPath, 'coverage.lcov')
+
       const expectedResultsJson = {
+        csv_result_path: resultsCsvPath,
+        xml_result_path: resultsXmlPath,
+        coverage_report_path: coverageReportPath,
+        tests_that_pass: '2/8 (25%)',
+        tests_with_results: '8/8 (100%)',
+        target_name: target.name,
+        target_server_url: target.serverUrl,
+        target_server_type: target.serverType,
+        local_date_time: expect.anything(),
+        local_user_id: expect.anything(),
+        local_machine_name: expect.anything(),
         sasjs_test_meta: [
           {
             test_target: 'testsetup',
@@ -673,19 +715,10 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
 
       await runTest(target, undefined, undefined, undefined, true)
 
-      const resultsFolderPath = path.join(
-        __dirname,
-        target.name,
-        'sasjsresults'
-      )
-      const resultsJsonPath = path.join(resultsFolderPath, 'testResults.json')
-
       await expect(folderExists(resultsFolderPath)).resolves.toEqual(true)
       await expect(fileExists(resultsJsonPath)).resolves.toEqual(true)
 
       const resultsJson = await readFile(resultsJsonPath)
-
-      const resultsCsvPath = path.join(resultsFolderPath, 'testResults.csv')
 
       await expect(fileExists(resultsCsvPath)).resolves.toEqual(true)
 
@@ -710,8 +743,6 @@ testteardown,tests/testteardown.sas,sasjs_test_id,not provided,,${testUrlLink(
       )
 
       expect(resultsCsv).toEqual(expectedResultsCsv)
-
-      const resultsXmlPath = path.join(resultsFolderPath, 'testResults.xml')
 
       await expect(fileExists(resultsXmlPath)).resolves.toEqual(true)
 

--- a/src/types/testing.ts
+++ b/src/types/testing.ts
@@ -1,3 +1,5 @@
+import { ServerType } from '@sasjs/utils'
+
 export interface TestFlow {
   testSetUp?: string
   testTearDown?: string
@@ -47,6 +49,19 @@ export interface TestResult {
 }
 export interface TestResults {
   sasjs_test_meta: TestDescription[]
+  csv_result_path?: string
+  xml_result_path?: string
+  coverage_report_path?: string
+  failed_to_complete?: number
+  completed_with_failures?: number
+  tests_with_results?: string
+  tests_that_pass?: string
+  target_name?: string
+  target_server_url?: string
+  target_server_type?: ServerType
+  local_date_time?: string
+  local_user_id?: string
+  local_machine_name?: string
 }
 
 export interface TestResultCsv {


### PR DESCRIPTION
## Issue

closes #1284

## Intent

add the following additional info to JSON file:
  * csv_result_path
  * xml_result_path
  * coverage_report_path
  * failed_to_complete
  * completed_with_failures
  * tests_with_results
  * tests_that_pass
  * target_name
  * target_server_url
  * target_server_type
  * local_date_time
  * local_user_id
  * local_machine_name


## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
