### PR TITLE
fix: bump adapter and core to fix JES _webout issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.11.3",
-        "@sasjs/core": "4.58.1",
+        "@sasjs/adapter": "4.12.1",
+        "@sasjs/core": "4.59.1",
         "@sasjs/lint": "2.4.3",
         "@sasjs/utils": "3.5.2",
         "adm-zip": "0.5.10",
@@ -2300,10 +2300,11 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.11.3.tgz",
-      "integrity": "sha512-KF6G4vzs4l4efjpCD02og3kB44uFfJ1u2UWu749VdHtLKNN9l+PO26/moR+YAmRmmz2I9sC3X09fZE1nlN6zgw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.12.1.tgz",
+      "integrity": "sha512-0217oZIkrecOyQygRe6Azgc1C4TIcjB5noi15fU4Rd5GsfDpleKVfQQdzYZ7im/vesWlLIVl/yUT67MMaQe0ew==",
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "@sasjs/utils": "3.5.2",
         "axios": "1.8.2",
@@ -2314,9 +2315,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.58.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.58.1.tgz",
-      "integrity": "sha512-Qp6KAtp1VZcmN5HLGSIUE9H41qpFuihWLbjNygOYp+NRs/Y8VagpHrYeyIQbh3cSgchiJEMXudLql8hoU06wpg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.59.1.tgz",
+      "integrity": "sha512-52GNI4nIll5YivI8uobWrucE6TkHcTjcbKTr/YPC9eTauC4sh0V0MptebfAJ5E6vE5P2WevNZGr42KdDpckLpg==",
       "license": "MIT"
     },
     "node_modules/@sasjs/lint": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "4.11.3",
-    "@sasjs/core": "4.58.1",
+    "@sasjs/adapter": "4.12.1",
+    "@sasjs/core": "4.59.1",
     "@sasjs/lint": "2.4.3",
     "@sasjs/utils": "3.5.2",
     "adm-zip": "0.5.10",


### PR DESCRIPTION
## Issue

 `sasjs test` has not been working due to a change in Viya, described here: https://communities.sas.com/t5/SAS-Viya/Returning-webout-from-JES-API/m-p/968153


## Implementation

Bumping adapter and sasjs/core to make use of the _omitsessionresults fix
