### PR TITLE
fix(viya): remove `_debug=2` query parameter from deployed URLs

### DIFF
--- a/src/commands/build/internal/getLaunchPageCode.ts
+++ b/src/commands/build/internal/getLaunchPageCode.ts
@@ -56,7 +56,7 @@ data _null_;
  urlEscaped = tranwrd(trim(url)," ","%20");
  putlog "NOTE: SASjs Streaming App Created! Check it out here:" ;
  putlog "NOTE- ";putlog "NOTE- ";putlog "NOTE- ";putlog "NOTE- ";
- putlog "NOTE- " urlEscaped +(-1) '${streamServiceName}.html&_debug=2' ;
+ putlog "NOTE- " urlEscaped +(-1) '${streamServiceName}.html' ;
  putlog "NOTE- ";putlog "NOTE- ";putlog "NOTE- ";putlog "NOTE- ";
 run;
 `

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -60,7 +60,7 @@ export async function deploy(target: Target, isLocal: boolean) {
 
       process.logger?.success(
         target.serverType === ServerType.SasViya && webIndexFileName
-          ? `${target.serverUrl}/SASJobExecution?_file=${appLoc}/services/${webIndexFileName}&_debug=2`
+          ? `${target.serverUrl}/SASJobExecution?_file=${appLoc}/services/${webIndexFileName}`
           : `${target.serverUrl}/SASJobExecution?_folder=${appLoc}`
       )
     } else if (target.serverType === ServerType.Sasjs) {

--- a/src/commands/deploy/internal/executeDeployScriptSasViya.ts
+++ b/src/commands/deploy/internal/executeDeployScriptSasViya.ts
@@ -82,7 +82,7 @@ export async function executeDeployScriptSasViya(
 
   if (streamConfig?.streamWeb) {
     const appLoc = encodeURI(target.appLoc)
-    const webAppStreamUrl = `${target.serverUrl}/SASJobExecution?_FILE=${appLoc}/services/${streamConfig.streamServiceName}.html&_debug=2`
+    const webAppStreamUrl = `${target.serverUrl}/SASJobExecution?_FILE=${appLoc}/services/${streamConfig.streamServiceName}.html`
     process.logger?.info(`Web app is available at ${webAppStreamUrl}`)
   }
 }

--- a/src/commands/deploy/spec/cbd.spec.server.viya.ts
+++ b/src/commands/deploy/spec/cbd.spec.server.viya.ts
@@ -211,7 +211,7 @@ describe('sasjs cbd with Viya', () => {
         ''
       )}/SASJobExecution?_FILE=${appLoc}${appLocTransformed}/services/${
         streamConfig.streamServiceName
-      }.html&_debug=2`
+      }.html`
 
       expect(logFileContent.replace(/\s/g, '')).toEqual(
         expect.stringContaining(streamingApplink)

--- a/src/commands/run/spec/run.spec.server.viya.ts
+++ b/src/commands/run/spec/run.spec.server.viya.ts
@@ -252,7 +252,7 @@ describe('sasjs run with Viya', () => {
     })
 
     it('should get the log having launch code message', async () => {
-      const logPart = `SASjs Streaming App Created! Check it out here:\n      \n      \n      \n      \n      your-sas-server.com/SASJobExecution?_FILE=${target.appLoc}/services/clickme.html&_debug=2\n`
+      const logPart = `SASjs Streaming App Created! Check it out here:\n      \n      \n      \n      \n      your-sas-server.com/SASJobExecution?_FILE=${target.appLoc}/services/clickme.html\n`
       await build(target)
       const result: any = await runSasCode(
         target,


### PR DESCRIPTION
## Issue

Related to #1400 

## Intent

When you run the `CBD` command to deploy a Viya Stream app, the link printed in the terminal no longer includes the `_debug=2` query parameter.

## Implementation

- Removed `_debug=2` from the link printed in the terminal
- Adjusted the `cbd.spec.server.viya`
- Adjusted the `run.spec.server.viya`

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] Any new functionality has been unit tested.
- [x] All unit tests are passing (`npm test`).
- [x] Unit tests coverage has been increased and a new threshold is set.
- [] All CI checks are green.
- [x] Development comments have been added or updated.
- [x] Development documentation coverage has been increased and a new threshold is set.
- [x] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
