### PR TITLE
fix: bump sasjs lint version to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@sasjs/adapter": "4.1.3",
         "@sasjs/core": "4.45.4",
-        "@sasjs/lint": "2.2.1",
+        "@sasjs/lint": "2.2.2",
         "@sasjs/utils": "2.52.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
@@ -2137,9 +2137,9 @@
       "integrity": "sha512-zf0foZHXNUb7hTHQAbGcQbHhiwX7qNK9g3PTT5XkjR8aDgcYeBpSxu1bEj7GTVvOmv49YF/3xrVZNh5J+38+DA=="
     },
     "node_modules/@sasjs/lint": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.2.1.tgz",
-      "integrity": "sha512-Y1/+IeIBLIqgTK8WiGKbq2dKfMCnrktkGfvElaWpsMw2enoB6llhJpa2jb3BBhOxX0c5gDbLGlynQlh8gyGyiA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.2.2.tgz",
+      "integrity": "sha512-s0E5O1bS7USZLyx7RjH8A5VDuZIrS1e5xYPVXx+N4KomlGntAOpAGiFS0kQmQ3XT0nmFPk/De+jEFD7089QX4A==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -9346,9 +9346,9 @@
       "integrity": "sha512-zf0foZHXNUb7hTHQAbGcQbHhiwX7qNK9g3PTT5XkjR8aDgcYeBpSxu1bEj7GTVvOmv49YF/3xrVZNh5J+38+DA=="
     },
     "@sasjs/lint": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.2.1.tgz",
-      "integrity": "sha512-Y1/+IeIBLIqgTK8WiGKbq2dKfMCnrktkGfvElaWpsMw2enoB6llhJpa2jb3BBhOxX0c5gDbLGlynQlh8gyGyiA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.2.2.tgz",
+      "integrity": "sha512-s0E5O1bS7USZLyx7RjH8A5VDuZIrS1e5xYPVXx+N4KomlGntAOpAGiFS0kQmQ3XT0nmFPk/De+jEFD7089QX4A==",
       "requires": {
         "@sasjs/utils": "2.52.0",
         "ignore": "5.2.4"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@sasjs/adapter": "4.1.3",
     "@sasjs/core": "4.45.4",
-    "@sasjs/lint": "2.2.1",
+    "@sasjs/lint": "2.2.2",
     "@sasjs/utils": "2.52.0",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",


### PR DESCRIPTION
## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
