### PR TITLE
Issue 1367

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,10 +43,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      statements: 73.44,
-      branches: 60.45,
+      statements: 73.51,
+      branches: 60.6,
       functions: 73.56,
-      lines: 74.09
+      lines: 74.17
     }
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.8.0",
+        "@sasjs/adapter": "4.9.0",
         "@sasjs/core": "4.46.3",
         "@sasjs/lint": "2.3.1",
         "@sasjs/utils": "3.4.0",
@@ -3234,9 +3234,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.8.0.tgz",
-      "integrity": "sha512-1eGQfhZcp2pTbCZKbCEABC3+Kz8B4PRWqJZG9XAhh9QkFAR+ENRKAkbk5Sf+xa9YS+ycz7SvusmYYInGZ9b54w==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.0.tgz",
+      "integrity": "sha512-YgzWWiCiCczwVfcO6aPdFmwO/8rqyyReVoIBiG3IvGGo3ESYNFvZqcJMDhe0MjeIHMKBj7mu+kPWDTnWxF0U5w==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -13468,9 +13468,9 @@
       "optional": true
     },
     "@sasjs/adapter": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.8.0.tgz",
-      "integrity": "sha512-1eGQfhZcp2pTbCZKbCEABC3+Kz8B4PRWqJZG9XAhh9QkFAR+ENRKAkbk5Sf+xa9YS+ycz7SvusmYYInGZ9b54w==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.0.tgz",
+      "integrity": "sha512-YgzWWiCiCczwVfcO6aPdFmwO/8rqyyReVoIBiG3IvGGo3ESYNFvZqcJMDhe0MjeIHMKBj7mu+kPWDTnWxF0U5w==",
       "requires": {
         "@sasjs/utils": "2.52.0",
         "axios": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "preinstall": "npm run nodeVersionMessage",
     "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true",
-    "doc": "npx compodoc -p tsconfig.doc.json --coverageTest 15 --coverageTestThresholdFail"
+    "doc": "npx compodoc -p tsconfig.doc.json --coverageTest 16 --coverageTestThresholdFail"
   },
   "testServerTypes": "sasjs",
   "release": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "4.8.0",
+    "@sasjs/adapter": "4.9.0",
     "@sasjs/core": "4.46.3",
     "@sasjs/lint": "2.3.1",
     "@sasjs/utils": "3.4.0",

--- a/src/commands/flow/execute.ts
+++ b/src/commands/flow/execute.ts
@@ -38,9 +38,12 @@ export async function execute(
           deadlockChain!.join(' -> ')
       )
 
+    // job state poll options
+    // maxPollCount and pollInterval are set to 0 to use default polling options
+    // configured in @sasjs/adapter/src/api/viya/pollJobState.ts
     const pollOptions: PollOptions = {
-      maxPollCount: 24 * 60 * 60,
-      pollInterval: 1000,
+      maxPollCount: 0,
+      pollInterval: 0,
       streamLog,
       logFolderPath: logFolderRealPath
     }

--- a/src/commands/flow/internal/spec/executeFlow.spec.ts
+++ b/src/commands/flow/internal/spec/executeFlow.spec.ts
@@ -7,8 +7,8 @@ import * as normalizeFilePath from '../normalizeFilePath'
 import csvColumns from '../csvColumns'
 
 const pollOptions: PollOptions = {
-  maxPollCount: 24 * 60 * 60,
-  pollInterval: 1000,
+  maxPollCount: 0,
+  pollInterval: 0,
   streamLog: false,
   logFolderPath: 'fake/log/folder/path'
 }

