### PR TITLE
Fixed run command for SASJS server type

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preinstall": "npm run nodeVersionMessage",
     "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true"
   },
-  "testServerTypes": "sasjs,sas9",
+  "testServerTypes": "sasjs",
   "release": {
     "branches": [
       "main"

--- a/src/commands/run/spec/run.spec.ts
+++ b/src/commands/run/spec/run.spec.ts
@@ -1,0 +1,86 @@
+import { Target, ServerType } from '@sasjs/utils'
+import { runSasCode } from '../run'
+import * as utilsModule from '../../../utils/utils'
+import * as configModule from '../../../utils/config'
+import * as saveLogModule from '../../../utils/saveLog'
+import * as fileModule from '@sasjs/utils/file'
+import * as getAbsolutePathModule from '@sasjs/utils/file/getAbsolutePath'
+import SASjs, { ErrorResponse } from '@sasjs/adapter/node'
+import { setConstants, saveLog } from '../../../utils'
+
+const sasjs = new (<jest.Mock<SASjs>>SASjs)()
+
+describe('sasjs run', () => {
+  describe('SASJS', () => {
+    const target = new Target({
+      name: 'test',
+      appLoc: '/Public/test/',
+      serverType: ServerType.Sasjs,
+      contextName: 'test context'
+    })
+    const logData = 'SAS log'
+    const filePath = 'test.sas'
+
+    beforeAll(async () => {
+      await setConstants(false)
+    })
+
+    beforeEach(() => {
+      setupMocks(filePath, logData)
+    })
+
+    it('should saveLog function with correct log data', async () => {
+      jest
+        .spyOn(sasjs, 'executeScript')
+        .mockImplementation(() => Promise.resolve({ log: logData }))
+      jest.spyOn(saveLogModule, 'saveLog').mockImplementation()
+
+      process.sasjsConstants.buildDestinationResultsFolder = __dirname
+
+      await runSasCode(target, filePath, false, '')
+
+      expect(saveLog).toHaveBeenCalledWith(
+        logData,
+        expect.stringMatching(/sasjs-run-\d{14}\.log$/),
+        '',
+        false,
+        undefined
+      )
+    })
+
+    it('should throw an error if log is not returned by @sasjs/adapter', async () => {
+      jest
+        .spyOn(sasjs, 'executeScript')
+        .mockImplementation(() => Promise.resolve({}))
+
+      const expectedError = new ErrorResponse(
+        'We were not able to fetch the log this time.'
+      )
+
+      await expect(runSasCode(target, filePath, false, '')).rejects.toEqual(
+        expectedError
+      )
+    })
+  })
+})
+
+const setupMocks = (filePath: string, logData: string) => {
+  jest
+    .spyOn(getAbsolutePathModule, 'getAbsolutePath')
+    .mockImplementation(() => filePath)
+  jest
+    .spyOn(fileModule, 'readFile')
+    .mockImplementation(() => Promise.resolve('test SAS code;'))
+  jest
+    .spyOn(utilsModule, 'isSasJsServerInServerMode')
+    .mockImplementation(() => Promise.resolve(true))
+  jest.spyOn(configModule, 'getAuthConfig').mockImplementation(() =>
+    Promise.resolve({
+      access_token: 'test_access_token',
+      refresh_token: 'test_refresh_token',
+      client: 'test_client',
+      secret: ''
+    })
+  )
+  jest.spyOn(configModule, 'getSASjs').mockImplementation((target) => sasjs)
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -590,10 +590,13 @@ export const getNodeModulePath = async (module: string): Promise<string> => {
 export const isSasJsServerInServerMode = async (target: Target) => {
   try {
     const res = await axios.get(`${target.serverUrl}/SASjsApi/info`)
+
     return res.data.mode === 'server'
   } catch (error) {
     const message = `An error occurred while fetching server info from ${target.serverUrl}/SASjsApi/info`
+
     displayError(error, message)
+
     throw new Error(message)
   }
 }


### PR DESCRIPTION
## Issue

- `executeScript` method of `@sasjs/adapter` returns an object for `SASJS` server type.
- Leave only server-side tests with `SASJS` server type.

## Intent

- Adjust the way the execution result of `executeScript` method is handled.

## Implementation

- Adjusted `executeOnSasJS` function in `src/commands/run/run.ts`.
- Added mocked `src/commands/run/spec/run.spec.ts` unit test for `SASJS` server type.
- Adjusted `testServerTypes` property in `package.json`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
