### PR TITLE
fix(help): added compile option to run command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@sasjs/adapter": "4.1.6",
         "@sasjs/core": "4.45.4",
         "@sasjs/lint": "2.2.2",
-        "@sasjs/utils": "3.1.0",
+        "@sasjs/utils": "3.2.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
         "dotenv": "10.0.0",
@@ -2354,9 +2354,9 @@
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
     "node_modules/@sasjs/utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.1.0.tgz",
-      "integrity": "sha512-b6Xjim+IjPAPS/dx6VVaZxz0J6kR+miAMst38oyaRU0FdyakmGizYalXcl0sEafZsImuTbtOTAQ/YMxrm/LAJg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-Hdt4t/ErAy9JeJAyH7sJ+tA3ipKYUwRAAWN1CGMG0+BK2/TUVjpPtP9xYCtKculzfHFadthNXTnFVTfe4D4MLw==",
       "hasInstallScript": true,
       "dependencies": {
         "@fast-csv/format": "4.3.5",
@@ -9384,9 +9384,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.1.0.tgz",
-      "integrity": "sha512-b6Xjim+IjPAPS/dx6VVaZxz0J6kR+miAMst38oyaRU0FdyakmGizYalXcl0sEafZsImuTbtOTAQ/YMxrm/LAJg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-Hdt4t/ErAy9JeJAyH7sJ+tA3ipKYUwRAAWN1CGMG0+BK2/TUVjpPtP9xYCtKculzfHFadthNXTnFVTfe4D4MLw==",
       "requires": {
         "@fast-csv/format": "4.3.5",
         "@types/fs-extra": "9.0.13",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@sasjs/adapter": "4.1.6",
     "@sasjs/core": "4.45.4",
     "@sasjs/lint": "2.2.2",
-    "@sasjs/utils": "3.1.0",
+    "@sasjs/utils": "3.2.0",
     "adm-zip": "0.5.9",
     "chalk": "4.1.2",
     "dotenv": "10.0.0",

--- a/src/commands/help/help.ts
+++ b/src/commands/help/help.ts
@@ -224,12 +224,13 @@ export async function printHelpText() {
     {
       name: 'run',
       title:
-        'run <sasFilePath> -t <targetName> --source /local/run.json -l <log/file/path>',
+        'run <sasFilePath> -t <targetName> --source /local/run.json -l <log/file/path> --compile',
       description: [
         `lets the user run a given SAS file against a specified target.`,
         `The target can exist either in the local project configuration or in the global .sasjsrc file.`,
         `Providing log flag (--log or -l) is optional. If not present, the log is stored locally with a timestamp. If present, CLI will fetch and save the log to the specified location. If a relative location, it will be relative to the directory in which the command is invoked.`,
-        `Providing source flag (--source or -s) is optional. It should point to a JSON file with the following structure:  {"macroVars": {"var1": "val1", "var2": "val2"}}. These will be parsed into SAS "%let" statements and pre-append to the SAS code being run.`
+        `Providing source flag (--source or -s) is optional. It should point to a JSON file with the following structure:  {"macroVars": {"var1": "val1", "var2": "val2"}}. These will be parsed into SAS "%let" statements and pre-append to the SAS code being run.`,
+        `Providing compile flag (--compile or -c) is optional. It is used to compile the program prior to execution. Useful for including dependent macros and includes. More info here: https://cli.sasjs.io/compile`
       ]
     },
     {


### PR DESCRIPTION
## Issue

Closes #1340 

## Intent

- Add `compile` option to `run` command documentation provided by `help` command.
- Bump `@sasjs/utils` to the latest version.

## Implementation

- Updated `src/commands/help/help.ts`.
- Adjusted `@sasjs/utils` version in `package.json`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
