### PR TITLE
fix(compile): terminate compilation if testSetUp or testTearDown failed

### DIFF
--- a/src/commands/compile/compile.ts
+++ b/src/commands/compile/compile.ts
@@ -12,6 +12,7 @@ import {
   listSubFoldersInFolder
 } from '@sasjs/utils'
 import { SASJsFileType, StreamConfig, Target } from '@sasjs/utils/types'
+import { prefixMessage } from '@sasjs/utils/error'
 import path from 'path'
 import {
   getMacroFolders,
@@ -157,10 +158,11 @@ export async function compileJobsServicesTests(
         true,
         false,
         compileTree
-      ).catch((err) =>
-        process.logger?.error('Test set up compilation has failed.')
-      )
+      ).catch((err) => {
+        throw prefixMessage(err, 'Test set up compilation has failed. ')
+      })
     }
+
     if (testTearDown) {
       await compileTestFile(
         target,
@@ -169,9 +171,9 @@ export async function compileJobsServicesTests(
         true,
         false,
         compileTree
-      ).catch((err) =>
-        process.logger?.error('Test tear down compilation has failed.')
-      )
+      ).catch((err) => {
+        throw prefixMessage(err, 'Test tear down compilation has failed. ')
+      })
     }
 
     await asyncForEach(serviceFolders, async (serviceFolder) => {
@@ -194,10 +196,6 @@ export async function compileJobsServicesTests(
       )
     })
   } catch (error) {
-    process.logger?.error(
-      'An error has occurred when compiling your jobs and services.'
-    )
-
     throw error
   }
 }

--- a/src/commands/compile/compileCommand.ts
+++ b/src/commands/compile/compileCommand.ts
@@ -99,7 +99,8 @@ export class CompileCommand extends TargetCommand {
         return ReturnCode.Success
       })
       .catch((err) => {
-        displayError(err, 'An error has occurred when compiling services.')
+        displayError(err, 'An error has occurred during compilation.')
+
         return ReturnCode.InternalError
       })
   }


### PR DESCRIPTION
## Issue

closes #1206

## Intent

- Terminate the compilation process if `testSetUp` option is present and test file compilation failed.
- Terminate the compilation process if `testTearDown` option is present and the test file compilation failed.

## Implementation

- Modified `src/commands/compile/compile.ts` to throw an error if there was an error during the compilation of the test file.
- Added unit tests to cover cases when `testSetUp` or `testTearDown` option is present and test file compilation failed.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
