### PR TITLE
fix(compile-web): added the ability to update link tags with rel='mod…

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -12,13 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [lts/Iron]
+        node-version: [lts/*]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -32,17 +32,16 @@ jobs:
 
       - name: Create .env file for sasjs/server
         run: |
-          touch .env
           echo RUN_TIMES=js >> .env
           echo NODE_PATH=node >> .env
 
-      - name: download sasjs/server package from github using curl
+      - name: Download sasjs/server package from GitHub
         run: curl -L https://github.com/sasjs/server/releases/latest/download/windows.zip --output windows.zip
 
-      - name: unzip downloaded package
+      - name: Unzip downloaded package
         run: npx extract-zip windows.zip
 
-      - name: run sasjs server in background
+      - name: Start sasjs server in background
         run: START .\api-win.exe >> run-sasjs-server.txt
 
       - name: Install dependencies
@@ -60,7 +59,11 @@ jobs:
         run: npm run build
 
       - name: Test Package Install
-        run: npm version "5.0.0" --no-git-tag-version && npm pack && npm install -g ./sasjs-cli-5.0.0.tgz && sasjs v
+        run: |
+          npm version "5.0.0" --no-git-tag-version
+          npm pack
+          npm install -g ./sasjs-cli-5.0.0.tgz
+          sasjs v
 
       - name: npm prefix for user
         run: echo prefix=C:\npm\prefix >> ~\.npmrc
@@ -72,12 +75,12 @@ jobs:
         run: npm run test:mocked
         env:
           CI: true
-          CLIENT: ${{secrets.CLIENT}}
-          SECRET: ${{secrets.SECRET}}
-          SAS_USERNAME: ${{secrets.SAS_USERNAME}}
-          SAS_PASSWORD: ${{secrets.SAS_PASSWORD}}
-          VIYA_SERVER_URL: ${{secrets.VIYA_SERVER_URL}}
-          SAS9_SERVER_URL: ${{secrets.SAS9_SERVER_URL}}
+          CLIENT: ${{ secrets.CLIENT }}
+          SECRET: ${{ secrets.SECRET }}
+          SAS_USERNAME: ${{ secrets.SAS_USERNAME }}
+          SAS_PASSWORD: ${{ secrets.SAS_PASSWORD }}
+          VIYA_SERVER_URL: ${{ secrets.VIYA_SERVER_URL }}
+          SAS9_SERVER_URL: ${{ secrets.SAS9_SERVER_URL }}
           SASJS_SERVER_URL: 'http://localhost:5000'
-          ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
-          REFRESH_TOKEN: ${{secrets.REFRESH_TOKEN}}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [lts/Iron]
+        node-version: [lts/*]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -48,13 +48,17 @@ jobs:
         run: npm run build
 
       - name: Test Package Install
-        run: npm version "5.0.0" --no-git-tag-version && npm pack && npm install -g ./sasjs-cli-5.0.0.tgz && sasjs v
+        run: |
+          npm version "5.0.0" --no-git-tag-version
+          npm pack
+          npm install -g ./sasjs-cli-5.0.0.tgz
+          sasjs v
 
       - name: Run smoke tests
         run: sh ./test.sh
 
       - name: Install Doxygen
-        run: sudo apt-get install doxygen
+        run: sudo apt-get install -y doxygen
 
       # Mocked (*.spec.ts) tests will be conducted during this step
       - name: Generate coverage report
@@ -63,23 +67,22 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: npx jest --config=jest.config.js --silent --runInBand --ci --coverage --testLocationInResults --json --outputFile="report.json"
 
-      - name: install pm2 for process management
+      - name: Install PM2
         run: npm i -g pm2
 
       - name: Create .env file for sasjs/server
         run: |
-          touch .env
-          echo RUN_TIMES=js >> .env
-          echo NODE_PATH=node >> .env
-          echo MOCK_SERVERTYPE=sas9 >> .env
+          echo "RUN_TIMES=js" >> .env
+          echo "NODE_PATH=node" >> .env
+          echo "MOCK_SERVERTYPE=sas9" >> .env
 
-      - name: download sasjs/server package from github using curl
-        run: curl -L https://github.com/sasjs/server/releases/latest/download/linux.zip > linux.zip
+      - name: Download sasjs/server package
+        run: curl -L https://github.com/sasjs/server/releases/latest/download/linux.zip -o linux.zip
 
-      - name: unzip downloaded package
+      - name: Unzip downloaded package
         run: unzip linux.zip
 
-      - name: run sasjs server
+      - name: Run sasjs server
         run: pm2 start api-linux
 
       - name: Deploy SAS9 tests
@@ -90,16 +93,15 @@ jobs:
           ls sasjs_root -R
 
       - name: Run server tests
-        run: |
-          npm run test:server
+        run: npm run test:server
         env:
           CI: true
-          CLIENT: ${{secrets.CLIENT}}
-          SECRET: ${{secrets.SECRET}}
-          SAS_USERNAME: ${{secrets.SAS_USERNAME}}
-          SAS_PASSWORD: ${{secrets.SAS_PASSWORD}}
-          VIYA_SERVER_URL: ${{secrets.VIYA_SERVER_URL}}
+          CLIENT: ${{ secrets.CLIENT }}
+          SECRET: ${{ secrets.SECRET }}
+          SAS_USERNAME: ${{ secrets.SAS_USERNAME }}
+          SAS_PASSWORD: ${{ secrets.SAS_PASSWORD }}
+          VIYA_SERVER_URL: ${{ secrets.VIYA_SERVER_URL }}
           SAS9_SERVER_URL: http://localhost:5000
           SASJS_SERVER_URL: http://localhost:5000
-          ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
-          REFRESH_TOKEN: ${{secrets.REFRESH_TOKEN}}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}

--- a/src/commands/create/spec/reactAppFiles.ts
+++ b/src/commands/create/spec/reactAppFiles.ts
@@ -49,7 +49,7 @@ export const reactAppFiles: Folder = {
             { fileName: 'data-page.component.tsx' },
             { fileName: 'home-page.component.tsx' },
             { fileName: 'login.component.tsx' },
-            { fileName: 'request-modal.component.jsx' },
+            { fileName: 'request-modal.component.tsx' },
             { fileName: 'syntax-highlighting.css' },
             { fileName: 'user-name.component.tsx' }
           ],
@@ -72,7 +72,7 @@ export const reactAppFiles: Folder = {
         },
         {
           folderName: 'theme',
-          files: [{ fileName: 'index.js' }],
+          files: [{ fileName: 'index.ts' }],
           subFolders: []
         }
       ]

--- a/src/commands/web/internal/getTags.ts
+++ b/src/commands/web/internal/getTags.ts
@@ -6,6 +6,11 @@ export const getSasjsTags = (parsedHtml: JSDOM) =>
 export const getScriptTags = (parsedHtml: JSDOM) =>
   Array.from(parsedHtml.window.document.getElementsByTagName('script'))
 
+export const getModulePreload = (parsedHtml: JSDOM) =>
+  Array.from(parsedHtml.window.document.getElementsByTagName('link')).filter(
+    (s) => s.getAttribute('rel') === 'modulepreload'
+  )
+
 export const getStyleInPageTags = (parsedHtml: JSDOM) =>
   Array.from(parsedHtml.window.document.getElementsByTagName('style'))
 

--- a/src/commands/web/internal/spec/getTags.spec.ts
+++ b/src/commands/web/internal/spec/getTags.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { JSDOM } from 'jsdom'
+import {
+  getSasjsTags,
+  getScriptTags,
+  getModulePreload,
+  getStyleInPageTags,
+  getStyleTags,
+  getFaviconTags,
+  getImgTags,
+  getSourceTags,
+  getManifestTags
+} from '../getTags'
+
+describe('getTags', () => {
+  // Helper function to create a JSDOM instance with given HTML
+  const createDOM = (html: string) => new JSDOM(`<!DOCTYPE html>${html}`)
+
+  describe('getSasjsTags', () => {
+    it('should return all sasjs tags', () => {
+      const html = `
+        <body>
+          <sasjs id="sasjs1"></sasjs>
+          <sasjs id="sasjs2"></sasjs>
+          <div>Not a sasjs tag</div>
+        </body>
+      `
+      const dom = createDOM(html)
+      const result = getSasjsTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('sasjs1')
+      expect(result[1].id).toBe('sasjs2')
+    })
+
+    it('should return empty array when no sasjs tags are present', () => {
+      const html = '<body><div>No sasjs tags here</div></body>'
+      const dom = createDOM(html)
+      const result = getSasjsTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getScriptTags', () => {
+    it('should return all script tags', () => {
+      const html = `
+        <head>
+          <script id="script1" src="script1.js"></script>
+        </head>
+        <body>
+          <script id="script2" src="script2.js"></script>
+          <div>Not a script tag</div>
+        </body>
+      `
+      const dom = createDOM(html)
+      const result = getScriptTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('script1')
+      expect(result[1].id).toBe('script2')
+    })
+
+    it('should return empty array when no script tags are present', () => {
+      const html = '<body><div>No script tags here</div></body>'
+      const dom = createDOM(html)
+      const result = getScriptTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getModulePreload', () => {
+    it('should return all link tags with rel="modulepreload"', () => {
+      const html = `
+        <head>
+          <link id="module1" rel="modulepreload" href="module1.js">
+          <link id="module2" rel="modulepreload" href="module2.js">
+          <link id="stylesheet" rel="stylesheet" href="style.css">
+        </head>
+      `
+      const dom = createDOM(html)
+      const result = getModulePreload(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('module1')
+      expect(result[1].id).toBe('module2')
+    })
+
+    it('should return empty array when no modulepreload links are present', () => {
+      const html = '<head><link rel="stylesheet" href="style.css"></head>'
+      const dom = createDOM(html)
+      const result = getModulePreload(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getStyleInPageTags', () => {
+    it('should return all style tags', () => {
+      const html = `
+        <head>
+          <style id="style1">.class1 { color: red; }</style>
+          <style id="style2">.class2 { color: blue; }</style>
+        </head>
+        <body>
+          <div>Not a style tag</div>
+        </body>
+      `
+      const dom = createDOM(html)
+      const result = getStyleInPageTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('style1')
+      expect(result[1].id).toBe('style2')
+    })
+
+    it('should return empty array when no style tags are present', () => {
+      const html = '<body><div>No style tags here</div></body>'
+      const dom = createDOM(html)
+      const result = getStyleInPageTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getStyleTags', () => {
+    it('should return all link tags with rel="stylesheet"', () => {
+      const html = `
+        <head>
+          <link id="css1" rel="stylesheet" href="style1.css">
+          <link id="css2" rel="stylesheet" href="style2.css">
+          <link id="icon" rel="icon" href="favicon.ico">
+        </head>
+      `
+      const dom = createDOM(html)
+      const result = getStyleTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('css1')
+      expect(result[1].id).toBe('css2')
+    })
+
+    it('should return empty array when no stylesheet links are present', () => {
+      const html = '<head><link rel="icon" href="favicon.ico"></head>'
+      const dom = createDOM(html)
+      const result = getStyleTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getFaviconTags', () => {
+    it('should return all link tags with rel containing "icon"', () => {
+      const html = `
+        <head>
+          <link id="icon1" rel="icon" href="favicon.ico">
+          <link id="icon2" rel="apple-touch-icon" href="apple-touch-icon.png">
+          <link id="css" rel="stylesheet" href="style.css">
+        </head>
+      `
+      const dom = createDOM(html)
+      const result = getFaviconTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('icon1')
+      expect(result[1].id).toBe('icon2')
+    })
+
+    it('should return empty array when no icon links are present', () => {
+      const html = '<head><link rel="stylesheet" href="style.css"></head>'
+      const dom = createDOM(html)
+      const result = getFaviconTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getImgTags', () => {
+    it('should return all img tags with src attribute', () => {
+      const html = `
+        <body>
+          <img id="img1" src="image1.jpg">
+          <img id="img2" src="image2.jpg">
+          <img id="img3">
+        </body>
+      `
+      const dom = createDOM(html)
+      const result = getImgTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('img1')
+      expect(result[1].id).toBe('img2')
+    })
+
+    it('should return empty array when no img tags with src are present', () => {
+      const html = '<body><img id="noSrc"></body>'
+      const dom = createDOM(html)
+      const result = getImgTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getSourceTags', () => {
+    it('should return all source tags with src attribute', () => {
+      const html = `
+        <body>
+          <audio>
+            <source id="source1" src="audio.mp3" type="audio/mpeg">
+          </audio>
+          <video>
+            <source id="source2" src="video.mp4" type="video/mp4">
+            <source id="source3">
+          </video>
+        </body>
+      `
+      const dom = createDOM(html)
+      const result = getSourceTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('source1')
+      expect(result[1].id).toBe('source2')
+    })
+
+    it('should return empty array when no source tags with src are present', () => {
+      const html = '<body><source id="noSrc"></body>'
+      const dom = createDOM(html)
+      const result = getSourceTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('getManifestTags', () => {
+    it('should return all link tags with rel="manifest"', () => {
+      const html = `
+        <head>
+          <link id="manifest1" rel="manifest" href="manifest.json">
+          <link id="manifest2" rel="manifest" href="another-manifest.json">
+          <link id="css" rel="stylesheet" href="style.css">
+        </head>
+      `
+      const dom = createDOM(html)
+      const result = getManifestTags(dom)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe('manifest1')
+      expect(result[1].id).toBe('manifest2')
+    })
+
+    it('should return empty array when no manifest links are present', () => {
+      const html = '<head><link rel="stylesheet" href="style.css"></head>'
+      const dom = createDOM(html)
+      const result = getManifestTags(dom)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+})

--- a/src/commands/web/internal/updateAllTags.ts
+++ b/src/commands/web/internal/updateAllTags.ts
@@ -8,7 +8,8 @@ import {
   getSourceTags,
   getStyleInPageTags,
   getSasjsTags,
-  getManifestTags
+  getManifestTags,
+  getModulePreload
 } from './getTags'
 import { updateScriptTag } from './updateScriptTag'
 import { updateLinkTag } from './updateLinkTag'
@@ -49,6 +50,15 @@ export const updateAllTags = async (
       serverType,
       assetPathMap
     ).catch((e) => assetsNotFound.push(e))
+  })
+
+  const modulePreloadTags = getModulePreload(parsedHtml)
+  modulePreloadTags.forEach((tag) => {
+    try {
+      updateLinkTag(tag, assetPathMap)
+    } catch (error) {
+      assetsNotFound.push(error as Error)
+    }
   })
 
   const styleExternalTags = getStyleTags(parsedHtml)

--- a/src/commands/web/internal/updateLinkTag.ts
+++ b/src/commands/web/internal/updateLinkTag.ts
@@ -18,7 +18,9 @@ export const updateLinkTag = (
 
   const assetPath = assetPathMap.find(
     (entry) =>
-      entry.source === linkSourcePath || `./${entry.source}` === linkSourcePath
+      entry.source === linkSourcePath ||
+      `./${entry.source}` === linkSourcePath ||
+      `/${entry.source}` === linkSourcePath
   )
 
   if (!assetPath?.target) {

--- a/src/commands/web/internal/updateScriptTag.ts
+++ b/src/commands/web/internal/updateScriptTag.ts
@@ -54,7 +54,9 @@ export const updateScriptTag = async (
         'src',
         assetPathMap.find(
           (entry) =>
-            entry.source === scriptPath || `./${entry.source}` === scriptPath
+            entry.source === scriptPath ||
+            `./${entry.source}` === scriptPath ||
+            `/${entry.source}` === scriptPath
         )!.target
       )
     }

--- a/src/commands/web/internal/updateStyleTag.ts
+++ b/src/commands/web/internal/updateStyleTag.ts
@@ -54,7 +54,9 @@ export const updateStyleTag = async (
         'href',
         assetPathMap.find(
           (entry) =>
-            entry.source === scriptPath || `./${entry.source}` === scriptPath
+            entry.source === scriptPath ||
+            `./${entry.source}` === scriptPath ||
+            `/${entry.source}` === scriptPath
         )!.target
       )
     }


### PR DESCRIPTION
…ulepreload'

## Issue

* Compile web wasn't processing links with `rel="modulepreload"`

## Implementation

* added a function to extract links and rel=modulepreload and updated these link tag

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] Unit tests coverage has been increased and a new threshold is set.
- [ ] All CI checks are green.
- [ ] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [ ] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
