### PR TITLE
feat(verbose): added verbose mode and deprecated --returnStatusOnly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.5.1",
+        "@sasjs/adapter": "4.8.0",
         "@sasjs/core": "4.46.3",
         "@sasjs/lint": "2.3.1",
         "@sasjs/utils": "3.3.0",
@@ -2245,9 +2245,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.5.1.tgz",
-      "integrity": "sha512-WeKDMfCivBywxDZ6t0jng78ZBPoMk8RIHKFTNDDmvuvmXq5Mr5oqZ0r5lRPB863XkGOeVi6UIEI1+JawZ2TlWQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.8.0.tgz",
+      "integrity": "sha512-1eGQfhZcp2pTbCZKbCEABC3+Kz8B4PRWqJZG9XAhh9QkFAR+ENRKAkbk5Sf+xa9YS+ycz7SvusmYYInGZ9b54w==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -9311,9 +9311,9 @@
       }
     },
     "@sasjs/adapter": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.5.1.tgz",
-      "integrity": "sha512-WeKDMfCivBywxDZ6t0jng78ZBPoMk8RIHKFTNDDmvuvmXq5Mr5oqZ0r5lRPB863XkGOeVi6UIEI1+JawZ2TlWQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.8.0.tgz",
+      "integrity": "sha512-1eGQfhZcp2pTbCZKbCEABC3+Kz8B4PRWqJZG9XAhh9QkFAR+ENRKAkbk5Sf+xa9YS+ycz7SvusmYYInGZ9b54w==",
       "requires": {
         "@sasjs/utils": "2.52.0",
         "axios": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "4.5.1",
+    "@sasjs/adapter": "4.8.0",
     "@sasjs/core": "4.46.3",
     "@sasjs/lint": "2.3.1",
     "@sasjs/utils": "3.3.0",

--- a/src/commands/add/addCredential.ts
+++ b/src/commands/add/addCredential.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { LogLevel } from '@sasjs/utils/logger'
 import { ServerType, Target, HttpsAgentOptions } from '@sasjs/utils/types'
 
-import SASjs, { CertificateError } from '@sasjs/adapter/node'
+import SASjs from '@sasjs/adapter/node'
 import { getNewAccessToken } from '../../utils/auth'
 import { isSasJsServerInServerMode } from '../../utils'
 import { createFile } from '@sasjs/utils'

--- a/src/commands/compile/internal/compileTestFile.ts
+++ b/src/commands/compile/internal/compileTestFile.ts
@@ -95,10 +95,7 @@ export async function copyTestMacroFiles(folderAbsolutePath: string) {
   })
 }
 
