### PR TITLE
feat(snippets): improved @param reg exp

### DIFF
--- a/src/commands/snippets/snippets.ts
+++ b/src/commands/snippets/snippets.ts
@@ -18,9 +18,9 @@ interface Snippet {
 const sasRegExp = /\.sas$/
 // to get lines that have @brief keyword (case insensitive)
 const briefRegExp = /^\s\s@brief\s/i
-// to get lines that have @param keyword and optionally [in] or [out] string
+// to get lines that have @param keyword and optionally [anything] string
 // following it (case insensitive)
-const paramRegExp = /^\s\s@param\s(\[(in|out)\]\s)?/i
+const paramRegExp = /^\s\s@param\s?(\[.*?]\s?)?/i
 
 /**
  * Generates VS Code snippets from the Doxygen headers in the SAS Macros.

--- a/src/commands/snippets/spec/snippets.spec.ts
+++ b/src/commands/snippets/spec/snippets.spec.ts
@@ -73,12 +73,17 @@ describe('sasjs snippets', () => {
         prefix: '%macro2',
         body: '%macro2($1)',
         description: [
-          'Macro 2',
+          'Macro 2 with uppercase @BRIEF',
           '\r',
           'Params:',
           '-msg The message to be printed',
-          '-indlm= ( ) Delimeter of the input string',
-          '-outdlm= ( ) Delimiter of the output string'
+          '-indlm= ( ) Uppercase @PARAM',
+          '-outdlm= ( ) Uppercase [OUT]',
+          '-outdlm= ( ) No space after @param',
+          '-outdlm= ( ) No space after [out]',
+          '-outdlm= ( ) No space after @param and [out]',
+          '-scopeds= () with [in,out]',
+          '-anything= () with [anything]'
         ]
       },
       badMacro: {

--- a/src/commands/snippets/spec/testMacros2/macro2.sas
+++ b/src/commands/snippets/spec/testMacros2/macro2.sas
@@ -1,11 +1,16 @@
 /**
   @file
-  @BRIEF Macro 2
+  @BRIEF Macro 2 with uppercase @BRIEF
   @details prints an arbitrary message to the log
 
   @param msg The message to be printed
-  @PARAM [in] indlm= ( ) Delimeter of the input string
-  @param [OUT] outdlm= ( ) Delimiter of the output string
+  @PARAM [in] indlm= ( ) Uppercase @PARAM
+  @param [OUT] outdlm= ( ) Uppercase [OUT]
+  @param[out] outdlm= ( ) No space after @param
+  @param [out]outdlm= ( ) No space after [out]
+  @param [out]outdlm= ( ) No space after @param and [out]
+  @param [in,out] scopeds= () with [in,out]
+  @param [anything] anything= () with [anything]
   @author Allan Bowe
 
 **/


### PR DESCRIPTION
## Issue

`[ianything]` `@param` entries don't bring value, but just use limited space in VS Code snippet description.

## Intent

- Remove `[anything]` `@param` entries from snippet description.

## Implementation

- Improved param regular expression in `src/commands/snippets/snippets.ts`.
- Adjusted unit test covering VS Code snippet generation.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] Unit tests coverage has been increased and a new threshold is set.
- [ ] All CI checks are green.
- [x] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [x] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
