### PR TITLE
feat(verbose): enable verbose mode if LOG_LEVEL is trace

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,8 @@ What code changes have been made to achieve the intent.
 - [ ] Code is formatted correctly (`npm run lint:fix`).
 - [ ] Any new functionality has been unit tested.
 - [ ] All unit tests are passing (`npm test`).
+- [ ] Unit tests coverage has been increased and a new threshold is set.
 - [ ] All CI checks are green.
 - [ ] Development comments have been added or updated.
-- [ ] Development documentation coverage has been increased and new threshold is set.
+- [ ] Development documentation coverage has been increased and a new threshold is set.
 - [ ] Reviewer is assigned.

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: uesteibar/reviewer-lottery@v1
         with:
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,7 @@ module.exports = {
     global: {
       statements: 73.16,
       branches: 60.2,
-      functions: 73.46,
+      functions: 73.23,
       lines: 73.23
     }
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,7 +41,13 @@ module.exports = {
   // ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    global: {
+      branches: 60.95,
+      functions: 73.46,
+      lines: 74.28
+    }
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,7 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
+      statements: 73.16,
       branches: 60.2,
       functions: 73.46,
       lines: 73.23

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,9 +43,9 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 60.95,
+      branches: 60.2,
       functions: 73.46,
-      lines: 74.28
+      lines: 73.23
     }
   },
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -958,7 +958,18 @@ export const getTestTearDown = async (target: Target) => {
  * @returns - instance of @sasjs/adapter.
  */
 export function getSASjs(target: Target) {
-  const verbose = process.env.VERBOSE
+  const { VERBOSE, LOG_LEVEL } = process.env
+
+  let verbose = false
+
+  // verbose mode should be enabled if VERBOSE environment variable present and is equal to 'on'(case insensitive)
+  if (typeof VERBOSE === 'string' && /on/i.test(VERBOSE)) {
+    verbose = true
+  }
+  // verbose mode should be enabled if LOG_LEVEL environment variable present and is equal to 'trace'(case insensitive)
+  else if (typeof LOG_LEVEL === 'string' && /trace/i.test(LOG_LEVEL)) {
+    verbose = true
+  }
 
   return new SASjs({
     serverUrl: target.serverUrl,
@@ -968,7 +979,7 @@ export function getSASjs(target: Target) {
     httpsAgentOptions: target.httpsAgentOptions,
     debug: true,
     useComputeApi: target.serverType === ServerType.SasViya, // compute api is used only on Viya server
-    verbose: typeof verbose === 'string' ? /on/i.test(verbose) : false // only string equal to 'on'(case insensitive) will enable verbose mode
+    verbose
   })
 }
 

--- a/src/utils/spec/config.spec.ts
+++ b/src/utils/spec/config.spec.ts
@@ -574,8 +574,27 @@ describe('getSASjs', () => {
     expect(verbose).toEqual(true)
   })
 
-  it('should disable verbose mode if VERBOSE env is not present', () => {
+  it(`should enable verbose mode if LOG_LEVEL env is present and is equal to 'trace'(case insensitive)`, () => {
+    process.env.LOG_LEVEL = 'trace'
+
+    let sasjs = getSASjs({} as Target)
+    let sasjsConfig = sasjs.getSasjsConfig()
+    let { verbose } = sasjsConfig
+
+    expect(verbose).toEqual(true)
+
+    process.env.LOG_LEVEL = 'TRACE'
+
+    sasjs = getSASjs({} as Target)
+    sasjsConfig = sasjs.getSasjsConfig()
+    verbose = sasjsConfig.verbose
+
+    expect(verbose).toEqual(true)
+  })
+
+  it('should disable verbose mode if VERBOSE and LOG_LEVEL env are not present', () => {
     process.env.VERBOSE = ''
+    process.env.LOG_LEVEL = ''
 
     const sasjs = getSASjs({} as Target)
     const sasjsConfig = sasjs.getSasjsConfig()
@@ -584,8 +603,9 @@ describe('getSASjs', () => {
     expect(verbose).toEqual(false)
   })
 
-  it(`should disable verbose mode if VERBOSE env is present and is not equal to 'on'(case insensitive)`, () => {
+  it(`should disable verbose mode if VERBOSE env is present and is not equal to 'on'(case insensitive) and LOG_LEVEL env is present and is not equal to 'trace'(case insensitive)`, () => {
     process.env.VERBOSE = 'start'
+    process.env.LOG_LEVEL = 'Info'
 
     const sasjs = getSASjs({} as Target)
     const sasjsConfig = sasjs.getSasjsConfig()


### PR DESCRIPTION
## Intent

- Verbose mode should be enabled if `LOG_LEVEL` environment variable is set to `Trace`(case insensitive).

## Implementation

- Updated logic in `getSASjs` utility.
- Adjusted unit tests covering `getSASjs` utility.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [x] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and new threshold is set.
- [x] Reviewer is assigned.