-export const compileTestFlow = async (
-  target: Target,
-  config?: Configuration
-) => {
+export const compileTestFlow = async (target: Target) => {
   if (
     target.testConfig &&
     Object.keys(target.testConfig).includes('testFolders')

--- a/src/commands/compile/internal/spec/compileTestFile.spec.ts
+++ b/src/commands/compile/internal/spec/compileTestFile.spec.ts
@@ -267,10 +267,7 @@ describe('compileTestFile', () => {
 
       expect(process.logger.warn).toHaveBeenCalledWith(expectedWarn)
 
-      compileTestFlow(
-        testTarget as unknown as Target,
-        testConfig as unknown as Configuration
-      )
+      compileTestFlow(testTarget as unknown as Target)
 
       expect(process.logger.warn).toHaveBeenCalledWith(expectedWarn)
     })

--- a/src/commands/help/help.ts
+++ b/src/commands/help/help.ts
@@ -289,14 +289,14 @@ export async function printHelpText() {
         `[2spaces]* ${chalk.cyanBright(
           'execute'
         )} - triggers job for execution.`,
-        `[2spaces]command example: sasjs job execute /Public/job -t targetName --output ./outputFolder/output.json --returnStatusOnly --ignoreWarnings`,
-        `[2spaces]command example: sasjs job execute /Public/job -t targetName --wait --log ./logFolder/log.json -r -i`,
+        `[2spaces]command example: sasjs job execute /Public/job -t targetName --output ./outputFolder/output.json --ignoreWarnings --verbose`,
+        `[2spaces]command example: sasjs job execute /Public/job -t targetName --wait --log ./logFolder/log.json -i -v`,
         ``,
         `[2spaces]NOTE: Providing wait flag (--wait or -w) is optional. If present, CLI will wait for job completion.`,
         `[2spaces]NOTE: Providing output flag (--output or -o) is optional. If present, CLI will immediately print out the response JSON. If value is provided, it will be treated as file path to save the response JSON.`,
         `[2spaces]NOTE: Providing log flag (--log or -l) is optional. If present, CLI will fetch and save job log to local file.`,
-        `[2spaces]NOTE: Providing return status only (--returnStatusOnly or -r) flag is optional. If present and wait flag is provided, CLI will job status only (0 = success, 1 = warning, 2 = error).`,
-        `[2spaces]NOTE: Providing ignore warnings (--ignoreWarnings or -i) flag is optional. If present and return status only is provided, CLI will return status '0', when the job state is warning.`
+        `[2spaces]NOTE: Providing ignore warnings (--ignoreWarnings or -i) flag is optional. If present, CLI will return status '0', when the job state is warning.`,
+        `[2spaces]NOTE: Providing verbose (--verbose or -v) flag is optional. If present, CLI will log summary of every HTTP response.`
       ]
     },
     {

--- a/src/commands/job/internal/execute/sas9.ts
+++ b/src/commands/job/internal/execute/sas9.ts
@@ -22,31 +22,31 @@ export async function executeJobSas9(
 ) {
   let macroVars: MacroVars | null = null
 
-  // INFO: get macro variables
+  // get macro variables
   if (source) macroVars = await parseSourceFile(source)
 
-  // INFO: timestamp of the execution start
+  // timestamp of the execution start
   const startTime = new Date().getTime()
 
   const result = await sasjs.request(jobPath, macroVars, config)
 
-  // INFO: timestamp of the execution end
+  // timestamp of the execution end
   const endTime = new Date().getTime()
 
   if (result) {
     if (result.status === 200) {
-      // INFO: handle success
+      // handle success
       process.logger.success(
         `Job executed successfully! in ${(endTime - startTime) / 1000} seconds`
       )
 
-      // INFO: save log if it is present
+      // save log if it is present
       if (!!logFile && result.log) await saveLog(result.log, logFile, jobPath)
 
-      // INFO: save output if it is present
+      // save output if it is present
       if (!!output && result.result) await saveOutput(result.result, output)
     } else {
-      // INFO: handle failure
+      // handle failure
       process.logger.error(result.message)
       process.logger.error(JSON.stringify(result.error, null, 2))
     }

--- a/src/commands/job/internal/execute/sas9.ts
+++ b/src/commands/job/internal/execute/sas9.ts
@@ -1,7 +1,5 @@
-import path from 'path'
 import SASjs from '@sasjs/adapter/node'
-import { MacroVars, createFile, createFolder, folderExists } from '@sasjs/utils'
-import { displayError, displaySuccess } from '../../../../utils/displayResult'
+import { MacroVars } from '@sasjs/utils'
 import { saveLog, saveOutput } from '../utils'
 import { parseSourceFile } from '../../../../utils/parseSourceFile'
 
@@ -46,7 +44,7 @@ export async function executeJobSas9(
       if (!!logFile && result.log) await saveLog(result.log, logFile, jobPath)
 
       // INFO: save output if it is present
-      if (!!output && result.result) saveOutput(result.result, output)
+      if (!!output && result.result) await saveOutput(result.result, output)
     } else {
       // INFO: handle failure
       process.logger.error(result.message)

--- a/src/commands/job/internal/execute/sas9.ts
+++ b/src/commands/job/internal/execute/sas9.ts
@@ -41,11 +41,11 @@ export async function executeJobSas9(
       )
 
       if (!!logFile && result.log) {
-        await saveLog(result.log, logFile, jobPath, false)
+        await saveLog(result.log, logFile, jobPath)
       }
 
       if (!!output && result.result) {
-        saveOutput(result.result, output, false)
+        saveOutput(result.result, output)
       }
     } else {
       process.logger.error(result.message)

--- a/src/commands/job/internal/execute/sas9.ts
+++ b/src/commands/job/internal/execute/sas9.ts
@@ -24,30 +24,31 @@ export async function executeJobSas9(
 ) {
   let macroVars: MacroVars | null = null
 
-  if (source) {
-    macroVars = await parseSourceFile(source)
-  }
+  // INFO: get macro variables
+  if (source) macroVars = await parseSourceFile(source)
 
+  // INFO: timestamp of the execution start
   const startTime = new Date().getTime()
 
   const result = await sasjs.request(jobPath, macroVars, config)
 
+  // INFO: timestamp of the execution end
   const endTime = new Date().getTime()
 
   if (result) {
     if (result.status === 200) {
+      // INFO: handle success
       process.logger.success(
         `Job executed successfully! in ${(endTime - startTime) / 1000} seconds`
       )
 
-      if (!!logFile && result.log) {
-        await saveLog(result.log, logFile, jobPath)
-      }
+      // INFO: save log if it is present
+      if (!!logFile && result.log) await saveLog(result.log, logFile, jobPath)
 
-      if (!!output && result.result) {
-        saveOutput(result.result, output)
-      }
+      // INFO: save output if it is present
+      if (!!output && result.result) saveOutput(result.result, output)
     } else {
+      // INFO: handle failure
       process.logger.error(result.message)
       process.logger.error(JSON.stringify(result.error, null, 2))
     }

--- a/src/commands/job/internal/execute/sasjs.ts
+++ b/src/commands/job/internal/execute/sasjs.ts
@@ -17,7 +17,7 @@ export async function executeJobSasjs(
   logFile?: string,
   output?: string
 ) {
-  // INFO: get authentication configuration if SASJS server is in server mode.
+  // get authentication configuration if SASJS server is in server mode.
   const authConfig = (await isSasJsServerInServerMode(target))
     ? await getAuthConfig(target)
     : undefined
@@ -35,13 +35,13 @@ export async function executeJobSasjs(
   )
 
   if (response) {
-    // INFO: handle success
+    // handle success
     process.logger?.success('Job executed successfully!')
 
-    // INFO: save log if it is present
+    // save log if it is present
     if (!!logFile && response.log) await saveLog(response.log, logFile, jobPath)
 
-    // INFO: save output if it is present
+    // save output if it is present
     if (!!output && response.result) await saveOutput(response.result, output)
   }
 

--- a/src/commands/job/internal/execute/sasjs.ts
+++ b/src/commands/job/internal/execute/sasjs.ts
@@ -3,12 +3,21 @@ import { Target } from '@sasjs/utils'
 import { getAuthConfig, isSasJsServerInServerMode } from '../../../../utils'
 import { saveLog, saveOutput } from '../utils'
 
+/**
+ * Triggers existing job for execution on SASJS server.
+ * @param target - SASJS server configuration.
+ * @param jobPath - location of the job.
+ * @param logFile - flag indicating if CLI should fetch and save log to provided file path. If filepath wasn't provided, {job}.log file will be created in current folder.
+ * @param output - flag indicating if CLI should save output to provided file path.
+ * @returns - promise that resolves into an object with log and output.
+ */
 export async function executeJobSasjs(
   target: Target,
   jobPath: string,
   logFile?: string,
   output?: string
 ) {
+  // INFO: get authentication configuration if SASJS server is in server mode.
   const authConfig = (await isSasJsServerInServerMode(target))
     ? await getAuthConfig(target)
     : undefined
@@ -26,15 +35,14 @@ export async function executeJobSasjs(
   )
 
   if (response) {
+    // INFO: handle success
     process.logger?.success('Job executed successfully!')
 
-    if (!!logFile && response.log) {
-      await saveLog(response.log, logFile, jobPath)
-    }
+    // INFO: save log if it is present
+    if (!!logFile && response.log) await saveLog(response.log, logFile, jobPath)
 
-    if (!!output && response.result) {
-      await saveOutput(response.result, output)
-    }
+    // INFO: save output if it is present
+    if (!!output && response.result) await saveOutput(response.result, output)
   }
 
   return response

--- a/src/commands/job/internal/execute/sasjs.ts
+++ b/src/commands/job/internal/execute/sasjs.ts
@@ -29,11 +29,11 @@ export async function executeJobSasjs(
     process.logger?.success('Job executed successfully!')
 
     if (!!logFile && response.log) {
-      await saveLog(response.log, logFile, jobPath, false)
+      await saveLog(response.log, logFile, jobPath)
     }
 
     if (!!output && response.result) {
-      await saveOutput(response.result, output, false)
+      await saveOutput(response.result, output)
     }
   }
 

--- a/src/commands/job/internal/execute/viya.ts
+++ b/src/commands/job/internal/execute/viya.ts
@@ -23,7 +23,7 @@ import { ReturnCode } from '../../../../types/command'
 import { saveLog } from '../utils'
 
 /**
- * Triggers existing job for execution.
+ * Triggers existing job for execution on Viya server.
  * @param {object} sasjs - configuration object of SAS adapter.
  * @param {string} accessToken - an access token for an authorized user.
  * @param {string} jobPath - location of the job on SAS Drive.

--- a/src/commands/job/internal/utils.ts
+++ b/src/commands/job/internal/utils.ts
@@ -3,6 +3,12 @@ import { createFile, createFolder, folderExists } from '@sasjs/utils'
 import { parseLogLines } from '../../../utils/utils'
 import { displayError, displaySuccess } from '../../../utils/displayResult'
 
+/**
+ * Saves log to a file.
+ * @param logData - log content.
+ * @param logFile - file path to log file.
+ * @param jobPath - file path to the job submitted for execution.
+ */
 export const saveLog = async (
   logData: any,
   logFile: string | undefined,
@@ -10,9 +16,13 @@ export const saveLog = async (
 ) => {
   let logPath
 
+  // INFO: use provide file path to log file
   if (logFile) {
     logPath = logFile
-  } else {
+  }
+  // INFO: use file path based on job file path
+  // the same file name will be used, but with *.log extension
+  else {
     logPath = path.join(
       process.projectDir,
       `${jobPath.split(path.sep).slice(-1).pop()}.log`
@@ -23,10 +33,12 @@ export const saveLog = async (
   folderPath.pop()
   const parentFolderPath = folderPath.join(path.sep)
 
+  // INFO: create parent folder of log file
   if (!(await folderExists(parentFolderPath))) {
     await createFolder(parentFolderPath)
   }
 
+  // INFO: try to parse log by lines
   const logLines =
     typeof logData === 'object' ? parseLogLines(logData) : logData
 
@@ -35,7 +47,13 @@ export const saveLog = async (
   displaySuccess(`Log saved to ${logPath}`)
 }
 
+/**
+ * Saves job output to the file.
+ * @param outputData - job output.
+ * @param outputFile - file path to output file.
+ */
 export const saveOutput = async (outputData: any, outputFile: string) => {
+  // INFO: try to convert job output into a string
   try {
     outputData = JSON.stringify(outputData, null, 2)
   } catch (error) {
@@ -45,6 +63,7 @@ export const saveOutput = async (outputData: any, outputFile: string) => {
     )
   }
 
+  // INFO: get absolute file path
   const currentDirPath = path.isAbsolute(outputFile) ? '' : process.projectDir
   const outputPath = path.join(
     currentDirPath,
@@ -57,6 +76,7 @@ export const saveOutput = async (outputData: any, outputFile: string) => {
   folderPath.pop()
   const parentFolderPath = folderPath.join(path.sep)
 
+  // INFO: create parent folder of output file
   if (!(await folderExists(parentFolderPath))) {
     await createFolder(parentFolderPath)
   }

--- a/src/commands/job/internal/utils.ts
+++ b/src/commands/job/internal/utils.ts
@@ -6,8 +6,7 @@ import { displayError, displaySuccess } from '../../../utils/displayResult'
 export const saveLog = async (
   logData: any,
   logFile: string | undefined,
-  jobPath: string,
-  returnStatusOnly: boolean
+  jobPath: string
 ) => {
   let logPath
 
@@ -33,14 +32,10 @@ export const saveLog = async (
 
   await createFile(logPath, logLines)
 
-  if (!returnStatusOnly) displaySuccess(`Log saved to ${logPath}`)
+  displaySuccess(`Log saved to ${logPath}`)
 }
 
-export const saveOutput = async (
-  outputData: any,
-  outputFile: string,
-  returnStatusOnly: boolean
-) => {
+export const saveOutput = async (outputData: any, outputFile: string) => {
   try {
     outputData = JSON.stringify(outputData, null, 2)
   } catch (error) {
@@ -68,5 +63,5 @@ export const saveOutput = async (
 
   await createFile(outputPath, outputData)
 
-  if (!returnStatusOnly) displaySuccess(`Output saved to: ${outputPath}`)
+  displaySuccess(`Output saved to: ${outputPath}`)
 }

--- a/src/commands/job/internal/utils.ts
+++ b/src/commands/job/internal/utils.ts
@@ -16,11 +16,11 @@ export const saveLog = async (
 ) => {
   let logPath
 
-  // INFO: use provide file path to log file
+  // use provide file path to log file
   if (logFile) {
     logPath = logFile
   }
-  // INFO: use file path based on job file path
+  // use file path based on job file path
   // the same file name will be used, but with *.log extension
   else {
     logPath = path.join(
@@ -33,12 +33,12 @@ export const saveLog = async (
   folderPath.pop()
   const parentFolderPath = folderPath.join(path.sep)
 
-  // INFO: create parent folder of log file
+  // create parent folder of log file
   if (!(await folderExists(parentFolderPath))) {
     await createFolder(parentFolderPath)
   }
 
-  // INFO: try to parse log by lines
+  // try to parse log by lines
   const logLines =
     typeof logData === 'object' ? parseLogLines(logData) : logData
 
@@ -53,7 +53,7 @@ export const saveLog = async (
  * @param outputFile - file path to output file.
  */
 export const saveOutput = async (outputData: any, outputFile: string) => {
-  // INFO: try to convert job output into a string
+  // try to convert job output into a string
   try {
     outputData = JSON.stringify(outputData, null, 2)
   } catch (error) {
@@ -63,7 +63,7 @@ export const saveOutput = async (outputData: any, outputFile: string) => {
     )
   }
 
-  // INFO: get absolute file path
+  // get absolute file path
   const currentDirPath = path.isAbsolute(outputFile) ? '' : process.projectDir
   const outputPath = path.join(
     currentDirPath,
@@ -76,7 +76,7 @@ export const saveOutput = async (outputData: any, outputFile: string) => {
   folderPath.pop()
   const parentFolderPath = folderPath.join(path.sep)
 
-  // INFO: create parent folder of output file
+  // create parent folder of output file
   if (!(await folderExists(parentFolderPath))) {
     await createFolder(parentFolderPath)
   }

--- a/src/commands/job/jobCommand.ts
+++ b/src/commands/job/jobCommand.ts
@@ -48,7 +48,7 @@ const executeParseOptions = {
     description:
       'path where output of the finished job execution will be saved.'
   },
-  // INFO: returnStatusOnly flag is deprecated and is left to display warning if used
+  // returnStatusOnly flag is deprecated and is left to display warning if used
   returnStatusOnly: {
     type: 'boolean',
     default: false,
@@ -114,13 +114,13 @@ export class JobCommand extends TargetCommand {
   public async execute() {
     const { target } = await this.getTargetInfo()
 
-    // INFO: returnStatusOnly flag is deprecated and is left to display warning if used
+    // returnStatusOnly flag is deprecated and is left to display warning if used
     const returnStatusOnly = !!this.parsed.returnStatusOnly
     if (returnStatusOnly) {
       process.logger.warn('--returnStatusOnly (-r) flag is deprecated.')
     }
 
-    // INFO: use execution function based on server type
+    // use execution function based on server type
     switch (target.serverType) {
       case ServerType.SasViya:
         return this.jobSubCommands.includes(this.parsed.subCommand)
@@ -155,7 +155,7 @@ export class JobCommand extends TargetCommand {
    * @returns - promise that resolves into return code.
    */
   async executeJobSasjs(target: Target) {
-    // INFO: use command attributes to get to get required details for job execution
+    // use command attributes to get to get required details for job execution
     const jobPath = prefixAppLoc(target.appLoc, this.parsed.jobPath as string)
     const log = getLogFilePath(this.parsed.log, jobPath)
 
@@ -166,7 +166,7 @@ export class JobCommand extends TargetCommand {
     const returnCode = await executeJobSasjs(target, jobPath, log, output)
       .then(() => ReturnCode.Success)
       .catch((err) => {
-        // INFO: handle job execution failure
+        // handle job execution failure
         process.logger?.error('Error executing job: ', err)
 
         return ReturnCode.InternalError
@@ -181,7 +181,7 @@ export class JobCommand extends TargetCommand {
    * @returns - promise that resolves into return code.
    */
   async executeJobSas9(target: Target) {
-    // INFO: use command attributes to get to get required details for job execution
+    // use command attributes to get to get required details for job execution
     const jobPath = prefixAppLoc(target.appLoc, this.parsed.jobPath as string)
     const log = getLogFilePath(this.parsed.log, jobPath)
     const source = this.parsed.source as string
@@ -192,7 +192,7 @@ export class JobCommand extends TargetCommand {
 
     const { sasjs, authConfigSas9 } = await getSASjsAndAuthConfig(target).catch(
       (err) => {
-        // INFO: handle getting instance of @sasjs/adapter and auth config failure
+        // handle getting instance of @sasjs/adapter and auth config failure
         process.logger?.error(
           'Unable to execute job. Error fetching auth config: ',
           err
@@ -217,7 +217,7 @@ export class JobCommand extends TargetCommand {
     )
       .then(() => ReturnCode.Success)
       .catch((err) => {
-        // INFO: handle job execution failure
+        // handle job execution failure
         process.logger?.error('Error executing job: ', err)
 
         return ReturnCode.InternalError
@@ -232,7 +232,7 @@ export class JobCommand extends TargetCommand {
    * @returns - promise that resolves into return code.
    */
   async executeJobViya(target: Target) {
-    // INFO: use command attributes to get to get required details for job execution
+    // use command attributes to get to get required details for job execution
     const jobPath = prefixAppLoc(target.appLoc, this.parsed.jobPath as string)
     const statusFile = getStatusFilePath(this.parsed.statusFile)
     const log = getLogFilePath(this.parsed.log, jobPath)
@@ -252,7 +252,7 @@ export class JobCommand extends TargetCommand {
 
     const { sasjs, authConfig } = await getSASjsAndAuthConfig(target).catch(
       (err) => {
-        // INFO: handle getting instance of @sasjs/adapter and auth config failure
+        // handle getting instance of @sasjs/adapter and auth config failure
         process.logger?.error(
           'Unable to execute job. Error fetching auth config: ',
           err
@@ -280,7 +280,7 @@ export class JobCommand extends TargetCommand {
     )
       .then(() => ReturnCode.Success)
       .catch((err) => {
-        // INFO: handle job execution failure
+        // handle job execution failure
         process.logger?.error('Error executing job: ', err)
 
         return ReturnCode.InternalError

--- a/src/commands/job/jobCommand.ts
+++ b/src/commands/job/jobCommand.ts
@@ -34,7 +34,7 @@ const executeParseOptions = {
     alias: 'i',
     default: false,
     description:
-      'If present and return status only is provided, CLI will return status 0 when the job state is warning.'
+      'If present, CLI will return status 0 when the job state is warning.'
   },
   log: {
     type: 'string',
@@ -113,6 +113,12 @@ export class JobCommand extends TargetCommand {
    */
   public async execute() {
     const { target } = await this.getTargetInfo()
+
+    // INFO: returnStatusOnly flag is deprecated and is left to display warning if used
+    const returnStatusOnly = !!this.parsed.returnStatusOnly
+    if (returnStatusOnly) {
+      process.logger.warn('--returnStatusOnly (-r) flag is deprecated.')
+    }
 
     // INFO: use execution function based on server type
     switch (target.serverType) {
@@ -241,12 +247,6 @@ export class JobCommand extends TargetCommand {
       : (this.parsed.output as string)?.length === 0
       ? true
       : false
-
-    // INFO: returnStatusOnly flag is deprecated and is left to display warning if used
-    const returnStatusOnly = !!this.parsed.returnStatusOnly
-    if (returnStatusOnly) {
-      process.logger.warn('--returnStatusOnly (-r) flag is deprecated.')
-    }
 
     if (verbose && !wait) wait = true
 

--- a/src/commands/job/spec/execute.spec.ts
+++ b/src/commands/job/spec/execute.spec.ts
@@ -56,7 +56,7 @@ describe('executeJobViya', () => {
       },
       true,
       undefined,
-      false
+      undefined
     )
 
     await deleteFile(testFilePath)
@@ -94,7 +94,45 @@ describe('executeJobViya', () => {
       },
       true,
       undefined,
+      undefined
+    )
+
+    await deleteFile(testFilePath)
+  })
+
+  it('should set verbose to undefined when the flag is false', async () => {
+    await executeJobViya(
+      sasjs,
+      mockAuthConfig,
+      'test/job',
+      target,
+      false,
+      false,
+      testLogsPath,
+      testFilePath,
+      false,
+      undefined,
+      false,
       false
+    )
+
+    expect(sasjs.startComputeJob).toHaveBeenCalledWith(
+      'test/job',
+      null,
+      {
+        contextName: 'Mock Context'
+      },
+      mockAuthConfig,
+      true,
+      {
+        maxPollCount: 24 * 60 * 60,
+        pollInterval: 1000,
+        streamLog: false,
+        logFolderPath: testLogsPath
+      },
+      true,
+      undefined,
+      undefined
     )
 
     await deleteFile(testFilePath)

--- a/src/commands/job/spec/execute.spec.ts
+++ b/src/commands/job/spec/execute.spec.ts
@@ -100,7 +100,7 @@ describe('executeJobViya', () => {
     await deleteFile(testFilePath)
   })
 
-  it('should set verbose to undefined when the flag is false', async () => {
+  it('should pass verbose as undefined when the flag is false', async () => {
     await executeJobViya(
       sasjs,
       mockAuthConfig,
@@ -133,6 +133,46 @@ describe('executeJobViya', () => {
       true,
       undefined,
       undefined
+    )
+
+    await deleteFile(testFilePath)
+  })
+
+  it('should pass verbose as true when the flag is true', async () => {
+    const verbose = true
+
+    await executeJobViya(
+      sasjs,
+      mockAuthConfig,
+      'test/job',
+      target,
+      false,
+      false,
+      testLogsPath,
+      testFilePath,
+      false,
+      undefined,
+      false,
+      verbose
+    )
+
+    expect(sasjs.startComputeJob).toHaveBeenCalledWith(
+      'test/job',
+      null,
+      {
+        contextName: 'Mock Context'
+      },
+      mockAuthConfig,
+      true,
+      {
+        maxPollCount: 24 * 60 * 60,
+        pollInterval: 1000,
+        streamLog: false,
+        logFolderPath: testLogsPath
+      },
+      true,
+      undefined,
+      verbose
     )
 
     await deleteFile(testFilePath)

--- a/src/commands/job/spec/execute.spec.ts
+++ b/src/commands/job/spec/execute.spec.ts
@@ -15,7 +15,6 @@ const target = new Target({
   appLoc: '/test',
   contextName: 'Mock Context'
 })
-let statusFile: string
 
 describe('executeJobViya', () => {
   beforeEach(async () => {
@@ -36,9 +35,9 @@ describe('executeJobViya', () => {
       testLogsPath,
       testFilePath,
       false,
-      false,
       undefined,
-      true
+      true,
+      false
     )
 
     expect(sasjs.startComputeJob).toHaveBeenCalledWith(
@@ -56,7 +55,8 @@ describe('executeJobViya', () => {
         logFolderPath: testLogsPath
       },
       true,
-      undefined
+      undefined,
+      false
     )
 
     await deleteFile(testFilePath)
@@ -73,8 +73,8 @@ describe('executeJobViya', () => {
       testLogsPath,
       testFilePath,
       false,
-      false,
       undefined,
+      false,
       false
     )
 
@@ -93,7 +93,8 @@ describe('executeJobViya', () => {
         logFolderPath: testLogsPath
       },
       true,
-      undefined
+      undefined,
+      false
     )
 
     await deleteFile(testFilePath)

--- a/src/commands/job/spec/job.spec.server.viya.ts
+++ b/src/commands/job/spec/job.spec.server.viya.ts
@@ -340,8 +340,7 @@ describe('sasjs job execute with Viya', () => {
     await expect(
       executeWrapper({
         jobPath: 'jobs/testJob/job',
-        waitForJob: true,
-        returnStatusOnly: true
+        waitForJob: true
       })
     ).toResolve()
 
@@ -354,8 +353,7 @@ describe('sasjs job execute with Viya', () => {
     await expect(
       executeWrapper({
         jobPath: 'jobs/testJob/jobWithWarning',
-        waitForJob: true,
-        returnStatusOnly: true
+        waitForJob: true
       })
     ).toResolve()
 
@@ -369,7 +367,6 @@ describe('sasjs job execute with Viya', () => {
       executeWrapper({
         jobPath: 'jobs/testJob/jobWithWarning',
         waitForJob: true,
-        returnStatusOnly: true,
         ignoreWarnings: true
       })
     ).toResolve()
@@ -384,8 +381,7 @@ describe('sasjs job execute with Viya', () => {
       executeWrapper({
         jobPath: 'jobs/testJob/failingJob',
         waitForJob: true,
-        logFile: path.join(process.projectDir, 'failingJob.log'),
-        returnStatusOnly: true
+        logFile: path.join(process.projectDir, 'failingJob.log')
       })
     ).toResolve()
 
@@ -410,8 +406,7 @@ describe('sasjs job execute with Viya', () => {
     await expect(
       executeWrapper({
         jobPath: 'jobs/testJob/failingJob_DOES_NOT_EXIST',
-        waitForJob: true,
-        returnStatusOnly: true
+        waitForJob: true
       })
     ).toResolve()
 
@@ -462,7 +457,6 @@ interface executeWrapperParams {
   output?: string | boolean
   logFile?: string
   statusFile?: string
-  returnStatusOnly?: boolean
   ignoreWarnings?: boolean
   source?: string
   streamLog?: boolean
@@ -475,7 +469,6 @@ const executeWrapper = async ({
   output = false,
   logFile = undefined,
   statusFile = undefined,
-  returnStatusOnly = false,
   ignoreWarnings = false,
   source = undefined,
   streamLog = false
@@ -489,8 +482,8 @@ const executeWrapper = async ({
     output,
     logFile,
     statusFile,
-    returnStatusOnly,
     ignoreWarnings,
     source,
-    streamLog
+    streamLog,
+    false
   )

--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -288,11 +288,13 @@ describe('JobCommand', () => {
       jest
         .spyOn(SasjsUtilsFilesModule, 'createFile')
         .mockImplementation(() => Promise.resolve())
+
       const returnCode = await executeCommandWrapper([
         jobPath,
         '--output',
         'output.json'
       ])
+
       expect(returnCode).toEqual(ReturnCode.Success)
     })
   })

--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -86,14 +86,14 @@ describe('JobCommand', () => {
       )
     })
 
-    it('should pass wait as true if returnStatusOnly flag is present', async () => {
-      await executeCommandWrapper([jobPath, '--returnStatusOnly'])
+    it('should pass wait as true if verbose flag is present', async () => {
+      await executeCommandWrapper([jobPath, '--verbose'])
 
       expect(viyaExecuteModule.executeJobViya).toHaveBeenCalledWith(
         ...executeCalledWith({
           jobPath,
           waitForJob: true,
-          returnStatusOnly: true
+          verbose: true
         })
       )
     })
@@ -111,10 +111,10 @@ describe('JobCommand', () => {
         statusFile,
         '--source',
         source,
-        '--returnStatusOnly',
         '--ignoreWarnings',
         '--wait',
-        '--streamLog'
+        '--streamLog',
+        '--verbose'
       ])
 
       expect(viyaExecuteModule.executeJobViya).toHaveBeenCalledWith(
@@ -124,10 +124,10 @@ describe('JobCommand', () => {
           output,
           logFile: path.join(projectFolder, log),
           statusFile: path.join(projectFolder, statusFile),
-          returnStatusOnly: true,
           ignoreWarnings: true,
           source,
-          streamLog: true
+          streamLog: true,
+          verbose: true
         })
       )
     })
@@ -145,10 +145,10 @@ describe('JobCommand', () => {
         statusFile,
         '-s',
         source,
-        '-r',
         '-i',
         '-w',
-        '--streamLog'
+        '--streamLog',
+        '-v'
       ])
 
       expect(viyaExecuteModule.executeJobViya).toHaveBeenCalledWith(
@@ -158,10 +158,10 @@ describe('JobCommand', () => {
           output,
           logFile: path.join(projectFolder, log),
           statusFile: path.join(projectFolder, statusFile),
-          returnStatusOnly: true,
           ignoreWarnings: true,
           source,
-          streamLog: true
+          streamLog: true,
+          verbose: true
         })
       )
     })
@@ -359,10 +359,10 @@ interface executeWrapperParams {
   output?: string | boolean
   logFile?: string
   statusFile?: string
-  returnStatusOnly?: boolean
   ignoreWarnings?: boolean
   source?: string
   streamLog?: boolean
+  verbose?: boolean
 }
 
 const executeCalledWith = ({
@@ -371,10 +371,10 @@ const executeCalledWith = ({
   output = false,
   logFile = undefined,
   statusFile = undefined,
-  returnStatusOnly = false,
   ignoreWarnings = false,
   source = undefined,
-  streamLog = false
+  streamLog = false,
+  verbose = false
 }: executeWrapperParams) => [
   expect.anything(),
   authConfig,
@@ -384,10 +384,10 @@ const executeCalledWith = ({
   output,
   logFile,
   statusFile,
-  returnStatusOnly,
   ignoreWarnings,
   source,
-  streamLog
+  streamLog,
+  verbose
 ]
 
 const executeCommandWrapper = async (additionalParams: string[]) => {

--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -298,6 +298,16 @@ describe('JobCommand', () => {
       expect(returnCode).toEqual(ReturnCode.Success)
     })
   })
+
+  it('should log deprecation warning if returnStatusOnly flag is present', async () => {
+    jest.spyOn(process.logger, 'warn')
+
+    await executeCommandWrapper([jobPath, '--returnStatusOnly'])
+
+    expect(process.logger.warn).toHaveBeenCalledWith(
+      '--returnStatusOnly (-r) flag is deprecated.'
+    )
+  })
 })
 
 const setupMocksForViya = () => {

--- a/src/commands/run/run.ts
+++ b/src/commands/run/run.ts
@@ -216,7 +216,7 @@ async function createOutputFile(
     )
   }
 
-  await saveLog(log || '', logFilePath, '', false, silent)
+  await saveLog(log || '', logFilePath, '', silent)
 
   return logFilePath
 }

--- a/src/commands/run/spec/run.spec.ts
+++ b/src/commands/run/spec/run.spec.ts
@@ -43,7 +43,6 @@ describe('sasjs run', () => {
         logData,
         expect.stringMatching(/sasjs-run-\d{14}\.log$/),
         '',
-        false,
         undefined
       )
     })

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -953,8 +953,9 @@ export const getTestTearDown = async (target: Target) => {
 }
 
 /**
- * Returns configuration object of SAS Adapter and authentication configuration
- * @param {Target} target - the target to get auth configuration from.
+ * Provides instance of @sasjs/adapter.
+ * @param target - server server.
+ * @returns - instance of @sasjs/adapter.
  */
 export function getSASjs(target: Target) {
   return new SASjs({
@@ -964,8 +965,8 @@ export function getSASjs(target: Target) {
     contextName: target.contextName,
     httpsAgentOptions: target.httpsAgentOptions,
     debug: true,
-    useComputeApi: target.serverType === ServerType.SasViya,
-    verbose: !!process.env.VERBOSE
+    useComputeApi: target.serverType === ServerType.SasViya, // compute api is used only on Viya server
+    verbose: !!process.env.VERBOSE // any not empty string should be considered as true
   })
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -964,7 +964,8 @@ export function getSASjs(target: Target) {
     contextName: target.contextName,
     httpsAgentOptions: target.httpsAgentOptions,
     debug: true,
-    useComputeApi: target.serverType === ServerType.SasViya
+    useComputeApi: target.serverType === ServerType.SasViya,
+    verbose: !!process.env.VERBOSE
   })
 }
 

--- a/src/utils/saveLog.ts
+++ b/src/utils/saveLog.ts
@@ -3,18 +3,27 @@ import path from 'path'
 import { parseLogLines, displaySuccess } from '.'
 import { LogJson } from '../types'
 
+/**
+ * Saves log to the log file.
+ * @param logData - log content.
+ * @param logFile - file path to log file.
+ * @param jobPath - file path to job, job name will be used as a fallback name for log file.
+ * @param silent - boolean indicating if additional info should be logged.
+ */
 export const saveLog = async (
   logData: LogJson | string,
   logFile: string | undefined,
   jobPath: string,
   silent: boolean = false
 ) => {
+  // throw an error if log is an object containing error property
   if (typeof logData !== 'string') {
     const { error } = logData
 
     if (error) throw JSON.stringify(error, null, 2)
   }
 
+  // get absolute file path to log file
   const logPath =
     logFile ||
     path.join(
@@ -27,14 +36,17 @@ export const saveLog = async (
 
   const parentFolderPath = folderPath.join(path.sep)
 
+  // create parent folder of the log file if it doesn't exist
   if (!(await folderExists(parentFolderPath))) {
     await createFolder(parentFolderPath)
   }
 
+  // try to parse log
   const logLines =
     typeof logData === 'object' ? parseLogLines(logData) : logData
 
   if (!silent) process.logger?.info(`Creating log file at ${logPath} .`)
+
   await createFile(logPath, logLines)
 
   if (!silent) displaySuccess(`Log saved to ${logPath}`)

--- a/src/utils/saveLog.ts
+++ b/src/utils/saveLog.ts
@@ -7,7 +7,6 @@ export const saveLog = async (
   logData: LogJson | string,
   logFile: string | undefined,
   jobPath: string,
-  returnStatusOnly: boolean,
   silent: boolean = false
 ) => {
   if (typeof logData !== 'string') {
@@ -38,5 +37,5 @@ export const saveLog = async (
   if (!silent) process.logger?.info(`Creating log file at ${logPath} .`)
   await createFile(logPath, logLines)
 
-  if (!returnStatusOnly && !silent) displaySuccess(`Log saved to ${logPath}`)
+  if (!silent) displaySuccess(`Log saved to ${logPath}`)
 }


### PR DESCRIPTION
## Issue

Closes #1356

## Intent

- Deprecate `--returnStatusOnly` flag in `sasjs job execute` command.
- Implement `--verbose` flag in `sasjs job execute` command.
- Implement `verbose` mode that should be enabled iF `VERBOSE` entry is present in `.env` file.

## Implementation

- Changed `sasjs job` command.
- Adjusted unit tests.
- Changed `getSASjs` utility that should instantiate of `SASjs` class with `verbose` mode on/off.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] JSDoc comments have been added or updated.
- [x] Reviewer is assigned.
