### PR TITLE
BREAKING CHANGE: bump sasjs utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@sasjs/adapter": "4.1.3",
         "@sasjs/core": "4.45.4",
         "@sasjs/lint": "2.2.2",
-        "@sasjs/utils": "3.0.1",
+        "@sasjs/utils": "3.1.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
         "dotenv": "10.0.0",
@@ -2244,9 +2244,9 @@
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
     "node_modules/@sasjs/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-0+4uUY3UPwTyl1Ll/HMJspihgEGggEIpJtd/NVIIZAfhODY4g1c8bLGkmQW6kASItPSkHDCiiW6ZUb0xTo5+4w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-b6Xjim+IjPAPS/dx6VVaZxz0J6kR+miAMst38oyaRU0FdyakmGizYalXcl0sEafZsImuTbtOTAQ/YMxrm/LAJg==",
       "hasInstallScript": true,
       "dependencies": {
         "@fast-csv/format": "4.3.5",
@@ -9557,9 +9557,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-0+4uUY3UPwTyl1Ll/HMJspihgEGggEIpJtd/NVIIZAfhODY4g1c8bLGkmQW6kASItPSkHDCiiW6ZUb0xTo5+4w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-b6Xjim+IjPAPS/dx6VVaZxz0J6kR+miAMst38oyaRU0FdyakmGizYalXcl0sEafZsImuTbtOTAQ/YMxrm/LAJg==",
       "requires": {
         "@fast-csv/format": "4.3.5",
         "@types/fs-extra": "9.0.13",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@sasjs/adapter": "4.1.3",
     "@sasjs/core": "4.45.4",
     "@sasjs/lint": "2.2.2",
-    "@sasjs/utils": "3.0.1",
+    "@sasjs/utils": "3.1.0",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",
     "dotenv": "10.0.0",

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -274,7 +274,6 @@ describe('sasjs compile single file', () => {
 })
 
 const defaultBuildConfig: BuildConfig = {
-  buildOutputFolder: '.sasjs/sasjsbuild',
   buildOutputFileName: 'test.sas',
   initProgram: '',
   termProgram: '',
@@ -472,10 +471,8 @@ describe('sasjs compile outside project', () => {
 
       await updateConfig(
         {
-          buildConfig: {
-            ...defaultBuildConfig,
-            buildOutputFolder
-          }
+          sasjsBuildFolder: buildOutputFolder,
+          buildConfig: defaultBuildConfig
         },
         false
       )
@@ -527,10 +524,8 @@ describe('sasjs compile outside project', () => {
 
       await updateConfig(
         {
-          buildConfig: {
-            ...defaultBuildConfig,
-            buildOutputFolder: appName + '/random-folder'
-          }
+          sasjsBuildFolder: appName + '/random-folder',
+          buildConfig: defaultBuildConfig
         },
         false
       )

--- a/src/commands/fs/fsCommand.ts
+++ b/src/commands/fs/fsCommand.ts
@@ -183,6 +183,8 @@ export class FSCommand extends TargetCommand {
   }
 
   async compile() {
+    // NOTE: call getTargetInfo() method once, so that process.sasjsConstants could be updated based on target config
+    await this.getTargetInfo()
     const folderPath = this.localFolder
     const outputPath = await this.getOutputPath()
 

--- a/src/types/command/targetCommand.ts
+++ b/src/types/command/targetCommand.ts
@@ -2,7 +2,8 @@ import { Target } from '@sasjs/utils'
 import {
   findTargetInConfiguration,
   loadTargetEnvVariables,
-  validateTargetName
+  validateTargetName,
+  updateSasjsConstants
 } from '../../utils'
 import { CommandBase, CommandOptions } from './commandBase'
 import { ReturnCode } from './returnCode'
@@ -40,7 +41,7 @@ export class TargetCommand extends CommandBase {
     return await findTargetInConfiguration(targetName)
       .then((res) => {
         this._targetInfo = res
-
+        updateSasjsConstants(res.target, res.isLocal)
         return res
       })
       .catch((err) => {

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { getLocalOrGlobalConfig } from './config'
 import { getNodeModulePath } from './utils'
-import { getAbsolutePath } from '@sasjs/utils'
+import { getAbsolutePath, Target } from '@sasjs/utils'
 
 export const contextName = 'sasjs cli compute context'
 
@@ -13,27 +13,33 @@ export const setConstants = async () => {
     })
   )
   const buildOutputFolder =
-    configuration?.buildConfig?.buildOutputFolder ||
+    configuration?.sasjsBuildFolder ||
     (isLocal ? 'sasjsbuild' : '.sasjs/sasjsbuild')
+
   const buildResultsFolder =
-    configuration?.buildConfig?.buildResultsFolder ||
+    configuration?.sasjsResultsFolder ||
     (isLocal ? 'sasjsresults' : '.sasjs/sasjsresults')
+
   const homeDir = require('os').homedir()
 
   const buildSourceFolder = path.join(isLocal ? process.projectDir : homeDir)
+
   const buildSourceDbFolder = path.join(
     isLocal ? process.projectDir : homeDir,
     'sasjs',
     'db'
   )
+
   const buildDestinationFolder = getAbsolutePath(
     buildOutputFolder,
     isLocal ? process.projectDir : homeDir
   )
+
   const buildDestinationServicesFolder = path.join(
     buildDestinationFolder,
     'services'
   )
+
   const buildDestinationTestFolder = path.join(buildDestinationFolder, 'tests')
   const buildDestinationJobsFolder = path.join(buildDestinationFolder, 'jobs')
   const buildDestinationDbFolder = path.join(buildDestinationFolder, 'db')
@@ -75,5 +81,59 @@ export const setConstants = async () => {
     sas9CredentialsError,
     invalidSasError,
     sas9GUID
+  }
+}
+
+export const updateSasjsConstants = (target: Target, isLocal: boolean) => {
+  const homeDir = require('os').homedir()
+
+  if (target.sasjsBuildFolder) {
+    const buildOutputFolder = target.sasjsBuildFolder
+
+    const buildDestinationFolder = getAbsolutePath(
+      buildOutputFolder,
+      isLocal ? process.projectDir : homeDir
+    )
+
+    process.sasjsConstants.buildDestinationFolder = buildDestinationFolder
+
+    process.sasjsConstants.buildDestinationServicesFolder = path.join(
+      buildDestinationFolder,
+      'services'
+    )
+
+    process.sasjsConstants.buildDestinationTestFolder = path.join(
+      buildDestinationFolder,
+      'tests'
+    )
+    process.sasjsConstants.buildDestinationJobsFolder = path.join(
+      buildDestinationFolder,
+      'jobs'
+    )
+    process.sasjsConstants.buildDestinationDbFolder = path.join(
+      buildDestinationFolder,
+      'db'
+    )
+    process.sasjsConstants.buildDestinationDocsFolder = path.join(
+      buildDestinationFolder,
+      'docs'
+    )
+  }
+
+  if (target.sasjsResultsFolder) {
+    const buildResultsFolder = target.sasjsResultsFolder
+
+    const buildDestinationResultsFolder = getAbsolutePath(
+      buildResultsFolder,
+      isLocal ? process.projectDir : homeDir
+    )
+
+    process.sasjsConstants.buildDestinationResultsFolder =
+      buildDestinationResultsFolder
+
+    process.sasjsConstants.buildDestinationResultsLogsFolder = path.join(
+      buildDestinationResultsFolder,
+      'logs'
+    )
   }
 }


### PR DESCRIPTION
## Issue

closes #1320

## Intent

BREAKING CHANGE

* add two new attributes (sasjsBuildFolder and sasjsResultsFolder) in configuration and targetJson interfaces
* remove buildOutputFolder and buildResultsFolder from build config
* There should be check at both the root and target level for sasjsBuild and sasjsResults folders (if the setting is in both, the target overrules)

## Implementation

* added a new function `updateSasjsConstants`, which updates the `process.sasjsConstants` based on the target.
* This function is called once from `getTargetInfo` method of TargetCommand's class

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
