### PR TITLE
fix(verbose-mode): used fixed @sasjs/adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.9.0",
+        "@sasjs/adapter": "4.9.1",
         "@sasjs/core": "4.46.3",
         "@sasjs/lint": "2.3.1",
         "@sasjs/utils": "3.4.0",
@@ -3234,9 +3234,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.0.tgz",
-      "integrity": "sha512-YgzWWiCiCczwVfcO6aPdFmwO/8rqyyReVoIBiG3IvGGo3ESYNFvZqcJMDhe0MjeIHMKBj7mu+kPWDTnWxF0U5w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.1.tgz",
+      "integrity": "sha512-D6U5+vfSmLqJfZZg93llSsSBZZqFnA0AweEGgcfhYQP304gibf0g6JYHU4IsosGetDfJegjiogtlgmjtb3Gfxg==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -13468,9 +13468,9 @@
       "optional": true
     },
     "@sasjs/adapter": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.0.tgz",
-      "integrity": "sha512-YgzWWiCiCczwVfcO6aPdFmwO/8rqyyReVoIBiG3IvGGo3ESYNFvZqcJMDhe0MjeIHMKBj7mu+kPWDTnWxF0U5w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.1.tgz",
+      "integrity": "sha512-D6U5+vfSmLqJfZZg93llSsSBZZqFnA0AweEGgcfhYQP304gibf0g6JYHU4IsosGetDfJegjiogtlgmjtb3Gfxg==",
       "requires": {
         "@sasjs/utils": "2.52.0",
         "axios": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "4.9.0",
+    "@sasjs/adapter": "4.9.1",
     "@sasjs/core": "4.46.3",
     "@sasjs/lint": "2.3.1",
     "@sasjs/utils": "3.4.0",

--- a/src/commands/add/addTarget.ts
+++ b/src/commands/add/addTarget.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { Target, ServerType } from '@sasjs/utils/types'
 import { TargetScope } from '../../types/targetScope'
 import {


### PR DESCRIPTION
## Issue

`@sasjs/adapter` couldn't properly parse HTTP responses with statuses `4**` in verbose mode.

## Intent

- Use `@sasjs/adapter` with improved verbose mode.

## Implementation

- Bumped `@sasjs/adapter`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] Unit tests coverage has been increased and a new threshold is set.
- [x] All CI checks are green.
- [ ] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [x] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
