### PR TITLE
Job command improvements

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -46,7 +46,7 @@ module.exports = {
       statements: 73.51,
       branches: 60.57,
       functions: 73.56,
-      lines: 74.17
+      lines: 74.12
     }
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.10.0",
+        "@sasjs/adapter": "4.10.1",
         "@sasjs/core": "4.46.3",
         "@sasjs/lint": "2.3.1",
         "@sasjs/utils": "3.4.0",
@@ -3234,9 +3234,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.10.0.tgz",
-      "integrity": "sha512-yZNJsknhq1iDzPxme296D8ZNzy3CV5dOtrgd+7n/v6lRVz+BdYK9HnPxgrPHyqt3tZ6qkXouzOx1Gg8CxMATFw==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.10.1.tgz",
+      "integrity": "sha512-/z6eR+3nNaLPyycK8YmpF+GAWNy0zgdl8n4cv4r45hjVBulPHVop7oj57JM/0uIPVOTT2V9IwrMCT/sFPq++vw==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -13479,9 +13479,9 @@
       "optional": true
     },
     "@sasjs/adapter": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.10.0.tgz",
-      "integrity": "sha512-yZNJsknhq1iDzPxme296D8ZNzy3CV5dOtrgd+7n/v6lRVz+BdYK9HnPxgrPHyqt3tZ6qkXouzOx1Gg8CxMATFw==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.10.1.tgz",
+      "integrity": "sha512-/z6eR+3nNaLPyycK8YmpF+GAWNy0zgdl8n4cv4r45hjVBulPHVop7oj57JM/0uIPVOTT2V9IwrMCT/sFPq++vw==",
       "requires": {
         "@sasjs/utils": "2.52.0",
         "axios": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "4.10.0",
+    "@sasjs/adapter": "4.10.1",
     "@sasjs/core": "4.46.3",
     "@sasjs/lint": "2.3.1",
     "@sasjs/utils": "3.4.0",

--- a/src/commands/add/internal/input.ts
+++ b/src/commands/add/internal/input.ts
@@ -5,14 +5,12 @@ import {
   getUrl
 } from '@sasjs/utils/input'
 import { Target, TargetJson, ServerType } from '@sasjs/utils/types'
-import { LogLevel } from '@sasjs/utils/logger'
 import { encodeToBase64 } from '@sasjs/utils'
 import path from 'path'
 import dotenv from 'dotenv'
-import SASjs from '@sasjs/adapter/node'
 import { TargetScope } from '../../../types/targetScope'
 import { CommonFields } from '../../../types/commonFields'
-import { findTargetInConfiguration } from '../../../utils/config'
+import { findTargetInConfiguration, getSASjs } from '../../../utils'
 
 export async function getCommonFields(): Promise<CommonFields> {
   const scope = await getAndValidateScope()
@@ -207,12 +205,7 @@ export async function getAndValidateSasViyaFields(
         }
       : target.httpsAgentOptions
 
-    const sasjs = new SASjs({
-      serverUrl,
-      serverType: ServerType.SasViya,
-      httpsAgentOptions,
-      debug: process.logger?.logLevel === LogLevel.Debug
-    })
+    const sasjs = getSASjs(target)
     let contexts: any[] = []
     if (scope === TargetScope.Local) {
       dotenv.config({

--- a/src/commands/context/contextCommand.ts
+++ b/src/commands/context/contextCommand.ts
@@ -1,8 +1,7 @@
-import SASjs from '@sasjs/adapter/node'
 import { readFile, ServerType } from '@sasjs/utils'
 import { CommandExample, ReturnCode } from '../../types/command'
 import { TargetCommand } from '../../types/command/targetCommand'
-import { getAuthConfig } from '../../utils'
+import { getAuthConfig, getSASjs } from '../../utils'
 import { create } from './create'
 import { deleteContext } from './delete'
 import { edit } from './edit'
@@ -145,12 +144,7 @@ export class ContextCommand extends TargetCommand {
 
   async executeCreateContext() {
     const { target } = await this.getTargetInfo()
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
     const config = await this.getConfig().catch((err) => {
       process.logger?.error(
         `Unable to create context. Error fetching context configuration from ${this.parsed.source}: `,
@@ -186,12 +180,7 @@ export class ContextCommand extends TargetCommand {
 
   async executeDeleteContext() {
     const { target } = await this.getTargetInfo()
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     const authConfig = await getAuthConfig(target).catch((err) => {
       process.logger?.error(
@@ -221,33 +210,29 @@ export class ContextCommand extends TargetCommand {
 
   async executeEditContext() {
     const { target } = await this.getTargetInfo()
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+
+    const sasjs = getSASjs(target)
     const config = await this.getConfig().catch((err) => {
       process.logger?.error(
         `Unable to edit context. Error fetching context configuration from ${this.parsed.source}: `,
         err
       )
+
       return null
     })
-    if (!config) {
-      return ReturnCode.InternalError
-    }
+
+    if (!config) return ReturnCode.InternalError
 
     const authConfig = await getAuthConfig(target).catch((err) => {
       process.logger?.error(
         'Unable to edit context. Error fetching auth config: ',
         err
       )
+
       return null
     })
-    if (!authConfig) {
-      return ReturnCode.InternalError
-    }
+
+    if (!authConfig) return ReturnCode.InternalError
 
     const returnCode = await edit(
       this.parsed.contextName as string,
@@ -255,85 +240,65 @@ export class ContextCommand extends TargetCommand {
       sasjs,
       authConfig.access_token
     )
-      .then(() => {
-        return ReturnCode.Success
-      })
-      .catch(() => {
-        return ReturnCode.InternalError
-      })
+      .then(() => ReturnCode.Success)
+      .catch(() => ReturnCode.InternalError)
 
     return returnCode
   }
 
   async executeExportContext() {
     const { target } = await this.getTargetInfo()
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     const authConfig = await getAuthConfig(target).catch((err) => {
       process.logger?.error(
         'Unable to create context. Error fetching auth config: ',
         err
       )
+
       return null
     })
-    if (!authConfig) {
-      return ReturnCode.InternalError
-    }
+
+    if (!authConfig) return ReturnCode.InternalError
 
     const returnCode = await exportContext(
       this.parsed.contextName as string,
       sasjs,
       authConfig.access_token
     )
-      .then(() => {
-        return ReturnCode.Success
-      })
-      .catch(() => {
-        return ReturnCode.InternalError
-      })
+      .then(() => ReturnCode.Success)
+      .catch(() => ReturnCode.InternalError)
 
     return returnCode
   }
 
   async executeListContext() {
     const { target } = await this.getTargetInfo()
+
     if (target.serverType !== ServerType.SasViya) {
       process.logger?.error(
         `'context list' command is only supported for SAS Viya build targets.\nPlease try again with a different target.`
       )
+
       return ReturnCode.InternalError
     }
 
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     const authConfig = await getAuthConfig(target).catch((err) => {
       process.logger?.error(
         'Unable to create context. Error fetching auth config: ',
         err
       )
+
       return null
     })
-    if (!authConfig) {
-      return ReturnCode.InternalError
-    }
+
+    if (!authConfig) return ReturnCode.InternalError
 
     const returnCode = await list(target, sasjs, authConfig)
-      .then(() => {
-        return ReturnCode.Success
-      })
-      .catch(() => {
-        return ReturnCode.InternalError
-      })
+      .then(() => ReturnCode.Success)
+      .catch(() => ReturnCode.InternalError)
 
     return returnCode
   }

--- a/src/commands/flow/flowCommand.ts
+++ b/src/commands/flow/flowCommand.ts
@@ -3,7 +3,7 @@ import { AuthConfig, Target } from '@sasjs/utils'
 import SASjs from '@sasjs/adapter/node'
 import { CommandExample, ReturnCode } from '../../types/command'
 import { TargetCommand } from '../../types/command/targetCommand'
-import { displayError, getAuthConfig } from '../../utils'
+import { displayError, getAuthConfig, getSASjs } from '../../utils'
 import { execute } from './execute'
 
 enum FlowSubCommand {
@@ -67,13 +67,7 @@ export class FlowCommand extends TargetCommand {
 
   public async execute() {
     const { target } = await this.getTargetInfo()
-
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     const authConfig = await getAuthConfig(target as Target).catch((err) => {
       displayError(err, 'Error while getting access token.')

--- a/src/commands/folder/folderCommand.ts
+++ b/src/commands/folder/folderCommand.ts
@@ -2,7 +2,7 @@ import SASjs from '@sasjs/adapter/node'
 import { AuthConfig, ServerType, Target } from '@sasjs/utils'
 import { CommandExample, ReturnCode } from '../../types/command'
 import { TargetCommand } from '../../types/command/targetCommand'
-import { getAuthConfig } from '../../utils'
+import { getAuthConfig, getSASjs } from '../../utils'
 import { prefixAppLoc } from '../../utils/prefixAppLoc'
 import { create } from './create'
 import { deleteFolder } from './delete'
@@ -74,12 +74,7 @@ export class FolderCommand extends TargetCommand {
       return ReturnCode.InternalError
     }
 
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     const authConfig = await getAuthConfig(target).catch((err) => {
       process.logger?.error(
@@ -185,12 +180,7 @@ export class FolderCommand extends TargetCommand {
       return ReturnCode.InternalError
     }
 
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      appLoc: target.appLoc,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     const authConfig = await getAuthConfig(target).catch((err) => {
       process.logger?.error(

--- a/src/commands/job/jobCommand.ts
+++ b/src/commands/job/jobCommand.ts
@@ -95,7 +95,7 @@ const executeParseOptions = {
 
 export class JobCommand extends TargetCommand {
   private jobSubCommands: any[]
-  private verbose: VerboseMode = false
+  private verbose?: VerboseMode
   private sasjs: SASjs = new SASjs()
   private authConfig?: AuthConfig | AuthConfigSas9
 
@@ -159,8 +159,9 @@ export class JobCommand extends TargetCommand {
     }
 
     this.sasjs = sasjs
-    this.sasjs.setVerboseMode(this.verbose)
     this.authConfig = authConfig || authConfigSas9
+
+    if (this.verbose) this.sasjs.setVerboseMode(this.verbose)
 
     // use execution function based on server type
     switch (target.serverType) {
@@ -345,5 +346,5 @@ const getVerbose = (args: string[], verboseArg: unknown) => {
     return true
   }
 
-  return false
+  return undefined
 }

--- a/src/commands/job/spec/jobCommand.spec.ts
+++ b/src/commands/job/spec/jobCommand.spec.ts
@@ -235,7 +235,7 @@ describe('JobCommand', () => {
       expect(sasjs.setVerboseMode).toHaveBeenCalledWith('bleached')
     })
 
-    it('should set verbose to false if verbose flag is not present', async () => {
+    it('should not call @sasjs/adapter/setVerboseMode method if verbose flag is not present', async () => {
       let sasjs = new SASjs()
 
       jest
@@ -253,7 +253,7 @@ describe('JobCommand', () => {
 
       await executeCommandWrapper([jobPath])
 
-      expect(sasjs.setVerboseMode).toHaveBeenCalledWith(false)
+      expect(sasjs.setVerboseMode).not.toHaveBeenCalled()
     })
   })
 

--- a/src/commands/request/request.ts
+++ b/src/commands/request/request.ts
@@ -9,10 +9,14 @@ import {
   getAbsolutePath,
   generateTimestamp
 } from '@sasjs/utils'
-import { displayError, displaySuccess } from '../../utils/displayResult'
 import { AuthConfig, ServerType, Target } from '@sasjs/utils/types'
-import { isSASjsProject } from '../../utils/utils'
-import { saveLog } from '../../utils/saveLog'
+import {
+  isSASjsProject,
+  saveLog,
+  displayError,
+  displaySuccess,
+  getSASjs
+} from '../../utils'
 
 export async function runSasJob(
   target: Target,
@@ -80,15 +84,7 @@ export async function runSasJob(
     configJson.password = decodeFromBase64(configJson.password)
   }
 
-  const sasjs = new SASjs({
-    serverUrl: target.serverUrl,
-    httpsAgentOptions: target.httpsAgentOptions,
-    appLoc: target.appLoc,
-    serverType: target.serverType,
-    contextName: target.contextName,
-    useComputeApi: false,
-    debug: true
-  })
+  const sasjs = getSASjs(target)
 
   let result
 

--- a/src/commands/shared/deployToSasViyaWithServicePack.ts
+++ b/src/commands/shared/deployToSasViyaWithServicePack.ts
@@ -1,6 +1,5 @@
-import SASjs from '@sasjs/adapter/node'
 import { FileTree, MemberType, readFile, Target } from '@sasjs/utils'
-import { getAccessToken } from '../../utils'
+import { getAccessToken, getSASjs } from '../../utils'
 
 export async function deployToSasViyaWithServicePack(
   jsonFilePath: string,
@@ -30,13 +29,7 @@ export async function deployToSasViyaWithServicePack(
     )
   }
 
-  const sasjs = new SASjs({
-    httpsAgentOptions: target.httpsAgentOptions,
-    appLoc: target.appLoc,
-    serverType: target.serverType,
-    serverUrl: target.serverUrl,
-    useComputeApi: true
-  })
+  const sasjs = getSASjs(target)
 
   await sasjs
     .deployServicePack(jsonObject, undefined, undefined, access_token, isForced)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -653,11 +653,7 @@ export async function getAuthConfig(target: Target): Promise<AuthConfig> {
   }
 
   if (isAccessTokenExpiring(access_token)) {
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     let tokens
     if (isRefreshTokenExpiring(refresh_token)) {
@@ -799,11 +795,7 @@ export async function getAccessToken(target: Target, checkIfExpiring = true) {
   }
 
   if (checkIfExpiring && isAccessTokenExpiring(accessToken)) {
-    const sasjs = new SASjs({
-      serverUrl: target.serverUrl,
-      httpsAgentOptions: target.httpsAgentOptions,
-      serverType: target.serverType
-    })
+    const sasjs = getSASjs(target)
 
     let client =
       target.authConfig && target.authConfig.client

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -704,9 +704,13 @@ export const saveTokens = async (
     })
 
   if (isLocalTarget) {
-    const envFileContent = `CLIENT=${client}\nSECRET=${secret}\nACCESS_TOKEN=${access_token}\nREFRESH_TOKEN=${refresh_token}\n`
+    const { VERBOSE } = process.env
+    const envFileContent = `CLIENT=${client}\nSECRET=${secret}\nACCESS_TOKEN=${access_token}\nREFRESH_TOKEN=${refresh_token}\n${
+      VERBOSE ? 'VERBOSE=' + VERBOSE + '\n' : ''
+    }`
     const envFilePath = path.join(process.projectDir, `.env.${targetName}`)
     await createFile(envFilePath, envFileContent)
+
     process.logger?.success(`Environment file saved at ${envFilePath}`)
   } else {
     const globalConfig = await getGlobalRcFile()

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -24,7 +24,8 @@ import {
   getGlobalRcFile,
   saveGlobalRcFile,
   saveToGlobalConfig,
-  getAccessToken
+  getAccessToken,
+  getSASjs
 } from './config'
 import { dbFiles } from './fileStructures/dbFiles'
 import { compiledFiles } from './fileStructures/compiledFiles'
@@ -36,7 +37,6 @@ import { ServiceConfig, JobConfig } from '@sasjs/utils/types/config'
 import { create } from '../commands/create/create'
 import { setConstants, contextName } from './setConstants'
 import { Constants } from '../constants'
-import SASjs from '@sasjs/adapter/node'
 
 export const createTestApp = async (parentFolder: string, appName: string) => {
   process.projectDir = parentFolder
@@ -89,12 +89,7 @@ export const removeTestServerFolder = async (
     return
   }
 
-  const sasjs = new SASjs({
-    serverUrl: target.serverUrl,
-    httpsAgentOptions: target.httpsAgentOptions,
-    appLoc: target.appLoc,
-    serverType: target.serverType
-  })
+  const sasjs = getSASjs(target)
 
   const accessToken = await getAccessToken(target)
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,6 +20,7 @@ import { displayError } from './displayResult'
 import dotenv from 'dotenv'
 import AdmZip from 'adm-zip'
 import { LogJson } from '../types'
+import { getSASjs } from './config'
 
 export async function inExistingProject(folderPath: string) {
   const packageJsonExists = await fileExists(
@@ -455,14 +456,7 @@ export function getAdapterInstance(target: Target): SASjs {
     )
   }
 
-  const sasjs = new SASjs({
-    serverUrl: target.serverUrl,
-    serverType: target.serverType,
-    httpsAgentOptions: target.httpsAgentOptions,
-    contextName: target.contextName,
-    useComputeApi: true,
-    debug: process.env.LOG_LEVEL === LogLevel.Debug
-  })
+  const sasjs = getSASjs(target)
 
   return sasjs
 }


### PR DESCRIPTION
## Issue

- Bleached verbose mode wasn't working when set through the environment variable.
- `@sasjs/adapter` was treating `idle` parent session state as not healthy while polling the job state.

## Intent

- Bump `@sasjs/adapter`.
- Fix verbose mode while running `sasjs job execute` command.
- Refactor `@sasjs/adapter` instantiation.

## Implementation

- Fixed `getVerbose` function in `src/commands/job/jobCommand.ts`.
- Adjusted unit tests related to `sasjs job execute` command.
- Fixed `createEnvFileForViya` utility.
- Used `getSASjs` utility to get an instance of `@sasjs/adapter` instead of instantiating it manually .

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] Unit tests coverage has been increased and a new threshold is set.
- [x] All CI checks are green.
- [ ] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [x] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
