### PR TITLE
fix: mixing of settings from sasjsconfig.json and .sasjsrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/",
     "test": "npm run test:mocked && npm run test:server",
     "test:server": "jest --silent --runInBand --config=jest.server.config.js",
-    "test:mocked": "jest --runInBand --config=jest.config.js --coverage",
+    "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "preinstall": "npm run nodeVersionMessage",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "copy:doxy": "copyfiles -u 2 src/doxy/* build/doxy/",
     "test": "npm run test:mocked && npm run test:server",
     "test:server": "jest --silent --runInBand --config=jest.server.config.js",
-    "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
+    "test:mocked": "jest --runInBand --config=jest.config.js --coverage",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "preinstall": "npm run nodeVersionMessage",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,10 @@
 import { LogLevel, Logger } from '@sasjs/utils/logger'
-import { loadProjectEnvVariables, setProjectDir, setConstants } from './utils'
+import { loadProjectEnvVariables, setProjectDir } from './utils'
 import { parse } from './types/command/parse'
 
 export async function cli(args: string[]) {
   await setProjectDir(args)
   await instantiateLogger()
-  await setConstants()
   await loadProjectEnvVariables()
 
   const command = parse(args)

--- a/src/commands/add/spec/addCommand.spec.ts
+++ b/src/commands/add/spec/addCommand.spec.ts
@@ -2,6 +2,7 @@ import { AddCommand } from '../addCommand'
 import * as addTargetModule from '../addTarget'
 import * as addCredentialModule from '../addCredential'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import { TargetScope } from '../../../types'
 import { ReturnCode } from '../../../types/command'
@@ -84,6 +85,15 @@ describe('AddCommand - cred', () => {
     jest
       .spyOn(configUtils, 'findTargetInConfiguration')
       .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+    jest
+      .spyOn(configUtils, 'getLocalConfig')
+      .mockImplementation(() => Promise.resolve({}))
+
+    jest
+      .spyOn(setConstantsUtils, 'setConstants')
+      .mockImplementation(() => Promise.resolve())
+
     jest.spyOn(process.logger, 'success')
     jest.spyOn(process.logger, 'error')
   })

--- a/src/commands/build/internal/config.ts
+++ b/src/commands/build/internal/config.ts
@@ -1,6 +1,4 @@
-import path from 'path'
 import { Target, readFile, getAbsolutePath } from '@sasjs/utils'
-import { getConfiguration } from '../../../utils/config'
 
 export const getBuildInit = async (target: Target) => {
   const { buildSourceFolder } = process.sasjsConstants
@@ -10,9 +8,7 @@ export const getBuildInit = async (target: Target) => {
       getAbsolutePath(target.buildConfig.initProgram, buildSourceFolder)
     )
   } else {
-    const configuration = await getConfiguration(
-      path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
-    )
+    const configuration = process.sasjsConfig
     if (configuration?.buildConfig?.initProgram) {
       buildInitContent = await readFile(
         getAbsolutePath(
@@ -36,9 +32,7 @@ export const getBuildTerm = async (target: Target) => {
       getAbsolutePath(target.buildConfig.termProgram, buildSourceFolder)
     )
   } else {
-    const configuration = await getConfiguration(
-      path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
-    )
+    const configuration = process.sasjsConfig
     if (configuration?.buildConfig?.termProgram) {
       buildTermContent = await readFile(
         getAbsolutePath(

--- a/src/commands/build/spec/buildCommand.spec.ts
+++ b/src/commands/build/spec/buildCommand.spec.ts
@@ -2,6 +2,7 @@ import * as buildModule from '../build'
 import { BuildCommand } from '../buildCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
 import { setConstants } from '../../../utils'
 
@@ -15,7 +16,7 @@ const target = new Target({
 
 describe('BuildCommand', () => {
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
   })
   beforeEach(() => {
     setupMocks()
@@ -99,6 +100,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'success')

--- a/src/commands/build/spec/compileBuildCommand.spec.ts
+++ b/src/commands/build/spec/compileBuildCommand.spec.ts
@@ -3,6 +3,7 @@ import * as compileModule from '../../compile/compile'
 import { CompileBuildCommand } from '../compileBuildCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
 import { setConstants } from '../../../utils'
 
@@ -16,7 +17,7 @@ describe('CompileBuildCommand', () => {
   })
 
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
   })
 
   beforeEach(() => {
@@ -32,6 +33,14 @@ describe('CompileBuildCommand', () => {
     jest
       .spyOn(configUtils, 'findTargetInConfiguration')
       .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+    jest
+      .spyOn(configUtils, 'getLocalConfig')
+      .mockImplementation(() => Promise.resolve({}))
+
+    jest
+      .spyOn(setConstantsUtils, 'setConstants')
+      .mockImplementation(() => Promise.resolve())
 
     process.logger = new Logger(LogLevel.Off)
     jest.spyOn(process.logger, 'success')

--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -191,7 +191,6 @@ export async function compileJobsServicesTests(
       )
     })
 
-    console.log('jobFolders :>> ', jobFolders)
     await asyncForEach(jobFolders, async (jobFolder) => {
       await compileJobFolder(
         target,

--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -363,10 +363,7 @@ const compileJobFolder = async (
 }
 
 async function compileWeb(target: Target) {
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   const streamConfig = {
     ...configuration?.streamConfig,
@@ -392,10 +389,7 @@ async function compileWeb(target: Target) {
 }
 
 const syncFolder = async (target: Target) => {
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   if (configuration.syncFolder) {
     await copySyncFolder(configuration.syncFolder)

--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -1,10 +1,11 @@
 import path from 'path'
 import {
-  getLocalOrGlobalConfig,
   getProgramFolders,
   getMacroFolders,
   getTestSetUp,
-  getTestTearDown
+  getTestTearDown,
+  getLocalConfig,
+  getGlobalRcFile
 } from '../../utils/config'
 import {
   listSubFoldersInFolder,
@@ -21,7 +22,12 @@ import {
 } from '@sasjs/utils'
 import { createWebAppServices } from '../web/web'
 import { isSasFile } from '../../utils/file'
-import { Target, StreamConfig, SASJsFileType } from '@sasjs/utils/types'
+import {
+  Target,
+  StreamConfig,
+  SASJsFileType,
+  Configuration
+} from '@sasjs/utils/types'
 import { checkCompileStatus } from './internal/checkCompileStatus'
 import * as compileModule from './compile'
 import { getAllFolders, SasFileType } from './internal/getAllFolders'
@@ -185,6 +191,7 @@ export async function compileJobsServicesTests(
       )
     })
 
+    console.log('jobFolders :>> ', jobFolders)
     await asyncForEach(jobFolders, async (jobFolder) => {
       await compileJobFolder(
         target,
@@ -357,7 +364,10 @@ const compileJobFolder = async (
 }
 
 async function compileWeb(target: Target) {
-  const { configuration } = await getLocalOrGlobalConfig()
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
   const streamConfig = {
     ...configuration?.streamConfig,
@@ -383,7 +393,10 @@ async function compileWeb(target: Target) {
 }
 
 const syncFolder = async (target: Target) => {
-  const { configuration } = await getLocalOrGlobalConfig()
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
   if (configuration.syncFolder) {
     await copySyncFolder(configuration.syncFolder)

--- a/src/commands/compile/internal/compileTestFile.ts
+++ b/src/commands/compile/internal/compileTestFile.ts
@@ -122,10 +122,7 @@ export const compileTestFlow = async (
       await listFilesAndSubFoldersInFolder(buildDestinationTestFolder)
     ).map((file) => path.join('tests', file))
 
-    const { isLocal } = process.sasjsConstants
-    const config: Configuration = isLocal
-      ? await getLocalConfig()
-      : await getGlobalRcFile()
+    const config = process.sasjsConfig
 
     const testFlow: TestFlow = { tests: [] }
     const testSetUp =

--- a/src/commands/compile/internal/compileTestFile.ts
+++ b/src/commands/compile/internal/compileTestFile.ts
@@ -27,7 +27,8 @@ import chalk from 'chalk'
 import {
   getProgramFolders,
   getMacroFolders,
-  getLocalOrGlobalConfig
+  getLocalConfig,
+  getGlobalRcFile
 } from '../../../utils/config'
 
 const getFileName = (filePath: string) => path.parse(filePath).base
@@ -121,7 +122,10 @@ export const compileTestFlow = async (
       await listFilesAndSubFoldersInFolder(buildDestinationTestFolder)
     ).map((file) => path.join('tests', file))
 
-    config = config || (await (await getLocalOrGlobalConfig()).configuration)
+    const { isLocal } = process.sasjsConstants
+    const config: Configuration = isLocal
+      ? await getLocalConfig()
+      : await getGlobalRcFile()
 
     const testFlow: TestFlow = { tests: [] }
     const testSetUp =

--- a/src/commands/compile/internal/getAllFolders.ts
+++ b/src/commands/compile/internal/getAllFolders.ts
@@ -12,9 +12,7 @@ export const getAllFolders = async (
   type: SasFileType,
   rootConfig?: Configuration
 ): Promise<string[]> => {
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration =
-    rootConfig || (isLocal ? await getLocalConfig() : await getGlobalRcFile())
+  const configuration = rootConfig || process.sasjsConfig
 
   let allFolders: string[] | undefined
   let config: ServiceConfig | JobConfig | undefined

--- a/src/commands/compile/internal/getAllFolders.ts
+++ b/src/commands/compile/internal/getAllFolders.ts
@@ -1,5 +1,5 @@
 import { Target, getAbsolutePath, Configuration } from '@sasjs/utils'
-import { getLocalOrGlobalConfig } from '../../../utils/config'
+import { getGlobalRcFile, getLocalConfig } from '../../../utils/config'
 import { ServiceConfig, JobConfig } from '@sasjs/utils'
 
 export enum SasFileType {
@@ -12,8 +12,10 @@ export const getAllFolders = async (
   type: SasFileType,
   rootConfig?: Configuration
 ): Promise<string[]> => {
-  const configuration =
-    rootConfig || (await (await getLocalOrGlobalConfig()).configuration)
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration =
+    rootConfig || (isLocal ? await getLocalConfig() : await getGlobalRcFile())
+
   let allFolders: string[] | undefined
   let config: ServiceConfig | JobConfig | undefined
   let folders: string[] | undefined

--- a/src/commands/compile/internal/getServerType.ts
+++ b/src/commands/compile/internal/getServerType.ts
@@ -11,10 +11,7 @@ import { getGlobalRcFile, getLocalConfig } from '../../../utils/config'
 export async function getServerType(target: Target): Promise<ServerType> {
   if (target?.serverType) return target.serverType
 
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   return configuration?.serverType
     ? configuration.serverType

--- a/src/commands/compile/internal/getServerType.ts
+++ b/src/commands/compile/internal/getServerType.ts
@@ -1,6 +1,6 @@
 import { Target } from '@sasjs/utils'
-import { ServerType } from '@sasjs/utils/types'
-import { getLocalOrGlobalConfig } from '../../../utils/config'
+import { Configuration, ServerType } from '@sasjs/utils/types'
+import { getGlobalRcFile, getLocalConfig } from '../../../utils/config'
 
 /**
  * Returns server type for 'compile' step.
@@ -11,7 +11,10 @@ import { getLocalOrGlobalConfig } from '../../../utils/config'
 export async function getServerType(target: Target): Promise<ServerType> {
   if (target?.serverType) return target.serverType
 
-  const { configuration } = await getLocalOrGlobalConfig()
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
   return configuration?.serverType
     ? configuration.serverType

--- a/src/commands/compile/internal/loadDependencies.ts
+++ b/src/commands/compile/internal/loadDependencies.ts
@@ -41,11 +41,9 @@ export async function loadDependencies(
     fileContent = await readFile(filePath)
   }
 
-  const { buildSourceFolder, macroCorePath, isLocal } = process.sasjsConstants
+  const { buildSourceFolder, macroCorePath } = process.sasjsConstants
   const binaryFolders = await getBinaryFolders(target)
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   headerSyntaxNotices(fileContent)
 

--- a/src/commands/compile/internal/loadDependencies.ts
+++ b/src/commands/compile/internal/loadDependencies.ts
@@ -5,9 +5,14 @@ import {
   loadDependenciesFile,
   DependencyHeader,
   CompileTree,
-  removeHeader
+  removeHeader,
+  Configuration
 } from '@sasjs/utils'
-import { getLocalOrGlobalConfig, getBinaryFolders } from '../../../utils/config'
+import {
+  getBinaryFolders,
+  getLocalConfig,
+  getGlobalRcFile
+} from '../../../utils/config'
 import path from 'path'
 
 export async function loadDependencies(
@@ -36,9 +41,11 @@ export async function loadDependencies(
     fileContent = await readFile(filePath)
   }
 
-  const { configuration } = await getLocalOrGlobalConfig()
-  const { buildSourceFolder, macroCorePath } = process.sasjsConstants
+  const { buildSourceFolder, macroCorePath, isLocal } = process.sasjsConstants
   const binaryFolders = await getBinaryFolders(target)
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
   headerSyntaxNotices(fileContent)
 

--- a/src/commands/compile/internal/spec/getAllFolders.spec.ts
+++ b/src/commands/compile/internal/spec/getAllFolders.spec.ts
@@ -10,7 +10,7 @@ describe('getAllFolders', () => {
   let target: Target
 
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
     ;({ config } = JSON.parse(
       await readFile(
         path.join(__dirname, '..', '..', '..', '..', 'config.json')

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -307,6 +307,7 @@ describe('sasjs compile outside project', () => {
       process.projectDir = ''
       const configuration = await getGlobalRcFile()
       await setConstants(false, undefined, configuration)
+      process.sasjsConfig = configuration
 
       process.currentDir = path.join(__dirname, appName)
       await createFolder(process.currentDir)
@@ -439,6 +440,9 @@ describe('sasjs compile outside project', () => {
         },
         false
       )
+      const configuration = await getGlobalRcFile()
+      process.sasjsConfig = configuration
+
       const command = new CompileCommand([
         'node',
         'sasjs',
@@ -576,6 +580,7 @@ describe('sasjs compile outside project', () => {
       await saveGlobalRcFile('')
       await setConstants(false)
 
+      process.sasjsConfig = {}
       process.projectDir = ''
       process.currentDir = path.join(__dirname, appName)
 

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -574,7 +574,7 @@ describe('sasjs compile outside project', () => {
       appName = `cli-tests-compile-${generateTimestamp()}`
 
       await saveGlobalRcFile('')
-      await setConstants()
+      await setConstants(false)
 
       process.projectDir = ''
       process.currentDir = path.join(__dirname, appName)

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -12,6 +12,7 @@ import {
 import { BuildConfig } from '@sasjs/utils/types/config'
 import {
   findTargetInConfiguration,
+  getGlobalRcFile,
   saveGlobalRcFile
 } from '../../../utils/config'
 import {
@@ -304,7 +305,8 @@ describe('sasjs compile outside project', () => {
         false
       )
       process.projectDir = ''
-      await setConstants()
+      const configuration = await getGlobalRcFile()
+      await setConstants(false, undefined, configuration)
 
       process.currentDir = path.join(__dirname, appName)
       await createFolder(process.currentDir)
@@ -346,7 +348,7 @@ describe('sasjs compile outside project', () => {
         '-s',
         '../services/example1.sas'
       ])
-      const output = await command.output
+      const output = command.output
 
       await expect(
         compileSingleFile(
@@ -458,7 +460,7 @@ describe('sasjs compile outside project', () => {
       )
     })
 
-    it('should compile single file at absolute path in global config.buildConfig.buildOutputFolder', async () => {
+    it('should compile single file at absolute path in global config.sasjsBuildFolder', async () => {
       const buildOutputFolder = path.join(__dirname, 'random-folder', appName)
       const destinationPath = path.join(
         buildOutputFolder,
@@ -476,7 +478,8 @@ describe('sasjs compile outside project', () => {
         },
         false
       )
-      await setConstants()
+      const configuration = await getGlobalRcFile()
+      await setConstants(false, undefined, configuration)
 
       const command = new CompileCommand([
         'node',
@@ -511,7 +514,7 @@ describe('sasjs compile outside project', () => {
       await verifyCompiledService(compiledContent, macrosToTest, false, false)
     })
 
-    it('should compile single file at relative path in global config.buildConfig.buildOutputFolder', async () => {
+    it('should compile single file at relative path in global config.sasjsBuildFolder', async () => {
       const buildOutputFolder = path.join(homedir, appName, 'random-folder')
       const destinationPath = path.join(
         buildOutputFolder,
@@ -529,7 +532,8 @@ describe('sasjs compile outside project', () => {
         },
         false
       )
-      await setConstants()
+      const configuration = await getGlobalRcFile()
+      await setConstants(false, undefined, configuration)
 
       const command = new CompileCommand([
         'node',

--- a/src/commands/compile/spec/compileCommand.spec.ts
+++ b/src/commands/compile/spec/compileCommand.spec.ts
@@ -4,9 +4,10 @@ import * as compileModule from '../compile'
 import * as compileSingleFileModule from '../compileSingleFile'
 import { CompileCommand } from '../compileCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
-import * as configUtils from '../../../utils/config'
-import { ReturnCode } from '../../../types/command'
 import { setConstants } from '../../../utils'
+import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
+import { ReturnCode } from '../../../types/command'
 
 const target = new Target({
   name: 'test',
@@ -18,7 +19,7 @@ const defaultArgs = ['node', 'sasjs']
 
 describe('CompileCommand', () => {
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
   })
 
   beforeEach(() => {
@@ -116,7 +117,7 @@ describe('CompileCommand', () => {
   })
 
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
   })
 
   beforeEach(() => {
@@ -330,6 +331,8 @@ const setupMocks = () => {
   jest.mock('../compile')
   jest.mock('../compileSingleFile')
   jest.mock('../../../utils/config')
+  jest.mock('../../../utils/setConstants')
+
   jest
     .spyOn(compileModule, 'compile')
     .mockImplementation(() => Promise.resolve())
@@ -337,6 +340,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'success')

--- a/src/commands/compile/spec/loadDependencies.spec.ts
+++ b/src/commands/compile/spec/loadDependencies.spec.ts
@@ -18,7 +18,7 @@ import {
   removeTestApp,
   updateConfig
 } from '../../../utils/test'
-import { setConstants } from '../../../utils'
+import { getLocalConfig, setConstants } from '../../../utils'
 import { loadDependencies, getCompileTree } from '../internal/loadDependencies'
 import { SasFileType } from '../internal/getAllFolders'
 
@@ -201,6 +201,8 @@ describe('loadDependencies', () => {
       jobConfig: jobConfig(),
       serviceConfig: serviceConfig()
     })
+
+    process.sasjsConfig = await getLocalConfig()
   })
 
   afterAll(async () => {

--- a/src/commands/compile/spec/loadDependencies.spec.ts
+++ b/src/commands/compile/spec/loadDependencies.spec.ts
@@ -191,7 +191,7 @@ describe('loadDependencies', () => {
   let compileTree: CompileTree
 
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
 
     compileTree = getCompileTree(target)
 

--- a/src/commands/context/spec/contextCommand.spec.ts
+++ b/src/commands/context/spec/contextCommand.spec.ts
@@ -7,6 +7,7 @@ import { ContextCommand } from '../contextCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as fileModule from '@sasjs/utils/file'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
 import { mockAuthConfig, mockContext } from './mocks'
 
@@ -802,6 +803,7 @@ const setupMocks = () => {
   jest.mock('../export')
   jest.mock('../list')
   jest.mock('../../../utils/config')
+  jest.mock('../../../utils/setConstants')
 
   jest
     .spyOn(fileModule, 'readFile')
@@ -824,8 +826,15 @@ const setupMocks = () => {
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
   jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
     .spyOn(configUtils, 'getAuthConfig')
     .mockImplementation(() => Promise.resolve(mockAuthConfig))
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'success')

--- a/src/commands/deploy/internal/getDeployScripts.ts
+++ b/src/commands/deploy/internal/getDeployScripts.ts
@@ -1,12 +1,7 @@
 import { Target } from '@sasjs/utils'
-import path from 'path'
-import { getConfiguration } from '../../../utils/config'
 
 export async function getDeployScripts(target: Target) {
-  const { buildSourceFolder } = process.sasjsConstants
-  const configuration = await getConfiguration(
-    path.join(buildSourceFolder, 'sasjs', 'sasjsconfig.json')
-  )
+  const configuration = process.sasjsConfig
 
   const allDeployScripts: string[] = [
     ...(configuration?.deployConfig?.deployScripts || []),

--- a/src/commands/deploy/spec/cbd.spec.ts
+++ b/src/commands/deploy/spec/cbd.spec.ts
@@ -20,7 +20,10 @@ import { TargetScope } from '../../../types'
 import { build } from '../../build/build'
 import { deploy } from '../deploy'
 import { createLocalTarget, updateLocalTarget } from './utils'
-import { findTargetInConfiguration } from '../../../utils/config'
+import {
+  findTargetInConfiguration,
+  getLocalConfig
+} from '../../../utils/config'
 
 describe('sasjs cbd with server type SASJS', () => {
   let target: Target
@@ -73,6 +76,8 @@ describe('sasjs cbd with server type SASJS', () => {
         deployScripts: []
       }
     })
+
+    process.sasjsConfig = await getLocalConfig()
 
     const { target: customTarget } = await findTargetInConfiguration(
       target.name,

--- a/src/commands/deploy/spec/compileBuildDeployCommand.spec.ts
+++ b/src/commands/deploy/spec/compileBuildDeployCommand.spec.ts
@@ -4,8 +4,9 @@ import * as deployModule from '../deploy'
 import { CompileBuildDeployCommand } from '../compileBuildDeployCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
-import { ReturnCode } from '../../../types/command'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { setConstants } from '../../../utils'
+import { ReturnCode } from '../../../types/command'
 
 describe('CompileBuildDeployCommand', () => {
   const defaultArgs = ['node', 'sasjs']
@@ -17,7 +18,7 @@ describe('CompileBuildDeployCommand', () => {
   })
 
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
   })
 
   beforeEach(() => {
@@ -37,6 +38,14 @@ describe('CompileBuildDeployCommand', () => {
     jest
       .spyOn(configUtils, 'findTargetInConfiguration')
       .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+    jest
+      .spyOn(configUtils, 'getLocalConfig')
+      .mockImplementation(() => Promise.resolve({}))
+
+    jest
+      .spyOn(setConstantsUtils, 'setConstants')
+      .mockImplementation(() => Promise.resolve())
 
     process.logger = new Logger(LogLevel.Off)
     jest.spyOn(process.logger, 'success')

--- a/src/commands/deploy/spec/deployCommand.spec.ts
+++ b/src/commands/deploy/spec/deployCommand.spec.ts
@@ -2,6 +2,7 @@ import * as deployModule from '../deploy'
 import { DeployCommand } from '../deployCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
 
 const defaultArgs = ['node', 'sasjs']
@@ -95,6 +96,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'success')

--- a/src/commands/docs/spec/docsCommand.spec.ts
+++ b/src/commands/docs/spec/docsCommand.spec.ts
@@ -4,6 +4,7 @@ import * as generateDotModule from '../generateDot'
 import * as initDocsModule from '../initDocs'
 import { ReturnCode } from '../../../types/command'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { Logger, LogLevel } from '@sasjs/utils/logger'
 import { Configuration, ServerType, Target } from '@sasjs/utils'
 
@@ -236,4 +237,7 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'getLocalConfig')
     .mockImplementation(() => Promise.resolve(config))
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 }

--- a/src/commands/flow/spec/flowCommand.spec.ts
+++ b/src/commands/flow/spec/flowCommand.spec.ts
@@ -2,8 +2,8 @@ import * as executeModule from '../execute'
 import { FlowCommand } from '../flowCommand'
 import { AuthConfig, Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
-import { setConstants } from '../../../utils'
 
 const defaultArgs = ['node', 'sasjs']
 const target = new Target({
@@ -17,10 +17,6 @@ const source = 'path/to/json'
 const logFolder = 'path/to/logs/folder'
 const csvFile = 'path/to/csv/file'
 describe('FlowCommand', () => {
-  beforeAll(async () => {
-    await setConstants()
-  })
-
   beforeEach(() => {
     setupMocks()
   })
@@ -154,6 +150,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   jest
     .spyOn(configUtils, 'getAuthConfig')

--- a/src/commands/folder/spec/folderCommand.spec.ts
+++ b/src/commands/folder/spec/folderCommand.spec.ts
@@ -4,6 +4,7 @@ import * as deleteModule from '../delete'
 import * as listModule from '../list'
 import { ReturnCode } from '../../../types/command'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { Logger, LogLevel } from '@sasjs/utils/logger'
 import { ServerType, Target } from '@sasjs/utils'
 import { mockAuthConfig } from './mocks'
@@ -205,6 +206,12 @@ const setupMocks = () => {
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
   jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+  jest
     .spyOn(configUtils, 'getAuthConfig')
     .mockImplementation(() => Promise.resolve(mockAuthConfig))
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 }

--- a/src/commands/fs/spec/fsCommand.spec.ts
+++ b/src/commands/fs/spec/fsCommand.spec.ts
@@ -5,6 +5,7 @@ import { setConstants } from '../../../utils'
 import * as FSModule from '@sasjs/utils/fs'
 import * as FileModule from '@sasjs/utils/file'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import * as executeCodeModule from '../internal/executeCode'
 
 const defaultArgs = ['node', 'sasjs', 'fs']
@@ -17,8 +18,8 @@ const target = new Target({
 
 describe('FSCommand', () => {
   beforeAll(async () => {
-    await setConstants()
     process.projectDir = __dirname
+    await setConstants()
   })
 
   describe('compile', () => {
@@ -36,11 +37,7 @@ describe('FSCommand', () => {
         .spyOn(FileModule, 'createFile')
         .mockImplementation(() => Promise.resolve())
 
-      jest
-        .spyOn(configUtils, 'findTargetInConfiguration')
-        .mockImplementation(() =>
-          Promise.resolve({ target: target, isLocal: true })
-        )
+      setupMocks()
 
       const returnCode = await executeCommandWrapper([
         'compile',
@@ -56,11 +53,7 @@ describe('FSCommand', () => {
         .spyOn(FileModule, 'createFile')
         .mockImplementation(() => Promise.reject())
 
-      jest
-        .spyOn(configUtils, 'findTargetInConfiguration')
-        .mockImplementation(() =>
-          Promise.resolve({ target: target, isLocal: true })
-        )
+      setupMocks()
 
       const returnCode = await executeCommandWrapper(['compile', 'localFolder'])
       expect(returnCode).toEqual(ReturnCode.InternalError)
@@ -76,11 +69,7 @@ describe('FSCommand', () => {
       jest.spyOn(process.logger, 'error')
       jest.spyOn(process.logger, 'info')
 
-      jest
-        .spyOn(configUtils, 'findTargetInConfiguration')
-        .mockImplementation(() =>
-          Promise.resolve({ target: target, isLocal: true })
-        )
+      setupMocks()
 
       jest
         .spyOn(FSModule, 'generateCompileProgram')
@@ -131,11 +120,7 @@ describe('FSCommand', () => {
         .spyOn(FileModule, 'createFile')
         .mockImplementation(() => Promise.resolve())
 
-      jest
-        .spyOn(configUtils, 'findTargetInConfiguration')
-        .mockImplementation(() =>
-          Promise.resolve({ target: target, isLocal: true })
-        )
+      setupMocks()
 
       jest
         .spyOn(FSModule, 'generateProgramToGetRemoteHash')
@@ -256,6 +241,20 @@ describe('FSCommand', () => {
     })
   })
 })
+
+const setupMocks = () => {
+  jest
+    .spyOn(configUtils, 'findTargetInConfiguration')
+    .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
+}
 
 const executeCommandWrapper = async (additionalParams: string[]) => {
   const args = [...defaultArgs, ...additionalParams]

--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -313,6 +313,10 @@ const setupMocksForViya = () => {
     )
 
   jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
     .spyOn(configUtils, 'getSASjsAndAuthConfig')
     .mockImplementation((target: Target) => {
       return Promise.resolve({
@@ -340,6 +344,10 @@ const setupMocksForSAS9 = () => {
     .mockImplementation(() =>
       Promise.resolve({ target: target9, isLocal: true })
     )
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'error')

--- a/src/commands/request/spec/requestCommand.spec.ts
+++ b/src/commands/request/spec/requestCommand.spec.ts
@@ -2,8 +2,8 @@ import * as requestModule from '../request'
 import { RequestCommand } from '../requestCommand'
 import { AuthConfig, Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
-import { setConstants } from '../../../utils'
 
 const defaultArgs = ['node', 'sasjs']
 const target = new Target({
@@ -18,10 +18,6 @@ const configFilePath = 'path/to/config.json'
 const outputPath = './output.txt'
 const logPath = './log.txt'
 describe('RequestCommand', () => {
-  beforeAll(async () => {
-    await setConstants()
-  })
-
   beforeEach(() => {
     setupMocks()
   })
@@ -209,6 +205,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'error')

--- a/src/commands/run/spec/runCommand.spec.ts
+++ b/src/commands/run/spec/runCommand.spec.ts
@@ -2,8 +2,8 @@ import * as runModule from '../run'
 import { RunCommand } from '../runCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
-import { setConstants } from '../../../utils'
 
 const defaultArgs = ['node', 'sasjs', 'run']
 const target = new Target({
@@ -16,10 +16,6 @@ const sourceFilePath = 'path/to/source.json'
 const sasFilePath = 'path/to/soure.sas'
 const logFilePath = 'path/to/log.log'
 describe('RunCommand', () => {
-  beforeAll(async () => {
-    await setConstants()
-  })
-
   beforeEach(() => {
     setupMocks()
   })
@@ -112,6 +108,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'error')

--- a/src/commands/servicepack/spec/servicepackCommand.spec.ts
+++ b/src/commands/servicepack/spec/servicepackCommand.spec.ts
@@ -2,8 +2,8 @@ import * as deployModule from '../deploy'
 import { ServicePackCommand } from '../servicePackCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
-import { setConstants } from '../../../utils'
 
 const defaultArgs = ['node', 'sasjs', 'servicepack', 'deploy']
 const target = new Target({
@@ -14,10 +14,6 @@ const target = new Target({
 })
 const source = 'path/to/json'
 describe('ServicePackCommand', () => {
-  beforeAll(async () => {
-    await setConstants()
-  })
-
   beforeEach(() => {
     setupMocks()
   })
@@ -90,6 +86,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'error')

--- a/src/commands/testing/spec/testCommand.spec.ts
+++ b/src/commands/testing/spec/testCommand.spec.ts
@@ -2,8 +2,8 @@ import * as testModule from '../test'
 import { TestCommand } from '../testCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
-import { setConstants } from '../../../utils'
 
 const defaultArgs = ['node', 'sasjs']
 const target = new Target({
@@ -13,10 +13,6 @@ const target = new Target({
   contextName: 'test context'
 })
 describe('TestCommand', () => {
-  beforeAll(async () => {
-    await setConstants()
-  })
-
   beforeEach(() => {
     setupMocks()
   })
@@ -127,6 +123,14 @@ const setupMocks = () => {
   jest
     .spyOn(configUtils, 'findTargetInConfiguration')
     .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+  jest
+    .spyOn(configUtils, 'getLocalConfig')
+    .mockImplementation(() => Promise.resolve({}))
+
+  jest
+    .spyOn(setConstantsUtils, 'setConstants')
+    .mockImplementation(() => Promise.resolve())
 
   process.logger = new Logger(LogLevel.Off)
   jest.spyOn(process.logger, 'error')

--- a/src/commands/web/spec/web.spec.ts
+++ b/src/commands/web/spec/web.spec.ts
@@ -9,7 +9,7 @@ import {
 import { Folder } from '../../../types'
 import { createFile, generateTimestamp, StreamConfig } from '@sasjs/utils'
 import { createWebAppServices } from '../web'
-import { findTargetInConfiguration } from '../../../utils'
+import { findTargetInConfiguration, getLocalConfig } from '../../../utils'
 
 const webBuiltFilesSASVIYA = (indexHtml: string = 'clickme'): Folder => ({
   folderName: 'sasjsbuild',
@@ -96,6 +96,8 @@ describe('sasjs web', () => {
       { serverUrl: undefined, streamConfig: undefined },
       'sas9'
     )
+
+    process.sasjsConfig = await getLocalConfig()
   })
 
   afterAll(async () => {

--- a/src/commands/web/spec/webCommand.spec.ts
+++ b/src/commands/web/spec/webCommand.spec.ts
@@ -2,6 +2,7 @@ import * as webModule from '../web'
 import { WebCommand } from '../webCommand'
 import { Logger, LogLevel, ServerType, Target } from '@sasjs/utils'
 import * as configUtils from '../../../utils/config'
+import * as setConstantsUtils from '../../../utils/setConstants'
 import { ReturnCode } from '../../../types/command'
 import { setConstants } from '../../../utils'
 
@@ -15,7 +16,7 @@ describe('WebCommand', () => {
   })
 
   beforeAll(async () => {
-    await setConstants()
+    await setConstants(false)
   })
 
   beforeEach(() => {
@@ -29,6 +30,14 @@ describe('WebCommand', () => {
     jest
       .spyOn(configUtils, 'findTargetInConfiguration')
       .mockImplementation(() => Promise.resolve({ target, isLocal: true }))
+
+    jest
+      .spyOn(configUtils, 'getLocalConfig')
+      .mockImplementation(() => Promise.resolve({}))
+
+    jest
+      .spyOn(setConstantsUtils, 'setConstants')
+      .mockImplementation(() => Promise.resolve())
 
     process.logger = new Logger(LogLevel.Off)
     jest.spyOn(process.logger, 'success')

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,6 @@ export interface Constants {
   buildDestinationResultsFolder: string
   buildDestinationResultsLogsFolder: string
   buildDestinationTestFolder: string
-  isLocal: boolean
   macroCorePath: string
   contextName: string
   sas9CredentialsError: string

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export interface Constants {
   buildDestinationResultsFolder: string
   buildDestinationResultsLogsFolder: string
   buildDestinationTestFolder: string
+  isLocal: boolean
   macroCorePath: string
   contextName: string
   sas9CredentialsError: string

--- a/src/types/command/targetCommand.ts
+++ b/src/types/command/targetCommand.ts
@@ -48,7 +48,7 @@ export class TargetCommand extends CommandBase {
           ? await getLocalConfig()
           : await getGlobalRcFile()
 
-        setConstants(res.target, configuration, res.isLocal)
+        setConstants(res.isLocal, res.target, configuration)
 
         return res
       })

--- a/src/types/command/targetCommand.ts
+++ b/src/types/command/targetCommand.ts
@@ -48,7 +48,7 @@ export class TargetCommand extends CommandBase {
           ? await getLocalConfig()
           : await getGlobalRcFile()
 
-        setConstants(res.isLocal, res.target, configuration)
+        await setConstants(res.isLocal, res.target, configuration)
 
         return res
       })

--- a/src/types/command/targetCommand.ts
+++ b/src/types/command/targetCommand.ts
@@ -49,6 +49,7 @@ export class TargetCommand extends CommandBase {
           : await getGlobalRcFile()
 
         await setConstants(res.isLocal, res.target, configuration)
+        process.sasjsConfig = configuration
 
         return res
       })

--- a/src/types/command/targetCommand.ts
+++ b/src/types/command/targetCommand.ts
@@ -3,7 +3,9 @@ import {
   findTargetInConfiguration,
   loadTargetEnvVariables,
   validateTargetName,
-  updateSasjsConstants
+  getLocalConfig,
+  getGlobalRcFile,
+  setConstants
 } from '../../utils'
 import { CommandBase, CommandOptions } from './commandBase'
 import { ReturnCode } from './returnCode'
@@ -39,9 +41,15 @@ export class TargetCommand extends CommandBase {
     })
 
     return await findTargetInConfiguration(targetName)
-      .then((res) => {
+      .then(async (res) => {
         this._targetInfo = res
-        updateSasjsConstants(res.target, res.isLocal)
+
+        const configuration = res.isLocal
+          ? await getLocalConfig()
+          : await getGlobalRcFile()
+
+        setConstants(res.target, configuration, res.isLocal)
+
         return res
       })
       .catch((err) => {

--- a/src/types/system/process.d.ts
+++ b/src/types/system/process.d.ts
@@ -5,5 +5,6 @@ declare namespace NodeJS {
     currentDir: string
     logger: import('@sasjs/utils/logger').Logger
     sasjsConstants: import('../../constants').Constants
+    sasjsConfig: import('@sasjs/utils/types/configuration').Configuration
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -463,24 +463,27 @@ export async function getFolders() {
  * @param {Target} target- the target to check program folders for.
  */
 export async function getProgramFolders(target: Target) {
-  let programFolders: string[] = []
+  const programFolders: string[] = []
 
-  const localConfig = await getLocalConfig().catch(() => null)
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
-  if (localConfig?.programFolders) {
-    programFolders = programFolders.concat(localConfig.programFolders)
+  if (configuration?.programFolders) {
+    programFolders.push(...configuration.programFolders)
   }
 
   if (target?.programFolders) {
-    programFolders = programFolders.concat(target.programFolders)
+    programFolders.push(...target.programFolders)
   }
 
   const { buildSourceFolder } = process.sasjsConstants
-  programFolders = programFolders.map((programFolder) =>
+  const programFoldersWithAbsolutePath = programFolders.map((programFolder) =>
     getAbsolutePath(programFolder, buildSourceFolder)
   )
 
-  return [...new Set(programFolders)]
+  return [...new Set(programFoldersWithAbsolutePath)]
 }
 
 export async function getBinaryFolders(target: Target) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -510,22 +510,26 @@ export async function getBinaryFolders(target: Target) {
  * @param {Target} target- the target to check macro folders for.
  */
 export async function getMacroFolders(target?: Target) {
-  let macroFolders: string[] = []
-  const { configuration: localConfig } = await getLocalOrGlobalConfig()
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
-  if (target?.macroFolders) macroFolders = target.macroFolders
+  const macroFolders: string[] = []
 
-  if (localConfig?.macroFolders) {
-    macroFolders = localConfig.macroFolders.concat(macroFolders)
+  if (target?.macroFolders) macroFolders.push(...target.macroFolders)
+
+  if (configuration?.macroFolders) {
+    macroFolders.push(...configuration.macroFolders)
   }
 
   const { buildSourceFolder } = process.sasjsConstants
 
-  macroFolders = macroFolders.map((macroFolder) =>
+  const macroFoldersWithAbsolutePath = macroFolders.map((macroFolder) =>
     getAbsolutePath(macroFolder, buildSourceFolder)
   )
 
-  return [...new Set(macroFolders)]
+  return [...new Set(macroFoldersWithAbsolutePath)]
 }
 
 /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -487,24 +487,27 @@ export async function getProgramFolders(target: Target) {
 }
 
 export async function getBinaryFolders(target: Target) {
-  let binaryFolders: string[] = []
+  const binaryFolders: string[] = []
 
-  const localConfig = await getLocalConfig().catch(() => null)
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
-  if (localConfig?.binaryFolders) {
-    binaryFolders = binaryFolders.concat(localConfig.binaryFolders)
+  if (configuration?.binaryFolders) {
+    binaryFolders.push(...configuration.binaryFolders)
   }
 
   if (target?.binaryFolders) {
-    binaryFolders = binaryFolders.concat(target.binaryFolders)
+    binaryFolders.push(...target.binaryFolders)
   }
 
   const { buildSourceFolder } = process.sasjsConstants
-  binaryFolders = binaryFolders.map((binaryFolder) =>
+  const binaryFoldersWithAbsolutePath = binaryFolders.map((binaryFolder) =>
     getAbsolutePath(binaryFolder, buildSourceFolder)
   )
 
-  return [...new Set(binaryFolders)]
+  return [...new Set(binaryFoldersWithAbsolutePath)]
 }
 
 /**
@@ -541,11 +544,14 @@ export async function getMacroFolders(target?: Target) {
  * @param {Target} target- the target to check stream configuration for.
  */
 export async function getStreamConfig(target?: Target): Promise<StreamConfig> {
-  const localConfig = await getLocalConfig()
+  const { isLocal } = process.sasjsConstants
+  const configuration: Configuration = isLocal
+    ? await getLocalConfig()
+    : await getGlobalRcFile()
 
   return {
     streamServiceName: 'clickme',
-    ...localConfig?.streamConfig,
+    ...configuration?.streamConfig,
     ...target?.streamConfig
   } as StreamConfig
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -465,10 +465,7 @@ export async function getFolders() {
 export async function getProgramFolders(target: Target) {
   const programFolders: string[] = []
 
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   if (configuration?.programFolders) {
     programFolders.push(...configuration.programFolders)
@@ -489,10 +486,7 @@ export async function getProgramFolders(target: Target) {
 export async function getBinaryFolders(target: Target) {
   const binaryFolders: string[] = []
 
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   if (configuration?.binaryFolders) {
     binaryFolders.push(...configuration.binaryFolders)
@@ -516,10 +510,7 @@ export async function getBinaryFolders(target: Target) {
  * @param {Target} target- the target to check macro folders for.
  */
 export async function getMacroFolders(target?: Target) {
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   const macroFolders: string[] = []
 
@@ -544,10 +535,7 @@ export async function getMacroFolders(target?: Target) {
  * @param {Target} target- the target to check stream configuration for.
  */
 export async function getStreamConfig(target?: Target): Promise<StreamConfig> {
-  const { isLocal } = process.sasjsConstants
-  const configuration: Configuration = isLocal
-    ? await getLocalConfig()
-    : await getGlobalRcFile()
+  const configuration = process.sasjsConfig
 
   return {
     streamServiceName: 'clickme',

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -520,11 +520,11 @@ export async function getMacroFolders(target?: Target) {
 
   const macroFolders: string[] = []
 
-  if (target?.macroFolders) macroFolders.push(...target.macroFolders)
-
   if (configuration?.macroFolders) {
     macroFolders.push(...configuration.macroFolders)
   }
+
+  if (target?.macroFolders) macroFolders.push(...target.macroFolders)
 
   const { buildSourceFolder } = process.sasjsConstants
 

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -1,23 +1,22 @@
 import path from 'path'
-import { getLocalOrGlobalConfig } from './config'
 import { getNodeModulePath } from './utils'
-import { getAbsolutePath, Target } from '@sasjs/utils'
+import { Configuration, getAbsolutePath, Target } from '@sasjs/utils'
 
 export const contextName = 'sasjs cli compute context'
 
-export const setConstants = async () => {
-  const { configuration, isLocal } = await getLocalOrGlobalConfig().catch(
-    () => ({
-      configuration: null,
-      isLocal: false
-    })
-  )
+export const setConstants = async (
+  target: Target,
+  configuration: Configuration,
+  isLocal: boolean
+) => {
   const buildOutputFolder =
-    configuration?.sasjsBuildFolder ||
+    target.sasjsBuildFolder ||
+    configuration.sasjsBuildFolder ||
     (isLocal ? 'sasjsbuild' : '.sasjs/sasjsbuild')
 
   const buildResultsFolder =
-    configuration?.sasjsResultsFolder ||
+    target.sasjsResultsFolder ||
+    configuration.sasjsResultsFolder ||
     (isLocal ? 'sasjsresults' : '.sasjs/sasjsresults')
 
   const homeDir = require('os').homedir()
@@ -81,59 +80,5 @@ export const setConstants = async () => {
     sas9CredentialsError,
     invalidSasError,
     sas9GUID
-  }
-}
-
-export const updateSasjsConstants = (target: Target, isLocal: boolean) => {
-  const homeDir = require('os').homedir()
-
-  if (target.sasjsBuildFolder) {
-    const buildOutputFolder = target.sasjsBuildFolder
-
-    const buildDestinationFolder = getAbsolutePath(
-      buildOutputFolder,
-      isLocal ? process.projectDir : homeDir
-    )
-
-    process.sasjsConstants.buildDestinationFolder = buildDestinationFolder
-
-    process.sasjsConstants.buildDestinationServicesFolder = path.join(
-      buildDestinationFolder,
-      'services'
-    )
-
-    process.sasjsConstants.buildDestinationTestFolder = path.join(
-      buildDestinationFolder,
-      'tests'
-    )
-    process.sasjsConstants.buildDestinationJobsFolder = path.join(
-      buildDestinationFolder,
-      'jobs'
-    )
-    process.sasjsConstants.buildDestinationDbFolder = path.join(
-      buildDestinationFolder,
-      'db'
-    )
-    process.sasjsConstants.buildDestinationDocsFolder = path.join(
-      buildDestinationFolder,
-      'docs'
-    )
-  }
-
-  if (target.sasjsResultsFolder) {
-    const buildResultsFolder = target.sasjsResultsFolder
-
-    const buildDestinationResultsFolder = getAbsolutePath(
-      buildResultsFolder,
-      isLocal ? process.projectDir : homeDir
-    )
-
-    process.sasjsConstants.buildDestinationResultsFolder =
-      buildDestinationResultsFolder
-
-    process.sasjsConstants.buildDestinationResultsLogsFolder = path.join(
-      buildDestinationResultsFolder,
-      'logs'
-    )
   }
 }

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -5,18 +5,18 @@ import { Configuration, getAbsolutePath, Target } from '@sasjs/utils'
 export const contextName = 'sasjs cli compute context'
 
 export const setConstants = async (
-  target: Target,
-  configuration: Configuration,
-  isLocal: boolean
+  isLocal: boolean = true,
+  target?: Target,
+  configuration?: Configuration
 ) => {
   const buildOutputFolder =
-    target.sasjsBuildFolder ||
-    configuration.sasjsBuildFolder ||
+    target?.sasjsBuildFolder ||
+    configuration?.sasjsBuildFolder ||
     (isLocal ? 'sasjsbuild' : '.sasjs/sasjsbuild')
 
   const buildResultsFolder =
-    target.sasjsResultsFolder ||
-    configuration.sasjsResultsFolder ||
+    target?.sasjsResultsFolder ||
+    configuration?.sasjsResultsFolder ||
     (isLocal ? 'sasjsresults' : '.sasjs/sasjsresults')
 
   const homeDir = require('os').homedir()

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -79,6 +79,7 @@ export const setConstants = async (
     contextName,
     sas9CredentialsError,
     invalidSasError,
+    isLocal,
     sas9GUID
   }
 }

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -79,7 +79,6 @@ export const setConstants = async (
     contextName,
     sas9CredentialsError,
     invalidSasError,
-    isLocal,
     sas9GUID
   }
 }

--- a/src/utils/spec/setConstants.spec.ts
+++ b/src/utils/spec/setConstants.spec.ts
@@ -77,7 +77,7 @@ describe('setConstants', () => {
         })
       )
 
-    await setConstants()
+    await setConstants(false)
 
     verifySasjsConstants(undefined, false, false)
   })

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -43,6 +43,7 @@ export const createTestApp = async (parentFolder: string, appName: string) => {
   await create(appName, '')
   process.projectDir = path.join(parentFolder, appName)
   process.currentDir = process.projectDir
+  process.sasjsConfig = await getLocalConfig()
   await setConstants()
 }
 
@@ -54,6 +55,7 @@ export const createTestJobsApp = async (
   await create(appName, 'jobs')
   process.projectDir = path.join(parentFolder, appName)
   process.currentDir = process.projectDir
+  process.sasjsConfig = await getLocalConfig()
   await setConstants()
   await updateTarget({ serverUrl: 'https://example.com' }, 'viya')
 }
@@ -66,6 +68,7 @@ export const createTestMinimalApp = async (
   await create(appName, 'minimal')
   process.projectDir = path.join(parentFolder, appName)
   process.currentDir = process.projectDir
+  process.sasjsConfig = await getLocalConfig()
   await setConstants()
 }
 


### PR DESCRIPTION
## Issue

fixes #1333

## Intent

We should set `process.sasjsConstants` based on the target

## Implementation

* called `setConstants` function from `getTargetInfo` method of TargetCommand class

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [ ] Reviewer is assigned.
