### PR TITLE
@sasjs/adapter bump

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -44,7 +44,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 73.51,
-      branches: 60.6,
+      branches: 60.57,
       functions: 73.56,
       lines: 74.17
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.9.2",
+        "@sasjs/adapter": "4.10.0",
         "@sasjs/core": "4.46.3",
         "@sasjs/lint": "2.3.1",
         "@sasjs/utils": "3.4.0",
@@ -3234,9 +3234,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.2.tgz",
-      "integrity": "sha512-WAWhJAbhsOwChbRB6N+dcgj9Tods2Hq/ygsCASALbjKvqxtYlUDVBoEhdedur0VdsWyUaTAqcwioCiCpWtcRZA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.10.0.tgz",
+      "integrity": "sha512-yZNJsknhq1iDzPxme296D8ZNzy3CV5dOtrgd+7n/v6lRVz+BdYK9HnPxgrPHyqt3tZ6qkXouzOx1Gg8CxMATFw==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -13479,9 +13479,9 @@
       "optional": true
     },
     "@sasjs/adapter": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.9.2.tgz",
-      "integrity": "sha512-WAWhJAbhsOwChbRB6N+dcgj9Tods2Hq/ygsCASALbjKvqxtYlUDVBoEhdedur0VdsWyUaTAqcwioCiCpWtcRZA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.10.0.tgz",
+      "integrity": "sha512-yZNJsknhq1iDzPxme296D8ZNzy3CV5dOtrgd+7n/v6lRVz+BdYK9HnPxgrPHyqt3tZ6qkXouzOx1Gg8CxMATFw==",
       "requires": {
         "@sasjs/utils": "2.52.0",
         "axios": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "4.9.2",
+    "@sasjs/adapter": "4.10.0",
     "@sasjs/core": "4.46.3",
     "@sasjs/lint": "2.3.1",
     "@sasjs/utils": "3.4.0",

--- a/src/commands/job/internal/execute/viya.ts
+++ b/src/commands/job/internal/execute/viya.ts
@@ -143,7 +143,7 @@ export async function executeJobViya(
 
       // get additional information about error if it is present
       result =
-        typeof err === 'object' && Object.keys(err).length
+        typeof err === 'object' && err.job && err.job?.state
           ? JSON.stringify({ state: err.job?.state })
           : `${err}`
 

--- a/src/commands/testing/spec/testing.spec.ts
+++ b/src/commands/testing/spec/testing.spec.ts
@@ -22,6 +22,7 @@ import * as sasJsModules from '../../../utils/createSASjsInstance'
 import { testResponses } from './mockedAdapter/testResponses'
 import * as fileModule from '@sasjs/utils/file'
 import * as utilsModule from '@sasjs/utils/utils'
+import * as readAndValidateInputModule from '@sasjs/utils/input/readAndValidateInput'
 import * as configUtils from '../../../utils/config'
 import chalk from 'chalk'
 import { mockAuthConfig } from '../../context/spec/mocks'
@@ -962,4 +963,7 @@ const setupMocksForSASJS = () => {
         }
       } as unknown as SASjs
     })
+  jest
+    .spyOn(readAndValidateInputModule, 'getString')
+    .mockImplementation(() => Promise.resolve('mocked input'))
 }


### PR DESCRIPTION
## Issue

- Sometimes SAS API returns the job state `running` when the parent session is not in a `running` state.
- `sasjs job execute` wasn't handling all kind of errors.

## Intent

- Bump `@sasjs/adapter` that periodically checks parent session state while polling job status.
- Improve error handling in `sasjs job execute` command.
- Fix unit tests that were tacking to much time to complete.

## Implementation

- Bumped `@sasjs/adapter`.
- Fixed error handling in `src/commands/job/internal/execute/viya.ts`.
- Mocked `getString` utility to improve unit tests in `src/commands/testing/spec/testing.spec.ts`.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] Unit tests coverage has been increased and a new threshold is set.
- [x] All CI checks are green.
- [ ] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [x] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
