### PR TITLE
feat: configurable serverName in SAS 9

### DIFF
--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -217,7 +217,7 @@ ${
   serverType === ServerType.Sas9
     ? `
 /**
-  * The serverName represents the SAS 9logical server context
+  * The serverName represents the SAS 9 logical server context
   * There is no programmatic (SAS code) way to obtain this
   * So it is taken from the sasjsconfig file OR supplied at runtime, eg:
   * 

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -208,12 +208,31 @@ async function getBuildInfo(target: Target, streamWeb: boolean) {
   *
   */
 
-%global appLoc serverName;
+%global appLoc;
 %let compiled_apploc=${appLoc};
-
-${serverType === ServerType.Sas9 ? `%let serverName=${serverName};` : ''}
-
 %let appLoc=%sysfunc(coalescec(&appLoc,&compiled_apploc));
+
+
+${
+  serverType === ServerType.Sas9
+    ? `
+/**
+  * The serverName represents the SAS 9logical server context
+  * There is no programmatic (SAS code) way to obtain this
+  * So it is taken from the sasjsconfig file OR supplied at runtime, eg:
+  * 
+  * %let apploc=/my/apploc;
+  * %let serverName=SASAppDC;
+  * %inc thisfile;
+  * 
+  * /
+
+%global serverName;
+%let compiled_serverName=${serverName};
+%let serverName=%sysfunc(coalescec(&serverName,&compiled_serverName));
+`
+    : ''
+}
 
 %let sasjs_clickmeservice=clickme;
 %let syscc=0;


### PR DESCRIPTION
## Issue

Closes #1388

## Intent

Server Name in SAS 9 should be configurable

## Implementation

Updated SAS9-only logic in build.ts

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] Unit tests coverage has been increased and a new threshold is set.
- [ ] All CI checks are green.
- [ ] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [ ] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
