### PR TITLE
chore(ci): added generate coverage report step

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -101,3 +101,9 @@ jobs:
           SASJS_SERVER_URL: http://localhost:5000
           ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
           REFRESH_TOKEN: ${{secrets.REFRESH_TOKEN}}
+
+      # For some reason if coverage report action is run before other commands, those commands can't access the directories and files on which they depend on
+      - name: Generate coverage report
+        uses: artiomtr/jest-coverage-report-action@v2.0-rc.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,21 +66,7 @@ jobs:
       - name: Run smoke tests
         run: sh ./test.sh
 
-      - name: Run mocked tests
-        run: npm run test:mocked
-        env:
-          CI: true
-          CLIENT: ${{secrets.CLIENT}}
-          SECRET: ${{secrets.SECRET}}
-          SAS_USERNAME: ${{secrets.SAS_USERNAME}}
-          SAS_PASSWORD: ${{secrets.SAS_PASSWORD}}
-          VIYA_SERVER_URL: ${{secrets.VIYA_SERVER_URL}}
-          SAS9_SERVER_URL: 'http://localhost:5000'
-          SASJS_SERVER_URL: 'http://localhost:5000'
-          ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
-          REFRESH_TOKEN: ${{secrets.REFRESH_TOKEN}}
-
-      # For some reason if coverage report action is run before other commands, those commands can't access the directories and files on which they depend on
+      # Mocked (*.spec.ts) tests will be conducted during this step
       - name: Generate coverage report
         uses: artiomtr/jest-coverage-report-action@v2.0-rc.2
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -80,6 +80,12 @@ jobs:
           ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
           REFRESH_TOKEN: ${{secrets.REFRESH_TOKEN}}
 
+      # For some reason if coverage report action is run before other commands, those commands can't access the directories and files on which they depend on
+      - name: Generate coverage report
+        uses: artiomtr/jest-coverage-report-action@v2.0-rc.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Deploy SAS9 tests
         run: |
           cd mocks
@@ -101,9 +107,3 @@ jobs:
           SASJS_SERVER_URL: http://localhost:5000
           ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
           REFRESH_TOKEN: ${{secrets.REFRESH_TOKEN}}
-
-      # For some reason if coverage report action is run before other commands, those commands can't access the directories and files on which they depend on
-      - name: Generate coverage report
-        uses: artiomtr/jest-coverage-report-action@v2.0-rc.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -84,9 +84,7 @@ describe('sasjs compile', () => {
     await expect(compileModule.compile(target)).toResolve()
     await expect(folderExists(wrongSasjsBuildFolder)).resolves.toEqual(false)
     await expect(folderExists(correctSasjsBuildFolder)).resolves.toEqual(true)
-
-    // FIXME: intentional error
-    await expect(fileExists(correctBuildFile)).resolves.toEqual(false)
+    await expect(fileExists(correctBuildFile)).resolves.toEqual(true)
   })
 
   it('should compile an uncompiled project', async () => {

--- a/src/commands/compile/spec/compile.spec.ts
+++ b/src/commands/compile/spec/compile.spec.ts
@@ -84,7 +84,9 @@ describe('sasjs compile', () => {
     await expect(compileModule.compile(target)).toResolve()
     await expect(folderExists(wrongSasjsBuildFolder)).resolves.toEqual(false)
     await expect(folderExists(correctSasjsBuildFolder)).resolves.toEqual(true)
-    await expect(fileExists(correctBuildFile)).resolves.toEqual(true)
+
+    // FIXME: intentional error
+    await expect(fileExists(correctBuildFile)).resolves.toEqual(false)
   })
 
   it('should compile an uncompiled project', async () => {


### PR DESCRIPTION
## Issue

Closes #1341 

## Intent

- Add coverage report to CI on pull requests.

## Implementation

- Added `Generate coverage report` step to `.github/workflows/run-tests.yml`.
- Removed `Run mocked tests` step from `Node.js CI` because these tests will be conducted as during `Generate coverage report` step.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
