### PR TITLE
feat(snippets): remove [in] and [out] from @params

### DIFF
--- a/src/commands/snippets/snippets.ts
+++ b/src/commands/snippets/snippets.ts
@@ -16,11 +16,11 @@ interface Snippet {
 
 // to check if file has .sas extension
 const sasRegExp = /\.sas$/
-// to get lines that has @brief keyword
-const briefRegExp = /^\s\s@brief\s/
-// to get lines that has @param keyword and optionally [in] or [out] string
-// following it
-const paramRegExp = /^\s\s@param\s(\[(in|out)\]\s)?/
+// to get lines that have @brief keyword (case insensitive)
+const briefRegExp = /^\s\s@brief\s/i
+// to get lines that have @param keyword and optionally [in] or [out] string
+// following it (case insensitive)
+const paramRegExp = /^\s\s@param\s(\[(in|out)\]\s)?/i
 
 /**
  * Generates VS Code snippets from the Doxygen headers in the SAS Macros.

--- a/src/commands/snippets/snippets.ts
+++ b/src/commands/snippets/snippets.ts
@@ -14,9 +14,13 @@ interface Snippet {
   description: string[]
 }
 
-const sasRegExp = /\.sas$/ // to check if file has .sas extension
-const briefRegExp = /^\s\s@brief\s/ // to get lines that has @brief keyword
-const paramRegExp = /^\s\s@param\s/ // to get lines that has @param keyword
+// to check if file has .sas extension
+const sasRegExp = /\.sas$/
+// to get lines that has @brief keyword
+const briefRegExp = /^\s\s@brief\s/
+// to get lines that has @param keyword and optionally [in] or [out] string
+// following it
+const paramRegExp = /^\s\s@param\s(\[(in|out)\]\s)?/
 
 /**
  * Generates VS Code snippets from the Doxygen headers in the SAS Macros.

--- a/src/commands/snippets/spec/snippets.spec.ts
+++ b/src/commands/snippets/spec/snippets.spec.ts
@@ -76,7 +76,9 @@ describe('sasjs snippets', () => {
           'Macro 2',
           '\r',
           'Params:',
-          '-msg The message to be printed'
+          '-msg The message to be printed',
+          '-indlm= ( ) Delimeter of the input string',
+          '-outdlm= ( ) Delimiter of the output string'
         ]
       },
       badMacro: {

--- a/src/commands/snippets/spec/testMacros2/macro2.sas
+++ b/src/commands/snippets/spec/testMacros2/macro2.sas
@@ -4,6 +4,8 @@
   @details prints an arbitrary message to the log
 
   @param msg The message to be printed
+  @param [in] indlm= ( ) Delimeter of the input string
+  @param [out] outdlm= ( ) Delimiter of the output string
   @author Allan Bowe
 
 **/

--- a/src/commands/snippets/spec/testMacros2/macro2.sas
+++ b/src/commands/snippets/spec/testMacros2/macro2.sas
@@ -1,11 +1,11 @@
 /**
   @file
-  @brief Macro 2
+  @BRIEF Macro 2
   @details prints an arbitrary message to the log
 
   @param msg The message to be printed
-  @param [in] indlm= ( ) Delimeter of the input string
-  @param [out] outdlm= ( ) Delimiter of the output string
+  @PARAM [in] indlm= ( ) Delimeter of the input string
+  @param [OUT] outdlm= ( ) Delimiter of the output string
   @author Allan Bowe
 
 **/


### PR DESCRIPTION
## Issue

`[in]` and `[out]` `@param` entries don't bring value, but just use limited space in VS Code snippet description.

## Intent

- Remove `[in]` and `[out]` `@param` entries from snippet description.

## Implementation

- Improved param regular expression in `src/commands/snippets/snippets.ts`.
- Adjusted unit test covering VS Code snippet generation.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [ ] Unit tests coverage has been increased and a new threshold is set.
- [ ] All CI checks are green.
- [x] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [x] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
