### PR TITLE
fix(config): fixed verbose mode in getSASjs utility

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -958,6 +958,8 @@ export const getTestTearDown = async (target: Target) => {
  * @returns - instance of @sasjs/adapter.
  */
 export function getSASjs(target: Target) {
+  const verbose = process.env.VERBOSE
+
   return new SASjs({
     serverUrl: target.serverUrl,
     appLoc: target.appLoc,
@@ -966,7 +968,7 @@ export function getSASjs(target: Target) {
     httpsAgentOptions: target.httpsAgentOptions,
     debug: true,
     useComputeApi: target.serverType === ServerType.SasViya, // compute api is used only on Viya server
-    verbose: !!process.env.VERBOSE // any not empty string should be considered as true
+    verbose: typeof verbose === 'string' ? /on/i.test(verbose) : false // only string equal to 'on'(case insensitive) will enable verbose mode
   })
 }
 

--- a/src/utils/spec/config.spec.ts
+++ b/src/utils/spec/config.spec.ts
@@ -556,18 +556,36 @@ describe('getSASjs', () => {
     expect(useComputeApi).toEqual(false)
   })
 
-  it('should enable verbose mode if VERBOSE env is present', () => {
+  it(`should enable verbose mode if VERBOSE env is present and is equal to 'on'(case insensitive)`, () => {
     process.env.VERBOSE = 'on'
 
-    const sasjs = getSASjs({} as Target)
-    const sasjsConfig = sasjs.getSasjsConfig()
-    const { verbose } = sasjsConfig
+    let sasjs = getSASjs({} as Target)
+    let sasjsConfig = sasjs.getSasjsConfig()
+    let { verbose } = sasjsConfig
+
+    expect(verbose).toEqual(true)
+
+    process.env.VERBOSE = 'ON'
+
+    sasjs = getSASjs({} as Target)
+    sasjsConfig = sasjs.getSasjsConfig()
+    verbose = sasjsConfig.verbose
 
     expect(verbose).toEqual(true)
   })
 
   it('should disable verbose mode if VERBOSE env is not present', () => {
     process.env.VERBOSE = ''
+
+    const sasjs = getSASjs({} as Target)
+    const sasjsConfig = sasjs.getSasjsConfig()
+    const { verbose } = sasjsConfig
+
+    expect(verbose).toEqual(false)
+  })
+
+  it(`should disable verbose mode if VERBOSE env is present and is not equal to 'on'(case insensitive)`, () => {
+    process.env.VERBOSE = 'start'
 
     const sasjs = getSASjs({} as Target)
     const sasjsConfig = sasjs.getSasjsConfig()


### PR DESCRIPTION
## Intent

- Verbose mode should be enabled only by providing `on`(case insensitive) string to `VERBOSE` environment variable.

## Implementation

- Updated logic in `getSASjs` utility.
- Updated unit tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] All CI checks are green.
- [x] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and new threshold is set.
- [x] Reviewer is assigned.
