### PR TITLE
feat(compile): added currentFolder argument

### DIFF
--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -9,6 +9,7 @@ import {
   listSubFoldersInFolder,
   listFilesInFolder,
   createFile,
+  folderExists,
   asyncForEach,
   removeHeader
 } from '@sasjs/utils'
@@ -37,7 +38,12 @@ import {
 } from '../compile/internal/loadDependencies'
 
 export async function build(target: Target) {
-  await compile(target)
+  if (
+    process.sasjsConstants.buildDestinationFolder &&
+    !(await folderExists(process.sasjsConstants.buildDestinationFolder))
+  ) {
+    await compile(target)
+  }
 
   await createFinalSasFiles(target)
 }

--- a/src/commands/compile/compileSingleFile.ts
+++ b/src/commands/compile/compileSingleFile.ts
@@ -18,7 +18,8 @@ export async function compileSingleFile(
   subCommand: string = 'identify',
   source: string,
   output: string,
-  insertProgramVar: boolean = false
+  insertProgramVar: boolean = false,
+  currentFolder?: string
 ) {
   const subCommands = {
     job: 'job',
@@ -42,7 +43,10 @@ export async function compileSingleFile(
 
   source = source.split('/').join(path.sep)
 
-  const sourcePath = getAbsolutePath(source, process.currentDir)
+  const sourcePath = getAbsolutePath(
+    source,
+    currentFolder || process.currentDir
+  )
 
   if (!(await validateSourcePath(sourcePath))) {
     throw new Error(`Provide a path to source file (eg '${commandExample}')`)


### PR DESCRIPTION
## Issue

When `@sasjs/cli` functions are used in `@sasjs/vscode-extension` the `process` object is undefined and the current folder has to be provided in order to use the `compile` function

## Intent

- Improve the `compile` function.

## Implementation

- Added the `currentFolder` optional attribute to the `compile` function.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