--- a/src/commands/help/help.ts
+++ b/src/commands/help/help.ts
@@ -296,7 +296,7 @@ export async function printHelpText() {
         `[2spaces]NOTE: Providing output flag (--output or -o) is optional. If present, CLI will immediately print out the response JSON. If value is provided, it will be treated as file path to save the response JSON.`,
         `[2spaces]NOTE: Providing log flag (--log or -l) is optional. If present, CLI will fetch and save job log to local file.`,
         `[2spaces]NOTE: Providing ignore warnings (--ignoreWarnings or -i) flag is optional. If present, CLI will return status '0', when the job state is warning.`,
-        `[2spaces]NOTE: Providing verbose (--verbose or -v) flag is optional. If present, CLI will log summary of every HTTP response.`
+        `[2spaces]NOTE: Providing verbose (--verbose or -v) flag is optional. If present, CLI will log summary of every HTTP response. If set to 'bleached', , CLI will log summary of every HTTP response without extra colors.`
       ]
     },
     {

--- a/src/commands/help/help.ts
+++ b/src/commands/help/help.ts
@@ -296,7 +296,7 @@ export async function printHelpText() {
         `[2spaces]NOTE: Providing output flag (--output or -o) is optional. If present, CLI will immediately print out the response JSON. If value is provided, it will be treated as file path to save the response JSON.`,
         `[2spaces]NOTE: Providing log flag (--log or -l) is optional. If present, CLI will fetch and save job log to local file.`,
         `[2spaces]NOTE: Providing ignore warnings (--ignoreWarnings or -i) flag is optional. If present, CLI will return status '0', when the job state is warning.`,
-        `[2spaces]NOTE: Providing verbose (--verbose or -v) flag is optional. If present, CLI will log summary of every HTTP response. If set to 'bleached', , CLI will log summary of every HTTP response without extra colors.`
+        `[2spaces]NOTE: Providing verbose (--verbose or -v) flag is optional. If present, CLI will log summary of every HTTP response. If set to 'bleached', CLI will log summary of every HTTP response without extra colors.`
       ]
     },
     {

--- a/src/commands/job/internal/execute/sasjs.ts
+++ b/src/commands/job/internal/execute/sasjs.ts
@@ -1,10 +1,10 @@
-import { SASjsApiClient, SasjsRequestClient } from '@sasjs/adapter/node'
-import { Target } from '@sasjs/utils'
-import { getAuthConfig, isSasJsServerInServerMode } from '../../../../utils'
+import { AuthConfig, Target } from '@sasjs/utils'
 import { saveLog, saveOutput } from '../utils'
+import SASjs from '@sasjs/adapter/node'
 
 /**
  * Triggers existing job for execution on SASJS server.
+ * @param {object} sasjs - configuration object of SAS adapter.
  * @param target - SASJS server configuration.
  * @param jobPath - location of the job.
  * @param logFile - flag indicating if CLI should fetch and save log to provided file path. If filepath wasn't provided, {job}.log file will be created in current folder.
@@ -12,21 +12,14 @@ import { saveLog, saveOutput } from '../utils'
  * @returns - promise that resolves into an object with log and output.
  */
 export async function executeJobSasjs(
+  sasjs: SASjs,
   target: Target,
   jobPath: string,
   logFile?: string,
-  output?: string
+  output?: string,
+  authConfig?: AuthConfig
 ) {
-  // get authentication configuration if SASJS server is in server mode.
-  const authConfig = (await isSasJsServerInServerMode(target))
-    ? await getAuthConfig(target)
-    : undefined
-
-  const sasjsApiClient = new SASjsApiClient(
-    new SasjsRequestClient(target.serverUrl, target.httpsAgentOptions)
-  )
-
-  const response = await sasjsApiClient.executeJob(
+  const response = await sasjs.executeJob(
     {
       _program: jobPath
     },

--- a/src/commands/job/internal/execute/viya.ts
+++ b/src/commands/job/internal/execute/viya.ts
@@ -35,7 +35,6 @@ import { saveLog } from '../utils'
  * @param {boolean} ignoreWarnings - flag indicating if CLI should return status '0', when the job state is warning.
  * @param {string | undefined} source - an optional path to a JSON file containing macro variables.
  * @param {boolean} streamLog - a flag indicating if the logs should be streamed to the supplied log path during job execution. This is useful for getting feedback on long running jobs.
- * @param {boolean} verbose - enables verbose mode that logs summary of every HTTP response.
  */
 export async function executeJobViya(
   sasjs: SASjs,
@@ -48,13 +47,14 @@ export async function executeJobViya(
   statusFile: string | undefined,
   ignoreWarnings: boolean,
   source: string | undefined,
-  streamLog: boolean,
-  verbose: boolean
+  streamLog: boolean
 ) {
-  // job status poll options
+  // job state poll options
+  // maxPollCount and pollInterval are set to 0 to use default polling options
+  // configured in @sasjs/adapter/src/api/viya/pollJobState.ts
   const pollOptions: PollOptions = {
-    maxPollCount: 24 * 60 * 60,
-    pollInterval: 1000,
+    maxPollCount: 0,
+    pollInterval: 0,
     streamLog,
     logFolderPath: logFile
   }
@@ -108,8 +108,7 @@ export async function executeJobViya(
       waitForJob || !!logFile,
       pollOptions,
       true,
-      macroVars?.macroVars,
-      verbose || undefined
+      macroVars?.macroVars
     )
     .catch(async (err) => {
       // handle error

--- a/src/commands/job/spec/execute.spec.ts
+++ b/src/commands/job/spec/execute.spec.ts
@@ -2,7 +2,7 @@ import SASjs, { SASjsApiClient } from '@sasjs/adapter/node'
 import { deleteFile } from '@sasjs/utils'
 import { ServerType, Target } from '@sasjs/utils/types'
 import path from 'path'
-import { setConstants } from '../../../utils'
+import { setConstants, getSASjsAndAuthConfig } from '../../../utils'
 import * as utilsModule from '../../../utils/utils'
 import { executeJobViya, executeJobSasjs } from '../internal/execute'
 import { mockAuthConfig } from './mocks'
@@ -36,8 +36,7 @@ describe('executeJobViya', () => {
       testFilePath,
       false,
       undefined,
-      true,
-      false
+      true
     )
 
     expect(sasjs.startComputeJob).toHaveBeenCalledWith(
@@ -49,13 +48,12 @@ describe('executeJobViya', () => {
       mockAuthConfig,
       true,
       {
-        maxPollCount: 24 * 60 * 60,
-        pollInterval: 1000,
+        maxPollCount: 0,
+        pollInterval: 0,
         streamLog: true,
         logFolderPath: testLogsPath
       },
       true,
-      undefined,
       undefined
     )
 
@@ -74,7 +72,6 @@ describe('executeJobViya', () => {
       testFilePath,
       false,
       undefined,
-      false,
       false
     )
 
@@ -87,92 +84,13 @@ describe('executeJobViya', () => {
       mockAuthConfig,
       true,
       {
-        maxPollCount: 24 * 60 * 60,
-        pollInterval: 1000,
+        maxPollCount: 0,
+        pollInterval: 0,
         streamLog: false,
         logFolderPath: testLogsPath
       },
       true,
-      undefined,
       undefined
-    )
-
-    await deleteFile(testFilePath)
-  })
-
-  it('should pass verbose as undefined when the flag is false', async () => {
-    await executeJobViya(
-      sasjs,
-      mockAuthConfig,
-      'test/job',
-      target,
-      false,
-      false,
-      testLogsPath,
-      testFilePath,
-      false,
-      undefined,
-      false,
-      false
-    )
-
-    expect(sasjs.startComputeJob).toHaveBeenCalledWith(
-      'test/job',
-      null,
-      {
-        contextName: 'Mock Context'
-      },
-      mockAuthConfig,
-      true,
-      {
-        maxPollCount: 24 * 60 * 60,
-        pollInterval: 1000,
-        streamLog: false,
-        logFolderPath: testLogsPath
-      },
-      true,
-      undefined,
-      undefined
-    )
-
-    await deleteFile(testFilePath)
-  })
-
-  it('should pass verbose as true when the flag is true', async () => {
-    const verbose = true
-
-    await executeJobViya(
-      sasjs,
-      mockAuthConfig,
-      'test/job',
-      target,
-      false,
-      false,
-      testLogsPath,
-      testFilePath,
-      false,
-      undefined,
-      false,
-      verbose
-    )
-
-    expect(sasjs.startComputeJob).toHaveBeenCalledWith(
-      'test/job',
-      null,
-      {
-        contextName: 'Mock Context'
-      },
-      mockAuthConfig,
-      true,
-      {
-        maxPollCount: 24 * 60 * 60,
-        pollInterval: 1000,
-        streamLog: false,
-        logFolderPath: testLogsPath
-      },
-      true,
-      undefined,
-      verbose
     )
 
     await deleteFile(testFilePath)
@@ -185,10 +103,15 @@ describe('executeJobSasjs', () => {
   })
 
   it('should pass job pass as a _program parameter', async () => {
+    const { sasjs, authConfig } = await getSASjsAndAuthConfig(target)
+
     await executeJobSasjs(
+      sasjs,
       target,
       'test/job',
-      path.join(process.projectDir, 'logs')
+      path.join(process.projectDir, 'logs'),
+      undefined,
+      authConfig
     )
 
     expect(executeJobMock).toHaveBeenCalledWith(

--- a/src/commands/job/spec/job.spec.server.viya.ts
+++ b/src/commands/job/spec/job.spec.server.viya.ts
@@ -484,6 +484,5 @@ const executeWrapper = async ({
     statusFile,
     ignoreWarnings,
     source,
-    streamLog,
-    false
+    streamLog
   )

--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -92,8 +92,7 @@ describe('JobCommand', () => {
       expect(viyaExecuteModule.executeJobViya).toHaveBeenCalledWith(
         ...executeCalledWith({
           jobPath,
-          waitForJob: true,
-          verbose: true
+          waitForJob: true
         })
       )
     })
@@ -192,6 +191,69 @@ describe('JobCommand', () => {
 
       expect(returnCode).toEqual(ReturnCode.InternalError)
       expect(process.logger.error).toHaveBeenCalled()
+    })
+
+    it('should set verbose to true if verbose flag present', async () => {
+      let sasjs = new SASjs()
+
+      jest
+        .spyOn(configUtils, 'getSASjsAndAuthConfig')
+        .mockImplementation((target: Target) => {
+          sasjs = configUtils.getSASjs(target)
+
+          jest.spyOn(sasjs, 'setVerboseMode')
+
+          return Promise.resolve({
+            sasjs: sasjs,
+            authConfig: authConfig as AuthConfig
+          })
+        })
+
+      await executeCommandWrapper([jobPath, '--verbose'])
+
+      expect(sasjs.setVerboseMode).toHaveBeenCalledWith(true)
+    })
+
+    it('should set verbose to bleached if verbose flag present and is equal to bleached', async () => {
+      let sasjs = new SASjs()
+
+      jest
+        .spyOn(configUtils, 'getSASjsAndAuthConfig')
+        .mockImplementation((target: Target) => {
+          sasjs = configUtils.getSASjs(target)
+
+          jest.spyOn(sasjs, 'setVerboseMode')
+
+          return Promise.resolve({
+            sasjs: sasjs,
+            authConfig: authConfig as AuthConfig
+          })
+        })
+
+      await executeCommandWrapper([jobPath, '-v', 'bleached'])
+
+      expect(sasjs.setVerboseMode).toHaveBeenCalledWith('bleached')
+    })
+
+    it('should set verbose to false if verbose flag is not present', async () => {
+      let sasjs = new SASjs()
+
+      jest
+        .spyOn(configUtils, 'getSASjsAndAuthConfig')
+        .mockImplementation((target: Target) => {
+          sasjs = configUtils.getSASjs(target)
+
+          jest.spyOn(sasjs, 'setVerboseMode')
+
+          return Promise.resolve({
+            sasjs: sasjs,
+            authConfig: authConfig as AuthConfig
+          })
+        })
+
+      await executeCommandWrapper([jobPath])
+
+      expect(sasjs.setVerboseMode).toHaveBeenCalledWith(false)
     })
   })
 
@@ -385,8 +447,7 @@ const executeCalledWith = ({
   statusFile = undefined,
   ignoreWarnings = false,
   source = undefined,
-  streamLog = false,
-  verbose = false
+  streamLog = false
 }: executeWrapperParams) => [
   expect.anything(),
   authConfig,
@@ -398,8 +459,7 @@ const executeCalledWith = ({
   statusFile,
   ignoreWarnings,
   source,
-  streamLog,
-  verbose
+  streamLog
 ]
 
 const executeCommandWrapper = async (additionalParams: string[]) => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,4 +1,4 @@
-import SASjs from '@sasjs/adapter/node'
+import SASjs, { VerboseMode } from '@sasjs/adapter/node'
 import {
   Configuration,
   Target,
@@ -960,13 +960,21 @@ export const getTestTearDown = async (target: Target) => {
 export function getSASjs(target: Target) {
   const { VERBOSE, LOG_LEVEL } = process.env
 
-  let verbose = false
+  let verbose: VerboseMode = false
 
-  // verbose mode should be enabled if VERBOSE environment variable present and is equal to 'on'(case insensitive)
+  // verbose mode should be enabled if VERBOSE environment variable present and
+  // is equal to 'on'(case insensitive)
   if (typeof VERBOSE === 'string' && /on/i.test(VERBOSE)) {
     verbose = true
   }
-  // verbose mode should be enabled if LOG_LEVEL environment variable present and is equal to 'trace'(case insensitive)
+  // verbose mode should be enabled in 'bleached' mode(without extra colors)
+  // if VERBOSE environment variable present and is equal to
+  // 'bleached'(case insensitive)
+  if (typeof VERBOSE === 'string' && /bleached/i.test(VERBOSE)) {
+    verbose = 'bleached'
+  }
+  // verbose mode should be enabled if LOG_LEVEL environment variable present
+  // and is equal to 'trace'(case insensitive)
   else if (typeof LOG_LEVEL === 'string' && /trace/i.test(LOG_LEVEL)) {
     verbose = true
   }


### PR DESCRIPTION
## Issue

Closes #1367 

## Intent

- Implement `bleached` verbose mode (without extra colors) that can be enabled through environment variable `VERBOSE=BLEACHED` or through `sasjs job execute --verbose bleached` command.
- Fix hardcoded job state polling options for `sasjs job execute` and `sasjs flow execute` commands.
- Refactor logic related to `sasjs job execute` command.

## Implementation

- Bumped `@sasjs/adapter`.
- Fixed job state polling options in `src/commands/flow/execute.ts` to use default polling strategies configured in `@sasjs/adapter` after the first poll.
- Updated `help` command.
- Used instance of `@sasjs/adapter` instead of `SASjsApiClient` in `src/commands/job/internal/execute/sasjs.ts`.
- Fixed job state polling options in `src/commands/job/internal/execute/viya.ts` to use default polling strategies configured in `@sasjs/adapter` after the first poll.
- Refactored `src/commands/job/jobCommand.ts` to reduce diversity between different server types.
- Adjusted unit tests.
- Improved logic in `getSASjs` utility to support bleached verbose mode.
- Refactored `getSASjsAndAuthConfig` utility.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] Unit tests coverage has been increased and a new threshold is set.
- [x] All CI checks are green.
- [x] Development comments have been added or updated.
- [x] Development documentation coverage has been increased and a new threshold is set.
- [x] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
