### PR TITLE
Add optional fallback of a macroCorePath environment variable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,9 @@
   "packages": {
     "": {
       "name": "@sasjs/cli",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "^4.16.0",
+        "@sasjs/adapter": "^4.16.1",
         "@sasjs/core": "4.59.9",
         "@sasjs/lint": "2.4.3",
         "@sasjs/utils": "3.5.2",
@@ -108,7 +107,6 @@
       "integrity": "sha512-D58mjF+Y+89UfbMJpV57UTCg+JRQIFgvROPfH7mmIfBcoFVMkwiiiJyzPyW3onN9kg9noDg7MVyI+Yt64bnfQQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.21.4",
@@ -2301,18 +2299,52 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.16.0.tgz",
-      "integrity": "sha512-DzF/+s++FtSfuBmONicBbgeKI8feiwDOm1iKWlcDlmHCPmHIoj1IbI0v2fGktzurnE37/vkyp6dvHO+FhwI87Q==",
-      "hasInstallScript": true,
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.16.1.tgz",
+      "integrity": "sha512-NsW9f5n9USYJbRe7f7AghfopVegI4lDKBn8dixopGnqbmGsTmMaZOdSOiKmmRmm0qrxet/MAor7h6ic/vqDCLA==",
       "license": "ISC",
       "dependencies": {
-        "@sasjs/utils": "3.5.2",
+        "@sasjs/utils": "3.5.6",
         "axios": "1.12.2",
         "axios-cookiejar-support": "5.0.5",
         "form-data": "4.0.4",
         "https": "1.0.0",
         "tough-cookie": "4.1.3"
+      }
+    },
+    "node_modules/@sasjs/adapter/node_modules/@sasjs/utils": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.5.6.tgz",
+      "integrity": "sha512-jx8zWSOysDD66vTjA0BWiZ8bcFqmqh8F+56fUCgLmJhm89eDbKrGF3mDKMQx3UE7d2+gxp9xYhJCdaBWz0Dlxw==",
+      "license": "ISC",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@types/fs-extra": "11.0.4",
+        "@types/prompts": "2.0.13",
+        "chalk": "4.1.1",
+        "cli-table": "0.3.6",
+        "consola": "2.15.0",
+        "find": "0.3.0",
+        "fs-extra": "11.3.0",
+        "jwt-decode": "3.1.2",
+        "prompts": "2.4.1",
+        "valid-url": "1.0.9"
+      }
+    },
+    "node_modules/@sasjs/adapter/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@sasjs/core": {
@@ -2639,8 +2671,7 @@
       "version": "18.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
       "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/prompts": {
       "version": "2.0.13",
@@ -2879,7 +2910,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -3195,7 +3225,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4991,7 +5020,6 @@
       "integrity": "sha512-XvK65feuEFGZT8OO0fB/QAQS+LGHvQpaadkH5p47/j3Ocqq3xf2pK9R+G0GzgfuhXVxEv76qCOOcMb5efLk6PA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.4.3",
         "@jest/types": "^29.4.3",
@@ -7349,7 +7377,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -7456,7 +7483,6 @@
       "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7529,7 +7555,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test:mocked": "jest --silent --runInBand --config=jest.config.js --coverage",
     "lint:fix": "npx prettier --write \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
     "lint": "npx prettier --check \"{src,test}/**/*.{ts,tsx,js,jsx,html,css,sass,less,yml,md,graphql}\"",
-    "preinstall": "npm run nodeVersionMessage",
     "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true",
     "doc": "npx compodoc -p tsconfig.doc.json --coverageTest 16 --coverageTestThresholdFail"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sasjs/adapter": "^4.16.0",
+    "@sasjs/adapter": "^4.16.1",
     "@sasjs/core": "4.59.9",
     "@sasjs/lint": "2.4.3",
     "@sasjs/utils": "3.5.2",

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -36,9 +36,10 @@ export async function build(target: Target) {
   if (macroCorePath === '') {
     throw new Error(
       `The @sasjs/core folder location is unknown.\n` +
-        `Check that @sasjs/core is a dependency in the package.json, or\n` +
-        `populate environment variable 'macroCorePath' with the path to\n` +
-        `a local @sasjs/core package's root directory.`
+        `Check that @sasjs/core is a dependency in the package.json, and \n` +
+        `that the package has been installed.\n` +
+        `Alternatively populate environment variable 'macroCorePath' with\n` +
+        `the path to a local @sasjs/core package's root directory.`
     )
   }
   process.logger?.info(`@sasjs/core found at ${macroCorePath}`)

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -33,14 +33,14 @@ import { getLaunchPageCode } from './internal/getLaunchPageCode'
 export async function build(target: Target) {
   const { macroCorePath } = process.sasjsConstants
 
-  if ( macroCorePath === '' ) {
+  if (macroCorePath === '') {
     throw new Error(
       `The @sasjs/core folder location is unknown.\n` +
-      `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
-      `environment variable named\n'macroCorePath' containing the path to ` +
-      `the @sasjs/core root folder.\n` +
-      `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
-      `@sasjs/core dependency.`
+        `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
+        `environment variable named\n'macroCorePath' containing the path to ` +
+        `the @sasjs/core root folder.\n` +
+        `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
+        `@sasjs/core dependency.`
     )
   }
 

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -203,11 +203,11 @@ ${
   * The serverName represents the SAS 9 logical server context
   * There is no programmatic (SAS code) way to obtain this
   * So it is taken from the sasjsconfig file OR supplied at runtime, eg:
-  * 
+  *
   * %let apploc=/my/apploc;
   * %let serverName=SASAppDC;
   * %inc thisfile;
-  * 
+  *
   */
 
 %global serverName;
@@ -234,6 +234,17 @@ ${removeHeader(buildConfig)}
 
 async function getCreateWebServiceScript(serverType: ServerType) {
   const { macroCorePath } = process.sasjsConstants
+
+  if ( macroCorePath === '' ) {
+    throw new Error(
+      `The @sasjs/core folder location is unknown.\n` +
+      `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
+      `environment variable named\n'macroCorePath' containing the path to ` +
+      `the @sasjs/core root folder.\n` +
+      `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
+      `@sasjs/core dependency.`
+    )
+  }
 
   switch (serverType) {
     case ServerType.SasViya:

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -31,6 +31,19 @@ import { getBuildInit, getBuildTerm } from './internal/config'
 import { getLaunchPageCode } from './internal/getLaunchPageCode'
 
 export async function build(target: Target) {
+  const { macroCorePath } = process.sasjsConstants
+
+  if ( macroCorePath === '' ) {
+    throw new Error(
+      `The @sasjs/core folder location is unknown.\n` +
+      `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
+      `environment variable named\n'macroCorePath' containing the path to ` +
+      `the @sasjs/core root folder.\n` +
+      `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
+      `@sasjs/core dependency.`
+    )
+  }
+
   if (
     process.sasjsConstants.buildDestinationFolder &&
     !(await folderExists(process.sasjsConstants.buildDestinationFolder))
@@ -234,17 +247,6 @@ ${removeHeader(buildConfig)}
 
 async function getCreateWebServiceScript(serverType: ServerType) {
   const { macroCorePath } = process.sasjsConstants
-
-  if ( macroCorePath === '' ) {
-    throw new Error(
-      `The @sasjs/core folder location is unknown.\n` +
-      `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
-      `environment variable named\n'macroCorePath' containing the path to ` +
-      `the @sasjs/core root folder.\n` +
-      `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
-      `@sasjs/core dependency.`
-    )
-  }
 
   switch (serverType) {
     case ServerType.SasViya:

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -36,13 +36,12 @@ export async function build(target: Target) {
   if (macroCorePath === '') {
     throw new Error(
       `The @sasjs/core folder location is unknown.\n` +
-        `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
-        `environment variable named\n'macroCorePath' containing the path to ` +
-        `the @sasjs/core root folder.\n` +
-        `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
-        `@sasjs/core dependency.`
+        `Check that @sasjs/core is a dependency in the package.json, or\n` +
+        `populate environment variable 'macroCorePath' with the path to\n` +
+        `a local @sasjs/core package's root directory.`
     )
   }
+  process.logger?.info(`@sasjs/core found at ${macroCorePath}`)
 
   if (
     process.sasjsConstants.buildDestinationFolder &&

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -52,7 +52,6 @@ export const setConstants = async (
     // If @sasjs/core was not found, check for and use an environment
     // variable with the same name as the variable we are setting.
     macroCorePath = process.env.macroCorePath as string ?? ''
-
   }
 
   const buildDestinationResultsFolder = getAbsolutePath(

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -43,7 +43,26 @@ export const setConstants = async (
   const buildDestinationJobsFolder = path.join(buildDestinationFolder, 'jobs')
   const buildDestinationDbFolder = path.join(buildDestinationFolder, 'db')
   const buildDestinationDocsFolder = path.join(buildDestinationFolder, 'docs')
-  const macroCorePath = await getNodeModulePath('@sasjs/core')
+  // Arriving here from a `@sasjs/cli` command invoked with `npx` can result
+  // in no discoverable installation of '@sasjs/core' for getNodeModulePath()
+  // to find (`npx` will have cached the @sasjs/cli dependencies in a temporary
+  // area).
+  let macroCorePath = await getNodeModulePath('@sasjs/core')
+  if ( macroCorePath === '' ) {
+    // If @sasjs/core was not found, check for and use an environment
+    // variable with the same name as the variable we are setting.
+    macroCorePath = process.env.macroCorePath as string ?? ''
+    if ( macroCorePath === '' ) {
+      throw new Error(
+        `@sasjs/core folder location is unknown.\n` +
+        `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
+        `environment variable named\n'macroCorePath' containing the path to ` +
+        `the @sasjs/core root folder.\n` +
+        `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
+        `@sasjs/core dependency.`
+      )
+    }
+  }
 
   const buildDestinationResultsFolder = getAbsolutePath(
     buildResultsFolder,

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -43,15 +43,18 @@ export const setConstants = async (
   const buildDestinationJobsFolder = path.join(buildDestinationFolder, 'jobs')
   const buildDestinationDbFolder = path.join(buildDestinationFolder, 'db')
   const buildDestinationDocsFolder = path.join(buildDestinationFolder, 'docs')
-  // Arriving here from a `@sasjs/cli` command invoked with `npx` can result
-  // in no discoverable installation of '@sasjs/core' for getNodeModulePath()
-  // to find (`npx` will have cached the @sasjs/cli dependencies in a temporary
-  // area).
-  let macroCorePath = await getNodeModulePath('@sasjs/core')
+  // Edge case: @sasjs/cli has a dependency on @sasjs/core.
+  // When @sasjs/cli is used to submit a test of the @sasjs/core
+  // repo, it is desirable to use that @sasjs/core repo as the dependency rather
+  // than the older version in @sasjs/cli node_modules.
+  // To achieve this, set environment variable `macroCorePath` to the root dir
+  // of the local @sasjs/core package. If found, this takes precedence over
+  // any node_modules installations of @sasjs/core.
+  let macroCorePath = (process.env.macroCorePath as string) ?? ''
   if (macroCorePath === '') {
-    // If @sasjs/core was not found, check for and use an environment
-    // variable with the same name as the variable we are setting.
-    macroCorePath = (process.env.macroCorePath as string) ?? ''
+    // If no environment variable is set/populated then check for an installed
+    // @sasjs/core in locations known to node.
+    macroCorePath = await getNodeModulePath('@sasjs/core')
   }
 
   const buildDestinationResultsFolder = getAbsolutePath(

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -52,16 +52,7 @@ export const setConstants = async (
     // If @sasjs/core was not found, check for and use an environment
     // variable with the same name as the variable we are setting.
     macroCorePath = process.env.macroCorePath as string ?? ''
-    if ( macroCorePath === '' ) {
-      throw new Error(
-        `@sasjs/core folder location is unknown.\n` +
-        `Either install @sasjs/core, install @sasjs/cli, or declare an ` +
-        `environment variable named\n'macroCorePath' containing the path to ` +
-        `the @sasjs/core root folder.\n` +
-        `Note: 'npx' invocations of @sasjs/cli do not install a discoverable ` +
-        `@sasjs/core dependency.`
-      )
-    }
+
   }
 
   const buildDestinationResultsFolder = getAbsolutePath(

--- a/src/utils/setConstants.ts
+++ b/src/utils/setConstants.ts
@@ -48,10 +48,10 @@ export const setConstants = async (
   // to find (`npx` will have cached the @sasjs/cli dependencies in a temporary
   // area).
   let macroCorePath = await getNodeModulePath('@sasjs/core')
-  if ( macroCorePath === '' ) {
+  if (macroCorePath === '') {
     // If @sasjs/core was not found, check for and use an environment
     // variable with the same name as the variable we are setting.
-    macroCorePath = process.env.macroCorePath as string ?? ''
+    macroCorePath = (process.env.macroCorePath as string) ?? ''
   }
 
   const buildDestinationResultsFolder = getAbsolutePath(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -552,30 +552,15 @@ export const isSASjsProject = async () => {
 }
 
 export const getNodeModulePath = async (module: string): Promise<string> => {
-  // Check if module is present in project's dependencies
-  const projectPath = path.join(process.cwd(), 'node_modules', module)
-
-  if (await folderExists(projectPath)) return projectPath
-
-  // Check if module is present in @sasjs/cli located in project's dependencies
-  const cliDepsPath = path.join('@sasjs', 'cli', 'node_modules')
-  const cliLocalPath = path.join(
-    process.cwd(),
-    'node_modules',
-    cliDepsPath,
-    module
-  )
-
-  if (await folderExists(cliLocalPath)) return cliLocalPath
-
-  // Check if module is present in global @sasjs/cli
-  const cliGlobalPath = path.join(
-    shelljs.exec(`npm root -g`, { silent: true }).stdout.replace(/\n/, ''),
-    cliDepsPath,
-    module
-  )
-
-  if (await folderExists(cliGlobalPath)) return cliGlobalPath
+  // Look for ${module}/package.json, then return only the path
+  try {
+    const nodePackagePath = path.dirname(
+      require.resolve(path.join(module, 'package.json'))
+    )
+    if (nodePackagePath) return nodePackagePath
+  } catch (e: any) {
+    if (e.code !== 'MODULE_NOT_FOUND') throw e
+  }
 
   // Return default value
   return ''


### PR DESCRIPTION
## Issue

1. `@sasjs/cli` has some dependencies on `@sasjs/core`.

When `@sasjs/cli` is used in pipeline testing of an updated `@sasjs/core` package it is preferable to use the updated `@sasjs/core` in place of the cli's `node_modules/@sasjs/core`.

In a clean environment, with no installed npm packages, an invocation of `npx @sasjs/cli` with the `build` argument results in failure as no installation of `@sasjs/core` is returned by the `getNodeModulesPath()` function (npx caches the `@sasjs/core` dependency locally but that temporary `node_modules` path is not being considered).

2. The repository is susceptible to npm supply chain attacks (SHA1-HULUD).

## Intent

1. When `@sasjs/cli` searches for the `@sasjs/core` folder, first read an environment variable that points at the root directory of a chosen local @sasjs/core package. This permits over-riding the @sasjs/core installed as the cli's node_modules dependency.

If no such environment variable is found, or if it is blank, rely instead on node's [`require.resolve()`](https://nodejs.org/api/modules.html#requireresolverequest-options) routine to determine the required package's node_modules path.

2. Prevent automatic execution of `pre` and `post` npm scripts.

## Implementation

1. `src/utils/setConstants.ts` has the job of declaring `sasjsConstants.macroCorePath` as the path to use.
`macroCorePath` is now first set from the value of an environment variable (also named `macroCorePath`). In the even that it is blank a secondary call to `getNodeModulePath('@sasjs/core')` _should_ return a non-blank value unless the `@sasjs/core` dependency has accidentally been removed from the package.json.

A blank value for `sasjsConstants.macroCorePath` is still a possibility and is acceptable for some functionality within `@sasjs/cli`.
However, for a `sasjs` command that requests a `build`, this path is required and processing only continues in `build.ts` if the value is populated, otherwise an informational error message is thrown and the process halts at an early build stage.

2. New file `.npmrc` containing the `ignore-scripts=true` directive configures `npm` to skip automatic processing of associated scripts with a `pre` or `post` prefix when running a given script name (i.e. given `npm install`, no script named `preinstall` or `postinstall` will also be executed in the same submission)

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] Unit tests coverage has been increased and a new threshold is set.
- [ ] All CI checks are green.
- [ ] Development comments have been added or updated.
- [ ] Development documentation coverage has been increased and a new threshold is set.
- [ ] Reviewer is assigned.

### Reviewer checks

- [ ] Any new code is documented.
